### PR TITLE
Harden and expand the advisory-board skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ tmp/
 dist/
 .cache/
 .claude/
+
+# Python
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,11 @@ Use one directory per skill:
 skills/<skill-name>/
   SKILL.md
   references/
+  scripts/
   agents/
 ```
 
-`SKILL.md` should contain the core behavior and should be understandable without a specific provider runtime. Put longer reusable prompts, examples, or reference material in `references/`.
+`SKILL.md` should contain the core behavior and should be understandable without a specific provider runtime. Put longer reusable prompts, examples, or reference material in `references/`. Optional executable helpers go in `scripts/` — keep them dependency-free (e.g. Python 3 standard library) and make sure the skill still works without them.
 
 ## Quality Bar
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ Use it to:
 - stress a decision, strategy, or proposal from several angles at once;
 - surface risks, stale assumptions, and missing evidence;
 - let strong models debate and sharpen each other's thinking;
-- collapse several model opinions into a single, clean takeaway.
+- collapse several model opinions into a single, clean takeaway;
+- review non-software work too — product, research, legal, business, and writing — via built-in lens presets.
+
+## See It In Action
+
+Every run ends in a single, self-contained HTML handoff — verdict, the round-by-round debate, consensus blockers, preserved dissent, and next actions — that opens offline in any browser with no dependencies.
+
+- **View a live sample:** [rendered handoff for a payments idempotency review](https://htmlpreview.github.io/?https://github.com/timharris707/skills/blob/main/examples/payments-idempotency-review/final-consensus.html)
+- **Browse the full run:** [`examples/payments-idempotency-review/`](./examples/payments-idempotency-review/) — per-seat round notes, the board packet, and both the Markdown and HTML handoffs.
+- **Gate on it:** every run also emits a machine-readable [`verdict.json`](./examples/payments-idempotency-review/verdict.json); `scripts/board_verdict.py --gate` turns the board's `ship | caution | block` call into a CI exit code, and `scripts/format_output.py` reshapes it into a PR comment, Slack message, or TL;DR.
+
+The look comes from one template, [`handoff-template.html`](./skills/advisory-board/references/handoff-template.html), so any agent that installs the skill renders the same clean output.
 
 ## Repository Layout
 
@@ -40,9 +51,24 @@ skills/
       openai.yaml
     references/
       prompt-templates.md
+      lens-presets.md
+      preflight.md
+      board-composition.md
+      data-handling.md
+      epistemics.md
+      run-metadata-template.md
+      verdict-schema.md
+      output-formats.md
+      intake-interview.md
+      handoff-template.html
+    scripts/
+      board_verdict.py
+      format_output.py
+      README.md
 docs/
   index.md
   advisory-board.md
+  sample-handoff.html
 ```
 
 ## Using A Skill

--- a/ROADMAP.html
+++ b/ROADMAP.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<!--
+  Advisory Board — Improvement Roadmap.
+  Self-contained (inline CSS only, no external fonts / CDNs / JS); opens offline
+  by double-clicking. A living tracker — flip a card's data-status between
+  "shipped", "progress", and "planned" and update the counters in the masthead.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Advisory Board — Improvement Roadmap</title>
+<style>
+  :root {
+    --maxw: 940px;
+    --ink: #1c1d22;
+    --ink-soft: #4a4d57;
+    --ink-faint: #74777f;
+    --line: #e4e3dd;
+    --line-strong: #d2d1c9;
+    --surface: #ffffff;
+    --page: #f6f5f1;
+    --surface-soft: #faf9f5;
+    --accent: #4f46b8;
+    --accent-soft: #efeefb;
+    --shipped-bg: #e9f5ec;  --shipped-edge: #2f7d46; --shipped-ink: #1d5e31;
+    --prog-bg: #fdf2dd;     --prog-edge: #b9791b;    --prog-ink: #7a4d09;
+    --plan-bg: #eeedf0;     --plan-edge: #9a9aa6;    --plan-ink: #54545f;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 Helvetica, Arial, sans-serif;
+    font-size: 16px; line-height: 1.6;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 32px 20px 72px; }
+
+  .eyebrow {
+    font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--ink-faint); font-weight: 600; margin: 0 0 8px;
+  }
+  h1 { font-size: 29px; line-height: 1.2; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
+  .subtitle { font-size: 16.5px; color: var(--ink-soft); margin: 0 0 18px; max-width: 60ch; }
+
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+  .chip {
+    display: inline-flex; align-items: baseline; gap: 6px;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 999px; padding: 5px 13px; font-size: 13.5px; color: var(--ink-soft);
+  }
+  .chip b { font-weight: 700; color: var(--ink); }
+
+  /* progress bar */
+  .progress { margin: 0 0 10px; }
+  .track { height: 10px; background: var(--line); border-radius: 999px; overflow: hidden; }
+  .fill { height: 100%; width: 100%; background: var(--shipped-edge); border-radius: 999px; }
+  .progress .cap { font-size: 13px; color: var(--ink-faint); margin: 7px 1px 0; }
+
+  /* legend */
+  .legend { display: flex; flex-wrap: wrap; gap: 14px; margin: 22px 0 8px; font-size: 13px; color: var(--ink-soft); }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; }
+  .dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+  .dot.shipped { background: var(--shipped-edge); }
+  .dot.progress { background: var(--prog-edge); }
+  .dot.planned { background: var(--plan-edge); }
+
+  /* section */
+  section { margin: 26px 0 0; }
+  h2 {
+    font-size: 13px; letter-spacing: 0.07em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-faint); margin: 0 0 12px;
+    padding-bottom: 7px; border-bottom: 1px solid var(--line);
+  }
+
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 12px; }
+
+  .card {
+    position: relative; background: var(--surface);
+    border: 1px solid var(--line-strong); border-left-width: 5px;
+    border-radius: 0 11px 11px 0; padding: 14px 16px 14px 16px;
+  }
+  .card[data-status="shipped"] { border-left-color: var(--shipped-edge); }
+  .card[data-status="progress"] { border-left-color: var(--prog-edge); }
+  .card[data-status="shipped"]  { border-left-color: var(--plan-edge); }
+
+  .card-head { display: flex; align-items: center; gap: 9px; margin-bottom: 5px; }
+  .num {
+    flex: none; width: 26px; height: 26px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    font-size: 13px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  }
+  .card[data-status="shipped"] .num { background: var(--shipped-bg); color: var(--shipped-ink); }
+  .card-title { font-size: 16px; font-weight: 700; margin: 0; line-height: 1.3; }
+  .pill {
+    margin-left: auto; flex: none; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.04em; text-transform: uppercase; border-radius: 999px; padding: 3px 9px;
+  }
+  .pill.shipped { background: var(--shipped-bg); color: var(--shipped-ink); }
+  .pill.progress { background: var(--prog-bg); color: var(--prog-ink); }
+  .pill.planned { background: var(--plan-bg); color: var(--plan-ink); }
+
+  .desc { font-size: 14.5px; color: var(--ink-soft); margin: 0 0 9px; }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .tag {
+    font-size: 11.5px; color: var(--ink-faint);
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 6px; padding: 2px 8px;
+  }
+  .tag.flag { color: var(--accent); background: var(--accent-soft); border-color: #ddd9f6; font-weight: 600; }
+  .tag.mine { color: #7a4d09; background: var(--prog-bg); border-color: #f0e2c0; font-weight: 600; }
+
+  footer { margin-top: 38px; padding-top: 16px; border-top: 1px solid var(--line); font-size: 13px; color: var(--ink-faint); line-height: 1.7; }
+  footer code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.86em; background: #efeee8; border-radius: 4px; padding: 1px 5px; }
+
+  @media (max-width: 560px) {
+    .grid { grid-template-columns: 1fr; }
+    h1 { font-size: 24px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <p class="eyebrow">Advisory Board · Improvement roadmap</p>
+    <h1>Hardening &amp; expanding the board</h1>
+    <p class="subtitle">Sixteen tracked improvements across the multi-model advisory-board skill — all shipped in v1.</p>
+    <div class="meta-row">
+      <span class="chip"><b>Updated</b> 2026-06-24</span>
+      <span class="chip"><b>Items</b> 16</span>
+      <span class="chip"><b>Shipped</b> 16</span>
+      <span class="chip"><b>Status</b> v1 complete</span>
+    </div>
+    <div class="progress">
+      <div class="track"><div class="fill"></div></div>
+      <p class="cap">16 of 16 shipped</p>
+    </div>
+    <div class="legend">
+      <span><i class="dot shipped"></i> Shipped</span>
+      <span><i class="dot progress"></i> In progress</span>
+      <span><i class="dot planned"></i> Planned</span>
+    </div>
+  </header>
+
+  <!-- ===== FOUNDATIONS ===== -->
+  <section>
+    <h2>Foundations · shipped</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">0</span><h3 class="card-title">Template output contract</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">One placeholder convention (single tokens vs. duplicate-me blocks) plus a zero-token, zero-comment, self-contained output contract. The template now renders the same anywhere.</p>
+        <div class="tags"><span class="tag">Effort: S</span><span class="tag">Impact: portability</span></div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ===== HARDEN ===== -->
+  <section>
+    <h2>Harden · reliability &amp; trust</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">1</span><h3 class="card-title">Preflight go/no-go</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Per-seat check — CLI present, auth active, model resolves, smoke ping returns — before spending real tokens. Proceed only with two healthy seats.</p>
+        <div class="tags"><span class="tag flag">Cheap win</span><span class="tag">Effort: S</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">2</span><h3 class="card-title">Real provenance capture</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Record the model that actually answered (not just the one requested), plus commands, flags, timings, and token counts.</p>
+        <div class="tags"><span class="tag">Effort: S–M</span><span class="tag">Impact: trust</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">3</span><h3 class="card-title">Dropped-seat status</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Show ran / degraded / dropped per seat, so a two-seat run never silently looks like the board only had two voices.</p>
+        <div class="tags"><span class="tag">Effort: S</span><span class="tag">Impact: trust</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">4</span><h3 class="card-title">Data-egress guardrail</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Disclose that source bytes go to three external providers; offer a redaction pass and a local-only model seat. Unlocks enterprise use.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: high</span></div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ===== EPISTEMICS ===== -->
+  <section>
+    <h2>Epistemics · make the verdict worth trusting</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">5</span><h3 class="card-title">Confidence &amp; independence</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Each seat states a confidence; in round 2 it must say whether it changed on evidence or just because the others agreed.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">6</span><h3 class="card-title">Guaranteed minority report</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">If the board goes unanimous, one seat must steelman the opposite before consensus is accepted. Fights groupthink.</p>
+        <div class="tags"><span class="tag">Effort: S–M</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">7</span><h3 class="card-title">Neutral synthesizer</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">A different model — or a blind merge — writes the final handoff, so the chair has no thumb on the scale.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: medium</span></div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ===== FLEXIBILITY ===== -->
+  <section>
+    <h2>Flexibility · more shapes, more subjects</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">8</span><h3 class="card-title">Any number of seats</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Two to five seats, the same provider twice with different lenses, or a human / local-model seat. The template already repeats cleanly.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: medium</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">9</span><h3 class="card-title">Lens / domain presets</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Named seat lineups for software, product, research, legal, business, and writing — the cheapest way to multiply the use cases.</p>
+        <div class="tags"><span class="tag flag">Cheap win</span><span class="tag">Effort: S</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">10</span><h3 class="card-title">Adaptive rounds</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Stop early on high-confidence convergence; add a round when material dissent remains. Rounds become a signal, not a fixed count.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: medium</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">11</span><h3 class="card-title">Pluggable outputs</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Off the same synthesis: a one-paragraph TL;DR, a PR comment, a Slack message, and a print / PDF stylesheet.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: medium</span></div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ===== ADOPTION ===== -->
+  <section>
+    <h2>Adoption &amp; impact · why a stranger picks it up</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">12</span><h3 class="card-title">Lead with the artifact</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Showcase the HTML handoff in the README with a live-view link and a Pages sample, so the payoff is visible in five seconds.</p>
+        <div class="tags"><span class="tag flag">Cheap win</span><span class="tag">Effort: S</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">13</span><h3 class="card-title">Works-with-what-you-have</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">A graceful minimal path — two seats, an API-key fallback, or one paid plus one local — so adoption doesn't die at "I lack all three CLIs."</p>
+        <div class="tags"><span class="tag">Effort: S</span><span class="tag">Impact: high</span></div>
+      </article>
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">14</span><h3 class="card-title">Machine-readable verdict</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">Emit a tiny JSON verdict beside the prose so the board can gate a merge or launch in CI. The differentiator: a model debate as a gate.</p>
+        <div class="tags"><span class="tag">Effort: M</span><span class="tag">Impact: high</span></div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ===== EXPERIENCE ===== -->
+  <section>
+    <h2>Experience · how a run begins</h2>
+    <div class="grid">
+      <article class="card" data-status="shipped">
+        <div class="card-head"><span class="num">15</span><h3 class="card-title">Onboarding interview wizard</h3><span class="pill shipped">Shipped</span></div>
+        <p class="desc">A grill-style Q&amp;A up front — source, rounds, cross-reading, output, domain preset, sensitivity, seats — instead of static defaults. Reuses the existing grilling skills.</p>
+        <div class="tags"><span class="tag mine">Tim's idea</span><span class="tag">Effort: M</span><span class="tag">Impact: high</span></div>
+      </article>
+    </div>
+  </section>
+
+  <footer>
+    A living tracker for the <code>advisory-board</code> skill. Self-contained HTML — opens offline.
+    To update: change a card's <code>data-status</code> (<code>shipped</code> / <code>progress</code> / <code>planned</code>), its pill, and the masthead counters + progress <code>.fill</code> width.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/advisory-board.md
+++ b/docs/advisory-board.md
@@ -8,6 +8,8 @@ title: Advisory Board
 
 Bring the board any material worth more than one expert opinion — a plan, design, architecture, document, decision, or goal. Each model reviews it independently, then reads a packet of the first-round findings and responds to the strongest objections, missed details, and points of disagreement. A final synthesis turns the debate into a single working handoff.
 
+**See a sample:** [a rendered handoff](./sample-handoff.html) from a payments idempotency review — self-contained HTML that opens offline.
+
 ## What It Is For
 
 - Adversarial review of a plan, design, or architecture before a build.
@@ -23,11 +25,11 @@ Bring the board any material worth more than one expert opinion — a plan, desi
 2. **Round 2** — each model reads the other seats' findings and responds: what it missed, what changed its mind, what it still disputes.
 3. **Final synthesis** — the chair writes a handoff with consensus, dissent, risks, guardrails, and next actions.
 
-Two rounds is the default: enough for the board to challenge itself without turning every review into a long-running process.
+Two rounds is the default: enough for the board to challenge itself without turning every review into a long-running process. Set rounds to `auto` to stop early on convergence or add a round when real disagreement remains.
 
 ## Seats
 
-Each seat gets a distinct lens, matched to the subject. For software and technical work:
+Each seat gets a distinct lens, matched to the subject — ready-made lens sets for software, product, research, legal, business, and writing live in [`lens-presets.md`](../skills/advisory-board/references/lens-presets.md). For software and technical work:
 
 - **Claude** — architecture, systems, and adversarial design review.
 - **Codex** — repo-grounded implementation, migration, testing, and execution.
@@ -37,6 +39,8 @@ For non-software subjects the seats take comparable lenses — first-principles 
 
 ## Safety Defaults
 
+- A preflight go/no-go check (CLI, auth, model, smoke ping) gates every run — a board needs at least two healthy seats.
+- Sensitive material is disclosed before it leaves the machine, with redaction or a local-only board as options.
 - Read-only unless edits are explicitly requested.
 - Subscription-backed CLIs where available.
 - Highest available reasoning settings, verified at run time.
@@ -49,11 +53,23 @@ A run saves:
 - per-seat Round 1 notes;
 - per-seat Round 2 rebuttals;
 - a board packet between rounds;
-- a final consensus handoff;
-- optional run metadata (no secrets).
+- a final consensus handoff (Markdown + self-contained HTML);
+- `verdict.json` — a machine-readable verdict you can gate CI on or reshape into a PR comment, Slack message, or TL;DR;
+- run metadata: provenance, per-seat status, and timings (no secrets).
 
 ## Source Files
 
 - [`SKILL.md`](../skills/advisory-board/SKILL.md)
 - [`prompt-templates.md`](../skills/advisory-board/references/prompt-templates.md)
+- [`lens-presets.md`](../skills/advisory-board/references/lens-presets.md)
+- [`preflight.md`](../skills/advisory-board/references/preflight.md)
+- [`board-composition.md`](../skills/advisory-board/references/board-composition.md)
+- [`data-handling.md`](../skills/advisory-board/references/data-handling.md)
+- [`epistemics.md`](../skills/advisory-board/references/epistemics.md)
+- [`run-metadata-template.md`](../skills/advisory-board/references/run-metadata-template.md)
+- [`verdict-schema.md`](../skills/advisory-board/references/verdict-schema.md)
+- [`output-formats.md`](../skills/advisory-board/references/output-formats.md)
+- [`intake-interview.md`](../skills/advisory-board/references/intake-interview.md)
+- [`handoff-template.html`](../skills/advisory-board/references/handoff-template.html)
+- [`scripts/`](../skills/advisory-board/scripts/) — `board_verdict.py`, `format_output.py`
 - [`openai.yaml`](../skills/advisory-board/agents/openai.yaml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ This repository is provider-agnostic. Individual skills may include runtime-spec
 
 ### [Advisory Board](./advisory-board)
 
-A multi-model round table for strengthening any plan, design, decision, or document before you commit to it. Several frontier models review the same material, debate across rounds, and converge on a single working handoff.
+A multi-model round table for strengthening any plan, design, decision, or document before you commit to it. Several frontier models review the same material, debate across rounds, and converge on a single working handoff — plus a machine-readable verdict you can gate CI on. Domain lens presets cover software, product, research, legal, business, and writing.
 
 ## Repository Principles
 

--- a/docs/sample-handoff.html
+++ b/docs/sample-handoff.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<!--
+  Rendered advisory-board handoff for the payments idempotency-keys review.
+  Self-contained: inline CSS only, no external fonts / CDNs / JS. Opens offline
+  by double-clicking. Generated from the handoff-template.html shipped with the
+  advisory-board skill, populated with the real 2026-06-24 review run.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Advisory Board — Payments idempotency keys</title>
+<style>
+  :root {
+    --maxw: 820px;
+    --ink: #1c1d22;
+    --ink-soft: #4a4d57;
+    --ink-faint: #74777f;
+    --line: #e4e3dd;
+    --line-strong: #d2d1c9;
+    --surface: #ffffff;
+    --page: #f6f5f1;
+    --surface-soft: #faf9f5;
+    --accent: #4f46b8;
+    --ship-bg: #e9f5ec;     --ship-edge: #2f7d46;   --ship-ink: #1d5e31;
+    --caution-bg: #fdf2dd;  --caution-edge: #b9791b; --caution-ink: #7a4d09;
+    --block-bg: #fbe9e9;    --block-edge: #b23535;  --block-ink: #7e1f1f;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+    font-size: 17px;
+    line-height: 1.65;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 32px 20px 72px; }
+
+  header.masthead { margin-bottom: 24px; }
+  .eyebrow {
+    font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--ink-faint); font-weight: 600; margin: 0 0 8px;
+  }
+  h1 { font-size: 30px; line-height: 1.2; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
+  .subtitle { font-size: 17px; color: var(--ink-soft); margin: 0 0 18px; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 999px; padding: 5px 13px; font-size: 13.5px; color: var(--ink-soft);
+  }
+  .chip b { font-weight: 600; color: var(--ink); }
+
+  .verdict {
+    border-radius: 14px; padding: 22px 24px; margin: 8px 0 32px;
+    border: 1px solid transparent; border-left-width: 6px;
+  }
+  .verdict .label {
+    font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
+    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+  }
+  .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
+  .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
+  .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
+  .verdict.caution { background: var(--caution-bg); border-color: var(--caution-edge); color: var(--caution-ink); }
+  .verdict.block   { background: var(--block-bg);   border-color: var(--block-edge);   color: var(--block-ink); }
+
+  section { margin: 0 0 34px; }
+  h2 {
+    font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-faint); margin: 0 0 14px;
+    padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+
+  .plan {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--accent); border-radius: 0 10px 10px 0;
+    padding: 16px 20px;
+  }
+  .plan p { margin: 0 0 10px; } .plan p:last-child { margin: 0; }
+
+  .seat {
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 14px; padding: 20px 22px; margin: 0 0 18px;
+  }
+  .seat-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 12px; margin-bottom: 4px; }
+  .seat-name { font-size: 19px; font-weight: 700; margin: 0; }
+  .seat-lens {
+    font-size: 12.5px; font-weight: 600; color: var(--accent);
+    background: #efeefb; border-radius: 999px; padding: 3px 11px;
+  }
+  .seat-model { font-size: 13px; color: var(--ink-faint); }
+  .round { margin-top: 16px; padding-top: 16px; border-top: 1px dashed var(--line); }
+  .round:first-of-type { margin-top: 12px; }
+  .round-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 8px; }
+  .round-tag { font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); }
+  .vpill { font-size: 12px; font-weight: 700; border-radius: 999px; padding: 3px 11px; line-height: 1.4; }
+  .vpill.ship    { background: var(--ship-bg);    color: var(--ship-ink); }
+  .vpill.caution { background: var(--caution-bg); color: var(--caution-ink); }
+  .vpill.block   { background: var(--block-bg);   color: var(--block-ink); }
+  .vpill.moved::after { content: " ↓"; }
+
+  .review-body { font-size: 15.5px; color: var(--ink); }
+  .review-body strong { font-weight: 600; }
+  .review-body ul { margin: 6px 0; padding-left: 22px; }
+  .review-body li { margin: 5px 0; }
+  .review-body p { margin: 6px 0; }
+  .review-body p.r-title { font-weight: 600; margin-top: 12px; }
+  code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em; background: #f0efe9; border: 1px solid var(--line);
+    border-radius: 5px; padding: 1px 5px;
+  }
+
+  .highlight {
+    background: #fff8e8; border: 1px solid #ecd9a3; border-radius: 10px;
+    padding: 12px 16px; margin: 14px 0 0; font-size: 14.5px; color: #6f5212;
+  }
+  .highlight b { color: #5a4209; }
+
+  ol.blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
+  ol.blockers > li {
+    counter-increment: blk; position: relative;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 11px; padding: 15px 18px 15px 56px; margin: 0 0 11px;
+  }
+  ol.blockers > li::before {
+    content: counter(blk); position: absolute; left: 14px; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--block-bg); color: var(--block-ink);
+    font-size: 14px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  }
+  ol.blockers .b-title { font-weight: 600; }
+  ol.blockers .b-body { font-size: 15px; color: var(--ink-soft); margin-top: 3px; }
+
+  .dissent {
+    background: #fbf3ec; border: 1px dashed var(--caution-edge);
+    border-radius: 12px; padding: 16px 20px;
+  }
+  .dissent .d-flag {
+    display: inline-block; font-size: 11.5px; font-weight: 700;
+    letter-spacing: 0.07em; text-transform: uppercase; color: var(--caution-ink);
+    background: var(--caution-bg); border-radius: 999px; padding: 3px 10px; margin-bottom: 8px;
+  }
+  .dissent p { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
+  .dissent .who { font-weight: 700; color: var(--caution-ink); }
+
+  ul.plain { margin: 0; padding-left: 22px; }
+  ul.plain li { margin: 7px 0; font-size: 15.5px; }
+
+  .actions {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 12px; padding: 16px 20px; font-size: 15.5px;
+  }
+  .actions ol { margin: 0; padding-left: 20px; }
+  .actions li { margin: 6px 0; }
+
+  footer.meta {
+    margin-top: 40px; padding-top: 18px; border-top: 1px solid var(--line);
+    font-size: 13px; color: var(--ink-faint); line-height: 1.7;
+  }
+  footer.meta code { background: #efeee8; }
+  footer.meta .prov { display: block; margin-top: 6px; }
+
+  @media (max-width: 560px) {
+    body { font-size: 16px; }
+    .wrap { padding: 22px 15px 56px; }
+    h1 { font-size: 25px; }
+    .verdict .headline { font-size: 20px; }
+    .seat, ol.blockers > li { padding-left: 16px; padding-right: 16px; }
+    ol.blockers > li { padding-left: 50px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="masthead">
+    <p class="eyebrow">Advisory Board · Multi-model review</p>
+    <h1>Payments API idempotency keys</h1>
+    <p class="subtitle">Adversarial plan review by a three-model board before implementation.</p>
+    <div class="meta-row">
+      <span class="chip"><b>Date</b> 2026-06-24</span>
+      <span class="chip"><b>Rounds</b> 2</span>
+      <span class="chip"><b>Board</b> Claude · Codex · Gemini</span>
+    </div>
+  </header>
+
+  <div class="verdict block">
+    <p class="label">Final verdict</p>
+    <p class="headline">Do not ship yet — unanimous</p>
+    <p class="note">Round&nbsp;1 was two &ldquo;do not ship&rdquo; plus one &ldquo;ship with changes&rdquo; (Codex). In Round&nbsp;2, after reading the others, <strong>Codex moved to &ldquo;do not ship yet.&rdquo;</strong> No seat dissents from the verdict.</p>
+  </div>
+
+  <section>
+    <h2>Plan under review</h2>
+    <div class="plan">
+      <p>Add idempotency keys to the payments API. Clients may send an <code>Idempotency-Key</code> header on <code>POST /charges</code>. The server stores the key-to-response mapping in Redis with a 24h TTL; on a duplicate key it returns the cached response.</p>
+      <p>Keys are optional, and the team intends to enable the feature for all clients at once next sprint.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Board reviews — round by round</h2>
+
+    <!-- ===== CLAUDE ===== -->
+    <article class="seat">
+      <div class="seat-head">
+        <h3 class="seat-name">Claude</h3>
+        <span class="seat-lens">Architecture lens</span>
+        <span class="seat-model">claude-opus-4-8</span>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 1 · independent</span>
+          <span class="vpill block">Do not ship yet</span>
+        </div>
+        <div class="review-body">
+          <p>Close — fix two things first.</p>
+          <p class="r-title">Top risks</p>
+          <ul>
+            <li><strong>Concurrent in-flight duplicates.</strong> Redis store-on-completion leaves a race: two requests with the same key arriving near-simultaneously both miss the cache and double-charge. You need an atomic reserve (<code>SET NX</code>) on receipt, with an in-progress sentinel, not store-after-response.</li>
+            <li><strong>Key collision / weak semantics.</strong> A cached response keyed on the header alone ignores the request body. A client reusing a key with a <em>different</em> payload silently gets the old charge — or worse, masks a real second charge. Must bind key&nbsp;&rarr;&nbsp;request-fingerprint and return 422 on mismatch.</li>
+            <li><strong>Big-bang rollout.</strong> &ldquo;All clients at once next sprint&rdquo; gives no blast-radius control. Redis is now in the critical payment path — define behavior when Redis is down (fail-open = lost idempotency; fail-closed = outage).</li>
+          </ul>
+          <p class="r-title">The one change I&rsquo;d insist on</p>
+          <p>Atomic <code>SET NX</code> reservation at request entry + persist the response under that key, so the dedup window covers in-flight requests, not just completed ones.</p>
+          <p class="r-title">Ask another seat to check</p>
+          <p>24h TTL vs. client retry/settlement windows — does a legitimate retry after expiry double-charge? Verify against payment-processor reconciliation semantics.</p>
+        </div>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 2 · rebuttal</span>
+          <span class="vpill block">Do not ship</span>
+        </div>
+        <div class="review-body">
+          <ol>
+            <li><strong>Under-weighted:</strong> Codex&rsquo;s point that transient 5xx must not be cached as authoritative is sharper than my generic &ldquo;cache the response.&rdquo; A 502 stored as the canonical reply would permanently poison the key. And Gemini&rsquo;s insistence on cache-hit/latency <em>alerting</em> — I named Redis-down behavior but not the observability to detect it.</li>
+            <li><strong>Changed my view:</strong> I&rsquo;m dropping any tolerance for big-bang. Gemini + Codex converge on phased rollout, and on a core payments path the blast radius argument is decisive. Rollout sequencing is now a blocker, not a footnote.</li>
+            <li><strong>Still dispute:</strong> Codex&rsquo;s overall &ldquo;ship with changes.&rdquo; The atomic-claim race and fingerprint binding aren&rsquo;t tweaks — without them the feature double-charges under the exact concurrency it exists to prevent. That&rsquo;s not-ready, not ship-with-changes.</li>
+            <li><strong>Recommendation:</strong> Do not ship — block on atomic claim + sentinel, key&nbsp;&harr;&nbsp;fingerprint binding (422), defined Redis-down behavior, non-caching of transient 5xx, and a phased rollout with latency/hit alerting.</li>
+          </ol>
+        </div>
+      </div>
+    </article>
+
+    <!-- ===== CODEX ===== -->
+    <article class="seat">
+      <div class="seat-head">
+        <h3 class="seat-name">Codex</h3>
+        <span class="seat-lens">Implementation / testing lens</span>
+        <span class="seat-model">gpt-5.5</span>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 1 · independent</span>
+          <span class="vpill caution">Ship with changes</span>
+        </div>
+        <div class="review-body">
+          <p class="r-title">Top risks</p>
+          <ul>
+            <li>Caching &ldquo;response&rdquo; is underspecified. You must replay status code, body, headers, and error shape consistently, but avoid caching transient 5xx/timeouts as authoritative charge outcomes.</li>
+            <li>No request fingerprinting. Same <code>Idempotency-Key</code> with different amount/customer/card should return a conflict, not a cached unrelated charge.</li>
+            <li>Race handling is missing. Two concurrent POSTs with the same key can both create charges unless Redis uses an atomic claim / in-progress / completed state.</li>
+          </ul>
+          <p class="r-title">Single change I&rsquo;d insist on</p>
+          <p>Implement atomic idempotency state: <code>SET NX</code> claim with request hash, mark completed only after a durable charge result, replay only matching hashes, return conflict on hash mismatch, and define behavior for in-flight retries.</p>
+          <p class="r-title">Ask other seats to check</p>
+          <p>Product / legal / ops should confirm whether 24h retention and optional keys match client retry behavior, dispute/audit needs, and payment provider idempotency guarantees.</p>
+        </div>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 2 · rebuttal</span>
+          <span class="vpill block moved">Do not ship yet</span>
+        </div>
+        <div class="review-body">
+          <ul>
+            <li><strong>Under-weighted:</strong> Claude/Gemini are right that Redis-down behavior and rollout mechanics are not secondary details. On a payments write path, &ldquo;idempotency available unless Redis has issues&rdquo; is a product/ops contract, not just an implementation edge case.</li>
+            <li><strong>Changed view:</strong> I&rsquo;d move from <em>ship with changes</em> to <em>do not ship yet</em>. The core algorithm changes are clear, but the plan lacks enough failure-mode and rollout specificity to safely schedule as-is.</li>
+            <li><strong>Still dispute:</strong> I don&rsquo;t think &ldquo;all clients at once next sprint&rdquo; is inherently impossible if keys are optional and server behavior is backwards compatible. But for payments, it still needs a kill switch, metrics, and staged enablement by route/client cohort before broad reliance.</li>
+            <li><strong>Final recommendation:</strong> Do not ship yet — require atomic reservation/in-progress handling, request fingerprint binding, explicit Redis failure policy, replay semantics, observability, and phased rollout before approval.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="highlight"><b>Verdict change:</b> Codex was the lone &ldquo;ship with changes&rdquo; in Round&nbsp;1. After reading Claude and Gemini, it moved to &ldquo;do not ship yet,&rdquo; making the board unanimous.</div>
+    </article>
+
+    <!-- ===== GEMINI ===== -->
+    <article class="seat">
+      <div class="seat-head">
+        <h3 class="seat-name">Gemini</h3>
+        <span class="seat-lens">Product / ops lens</span>
+        <span class="seat-model">Gemini frontier (thinking: HIGH)</span>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 1 · independent</span>
+          <span class="vpill block">Do not ship yet</span>
+        </div>
+        <div class="review-body">
+          <p class="r-title">Strongest objections &amp; risks</p>
+          <ul>
+            <li><strong>Operational blast radius:</strong> an &ldquo;all clients at once&rdquo; rollout is incredibly risky for a core payments path. A Redis latency spike or configuration error will instantly degrade all transactions.</li>
+            <li><strong>Concurrency / double-charge risk:</strong> the plan lacks a locking strategy. If a client sends two identical requests simultaneously, both may bypass the cache before the first response is saved, resulting in catastrophic double-charges for users.</li>
+            <li><strong>Undefined failure modes:</strong> there is no operational plan for Redis downtime. If Redis is unreachable, failing <em>closed</em> blocks all payments; failing <em>open</em> silently breaks the idempotency promise.</li>
+          </ul>
+          <p class="r-title">Single most insisted change</p>
+          <p>Mandate a phased, measurable rollout (e.g. internal testing &rarr; opt-in beta &rarr; progressive percentage) backed by strict alerting on Redis latency and cache-hit rates, replacing the proposed big-bang release.</p>
+          <p class="r-title">Question for other seats</p>
+          <p>Ask the architecture/security seat to strictly review the exact Redis locking mechanism (e.g. <code>SETNX</code>) to guarantee that concurrent identical requests are mathematically prevented from creating race conditions.</p>
+        </div>
+      </div>
+
+      <div class="round">
+        <div class="round-head">
+          <span class="round-tag">Round 2 · rebuttal</span>
+          <span class="vpill block">Do not ship</span>
+        </div>
+        <div class="review-body">
+          <ul>
+            <li><strong>Under-weighted:</strong> Codex&rsquo;s point about not caching 5xx errors. From an ops perspective, caching a transient 500 would permanently block a user&rsquo;s legitimate retry for 24 hours, causing a massive spike in unresolvable support tickets.</li>
+            <li><strong>Changed my view:</strong> Claude and Codex&rsquo;s alignment on request fingerprinting. I focused heavily on concurrency and rollout, but they correctly identified that a client reusing a key for a <em>different</em> payload without triggering a 422 mismatch is a catastrophic product flaw.</li>
+            <li><strong>Still dispute:</strong> Codex&rsquo;s &ldquo;ship with changes&rdquo; rating. This plan lacks fundamental architectural safety (atomic locks, fingerprinting) and operational safety (phased rollout). This isn&rsquo;t a minor tweak; it&rsquo;s a complete structural redesign of a core payments path. We cannot greenlight this conditionally.</li>
+            <li><strong>Recommendation:</strong> Do not ship — mandate atomic <code>SET NX</code> locks, payload fingerprinting, 5xx cache exclusion, and a dark-launched, phased rollout.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+  </section>
+
+  <section>
+    <h2>Consensus blockers — must fix before ship</h2>
+    <ol class="blockers">
+      <li>
+        <span class="b-title">Atomic dedup</span>
+        <div class="b-body"><code>SET NX</code> claim with an in-progress sentinel that completes only after a durable charge result. Without it, two concurrent same-key requests both miss the cache and double-charge — the exact failure the feature exists to prevent.</div>
+      </li>
+      <li>
+        <span class="b-title">Request-fingerprint binding</span>
+        <div class="b-body">Bind key&nbsp;&rarr;&nbsp;hash(request); a reused key with a different payload returns 409/422 conflict, never a replayed or unrelated charge.</div>
+      </li>
+      <li>
+        <span class="b-title">Redis failure policy + kill switch</span>
+        <div class="b-body">Redis is now in the critical payment path. Decide fail-open (lost idempotency) vs fail-closed (outage) explicitly, with a kill switch.</div>
+      </li>
+      <li>
+        <span class="b-title">Never cache transient failures</span>
+        <div class="b-body">Do not store 5xx/timeouts as the authoritative response; a cached 500 poisons the key and blocks legitimate retries for 24h.</div>
+      </li>
+      <li>
+        <span class="b-title">Replay fidelity</span>
+        <div class="b-body">Replay status code, body, and headers consistently.</div>
+      </li>
+      <li>
+        <span class="b-title">Phased rollout + observability</span>
+        <div class="b-body">Dark-launch then cohort/percentage ramp; alert on Redis latency and cache-hit rate. Replace the big-bang enablement.</div>
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Preserved dissent</h2>
+    <div class="dissent">
+      <span class="d-flag">Dissent on the record</span>
+      <p><span class="who">Codex:</span> &ldquo;All clients at once&rdquo; is not <em>inherently</em> impossible given optional keys + backwards-compatible server behavior — but only with a kill switch, metrics, and staged enablement by route/client cohort.</p>
+      <p>The rollout <em>aggressiveness</em> is debatable; the correctness blockers above are not.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Open questions</h2>
+    <ul class="plain">
+      <li>24h TTL vs client retry/settlement windows — does a legitimate retry after expiry double-charge?</li>
+      <li>Alignment with the downstream payment processor&rsquo;s own idempotency guarantees.</li>
+      <li>Dispute/audit retention needs vs the 24h window.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Next actions</h2>
+    <div class="actions">
+      <ol>
+        <li>Spec the atomic state machine + fingerprint.</li>
+        <li>Decide Redis failure policy + kill switch.</li>
+        <li>Enumerate non-cacheable status codes.</li>
+        <li>Design the phased rollout + dashboards.</li>
+        <li>Then re-review.</li>
+      </ol>
+    </div>
+  </section>
+
+  <footer class="meta">
+    Generated by the Advisory Board multi-model review skill.
+    <span class="prov">Board: Claude (architecture, <code>claude-opus-4-8</code>) · Codex (implementation/testing, <code>gpt-5.5</code>) · Gemini (product/ops, frontier thinking HIGH).</span>
+    <span class="prov">2 rounds · cross-read summaries · read-only · run dated 2026-06-24. Provenance: <code>round-1/{claude,codex,gemini}.out</code>, <code>round-2/{claude,codex,gemini}.out</code>, <code>final-consensus.md</code>.</span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/examples/payments-idempotency-review/verdict.json
+++ b/examples/payments-idempotency-review/verdict.json
@@ -1,0 +1,37 @@
+{
+  "schema": "advisory-board/verdict@1",
+  "title": "Payments API idempotency keys",
+  "date": "2026-06-24",
+  "verdict": "block",
+  "confidence": "high",
+  "unanimous": true,
+  "rounds": 2,
+  "board": [
+    { "seat": "Claude", "model": "claude-opus-4-8", "lens": "architecture", "round_verdicts": ["block", "block"], "dropped": false },
+    { "seat": "Codex", "model": "gpt-5.5", "lens": "implementation/testing", "round_verdicts": ["caution", "block"], "dropped": false },
+    { "seat": "Gemini", "model": "gemini-3.1-pro", "lens": "product/ops", "round_verdicts": ["block", "block"], "dropped": false }
+  ],
+  "blockers": [
+    { "title": "Atomic dedup", "body": "SET NX claim with an in-progress sentinel that completes only after a durable charge result; without it two concurrent same-key requests both miss the cache and double-charge." },
+    { "title": "Request-fingerprint binding", "body": "Bind key -> hash(request); a reused key with a different payload returns 409/422, never a replayed or unrelated charge." },
+    { "title": "Redis failure policy + kill switch", "body": "Redis is now in the critical payment path; decide fail-open vs fail-closed explicitly, with a kill switch." },
+    { "title": "Never cache transient failures", "body": "Do not store 5xx/timeouts as authoritative; a cached 500 poisons the key and blocks legitimate retries for 24h." },
+    { "title": "Replay fidelity", "body": "Replay status code, body, and headers consistently." },
+    { "title": "Phased rollout + observability", "body": "Dark-launch then cohort/percentage ramp; alert on Redis latency and cache-hit rate. Replace the big-bang enablement." }
+  ],
+  "dissent": [
+    { "who": "Codex", "body": "\"All clients at once\" is not inherently impossible given optional keys and backwards-compatible server behavior - but only with a kill switch, metrics, and staged enablement by route/client cohort. The rollout aggressiveness is debatable; the correctness blockers are not." }
+  ],
+  "open_questions": [
+    "24h TTL vs client retry/settlement windows - does a legitimate retry after expiry double-charge?",
+    "Alignment with the downstream payment processor's own idempotency guarantees.",
+    "Dispute/audit retention needs vs the 24h window."
+  ],
+  "next_actions": [
+    "Spec the atomic state machine + fingerprint.",
+    "Decide Redis failure policy + kill switch.",
+    "Enumerate non-cacheable status codes.",
+    "Design the phased rollout + dashboards.",
+    "Then re-review."
+  ]
+}

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -17,12 +17,15 @@ Bring an idea, problem, plan, or architecture to a board of frontier models sitt
 
 ## Upfront Choices
 
-Ask only for whatever the user hasn't already given:
+Optionally open with the intake interview (`references/intake-interview.md`) — a short structured Q&A, using the `grilling` or `grill-with-docs` skills as the engine when available — to settle the run. Otherwise ask only for whatever the user hasn't already given:
 
 1. Source material: file(s), repo, URL, or goal to review.
-2. Rounds: `1`, `2`, or `3` (default `2`).
+2. Rounds: `1`, `2`, `3`, or `auto` (default `2`; `auto` adapts — see Round Protocol).
 3. Cross-reading: `none`, `summaries`, or `full` (default `summaries`).
 4. Output: `quick verdict`, `full handoff`, or `implementation sequence` (default `full handoff`).
+5. Lens preset: the seat lineup's focus, from `references/lens-presets.md` (default: inferred from the material, falling back to `software-architecture`).
+6. Sensitivity: can the material go to external providers? (`references/data-handling.md` — may force a local-only board.)
+7. Board: seats and size, from `references/board-composition.md` (default: three seats — Claude, Codex, Gemini).
 
 If the user says "use defaults", stop asking and run.
 
@@ -36,7 +39,7 @@ Target the strongest reasoning model each provider offers:
 
 Model names and flags move fast — verify them against the installed CLIs or official docs before a large run. If a named model is unavailable, use the nearest same-provider frontier model and say so; never substitute silently.
 
-Preflight:
+Preflight — run `references/preflight.md` before launching: for each seat, check the CLI is present, auth is active (subscription-backed where possible), the requested model resolves, and a one-token smoke ping returns. Proceed only with at least two seats GO; label any degraded or dropped seat in the handoff. In summary:
 
 - Confirm Claude subscription auth is active.
 - Confirm Codex is on ChatGPT/subscription auth, not API-key-only, when possible.
@@ -45,7 +48,7 @@ Preflight:
 
 ## Seats
 
-Give each seat a distinct lens so the board covers more ground than any single reviewer, and match the lenses to the subject. For software and technical work, a strong default split:
+Give each seat a distinct lens so the board covers more ground than any single reviewer, and match the lenses to the subject. Pick a ready-made lens set from `references/lens-presets.md` — `software-architecture` (default), `product-strategy`, `research-paper`, `legal-contract`, `business-decision`, `writing-editing` — or compose your own. For software and technical work, the default split:
 
 - Claude: architecture, systems, and adversarial design review.
 - Codex: repo-grounded implementation, migration, testing, and execution.
@@ -55,28 +58,41 @@ For non-software subjects (strategy, research, writing, business, policy), assig
 
 Every seat still answers the full brief; the lens reduces blind spots, it doesn't narrow responsibility.
 
+The board defaults to three seats but isn't fixed at three — for sizing (2–5), the same provider in two seats, a human or local-model seat, and minimal "works with what you have" lineups, see `references/board-composition.md`.
+
+## Data Handling
+
+A board sends the same source material to every seat's provider. Before the first call, if the material isn't already public, tell the user what will leave the machine and to whom, and get a go-ahead. For sensitive material, redact the shared source packet; for must-not-leave material, run a local-only board or don't run it. Full guidance: `references/data-handling.md`.
+
 ## Round Protocol
 
 **Round 1 — independent.**
 
 - Give each seat the same source packet and its role lens, nothing else.
 - No other seat's opinions.
-- Require: verdict, strongest objections, revised sequence, invariants, risks, and concrete evidence.
+- Require: verdict (with a confidence level — low/medium/high), strongest objections, revised sequence, invariants, risks, and concrete evidence.
 
 **Round 2 — rebuttal (default).**
 
 - Build a board packet from Round 1: summaries with links/paths to the full artifacts (`summaries`), or full prior responses when the token budget allows (`full`).
-- Ask each seat: what another seat caught that you missed, what changed your view, what you still dispute, what should become consensus, and what stays unresolved.
+- Ask each seat: what another seat caught that you missed, what changed your view (and whether the change is driven by evidence or mere deference — see `references/epistemics.md`), what you still dispute, what should become consensus, and what stays unresolved.
 
 **Round 3 — convergence (optional).**
 
 - Give each seat the Round 2 packet.
 - Ask for the final position, hard dissent, and the smallest viable plan.
 
+**Adaptive rounds (`auto`).**
+
+- Stop early when the board has converged — a shared verdict, high confidence, and no material dissent after a round — rather than spending a round to rubber-stamp.
+- Add a round (up to 3) when material dissent or low confidence remains and another exchange could plausibly resolve it.
+
 **Final synthesis.**
 
 - After the last round, write the handoff: consensus, dissent (and why it matters), revised plan, risks, invariants, evidence, and next actions.
-- Label model and round provenance, and keep evidence-backed conclusions separate from judgment calls.
+- Prefer a neutral synthesizer — a seat that didn't debate, or a blind merge — so the chair doesn't grade its own work (`references/epistemics.md`). If the board is unanimous, include a minority report: the strongest case against the verdict.
+- Label model and round provenance (the model that actually answered, not just the one requested), and keep evidence-backed conclusions separate from judgment calls.
+- Emit `verdict.json` alongside the prose (`references/verdict-schema.md`) so the result can drive a gate or other tooling.
 
 ## Artifact Standard
 
@@ -85,8 +101,13 @@ Write:
 - `round-1/<seat>.md` (and `round-2/`, `round-3/` as rounds run)
 - `board-packet-round-2.md` (and `board-packet-round-3.md` when needed)
 - `final-consensus.md` — the handoff in Markdown
-- `final-consensus.html` — a self-contained, human-readable version of the handoff (inline CSS, no external files) so anyone can open it in a browser; render it from `references/handoff-template.html`
-- optional `run-metadata.md`: commands, model names, auth/account status (no secrets), timestamps, and source paths
+- `final-consensus.html` — a self-contained, human-readable view of the handoff, rendered from `references/handoff-template.html`
+- `verdict.json` — the machine-readable verdict (`references/verdict-schema.md`); gate or reformat it with `scripts/`
+- `run-metadata.md` — provenance: commands, the model that actually answered per seat, auth mode (no secrets), per-seat status (ran / degraded / dropped), timings, and source paths. Use `references/run-metadata-template.md`.
+
+When a seat is degraded or dropped, show it on its HTML seat card (status pill) and in `verdict.json` (`dropped: true`) — never let a smaller board look like a full one. Derive lighter shares (TL;DR, PR comment, Slack, print/PDF) per `references/output-formats.md`.
+
+**Output contract for the HTML.** It is a *view* of `final-consensus.md`, not a second source of truth — the two must not disagree. The rendered file must contain no leftover `{{tokens}}` and no template scaffolding comments, and must stay self-contained (inline CSS only; no external fonts, CDNs, scripts, or remote `<link>`/`<script src>`) so it opens offline on a double-click. Follow the template's two-placeholder convention: replace each single `{{TOKEN}}` in place, and duplicate each `BEGIN`/`END` block once per item (delete the sample block if there are none).
 
 Never store secrets. Redact keys, tokens, cookies, and private environment values.
 
@@ -95,7 +116,7 @@ Never store secrets. Redact keys, tokens, cookies, and private environment value
 You (the orchestrating agent) drive the board by shelling out to each provider's CLI and collecting its written artifact:
 
 - Run every seat as its own CLI subprocess — including the Claude seat as a separate `claude` process — so each reviews the source independently rather than reusing the orchestrator's context. That independence is what makes Round 1 worth anything.
-- Keep the orchestrator and the chair neutral: assemble packets and synthesize, but don't also count yourself as a debating seat. If you must, say so in the handoff.
+- Keep the orchestrator and the chair neutral: assemble packets and synthesize, but don't also count yourself as a debating seat. If you must, say so in the handoff and use a minority report to check chair bias (`references/epistemics.md`).
 - When the source is a repo or local files, decide once how seats reach it and record it in `run-metadata.md`: either every CLI reads the same shared path, or you build one source packet and hand identical bytes to each seat. Use one method for all seats so they review the same thing.
 
 ## CLI Execution Notes
@@ -154,6 +175,10 @@ Prefer a CLI flag or environment variable if the installed Gemini CLI exposes on
 
 Load `references/prompt-templates.md` when running a board. Use the templates as a starting point, then adapt them to the source material, output type, and project constraints.
 
+## Scripts
+
+Optional helpers in `scripts/` (Python 3 stdlib, no install): `board_verdict.py` validates `verdict.json` and gates CI on the verdict (`--gate`); `format_output.py` renders it as a TL;DR, PR comment, Slack message, or JSON. The skill runs fine without them — they're for wiring a board into CI and other tooling. See `scripts/README.md`.
+
 ## When To Stop
 
 Stop and ask or report if:
@@ -161,6 +186,7 @@ Stop and ask or report if:
 - no source material is given and none is inferable from an obvious file or repo;
 - fewer than two seats can authenticate or run — a board needs at least two voices;
 - a step would need write access but the user asked for review only;
-- full cross-reading would blow the context budget — fall back to summaries and say so.
+- full cross-reading would blow the context budget — fall back to summaries and say so;
+- the material is too sensitive to send to external providers and no local-only board is available (`references/data-handling.md`).
 
 If a provider is unavailable, or fails partway through, but at least two seats remain, continue as a smaller board and label the missing seat (and the round it dropped out) in the handoff rather than silently omitting it.

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -118,6 +118,7 @@ You (the orchestrating agent) drive the board by shelling out to each provider's
 - Run every seat as its own CLI subprocess — including the Claude seat as a separate `claude` process — so each reviews the source independently rather than reusing the orchestrator's context. That independence is what makes Round 1 worth anything.
 - Keep the orchestrator and the chair neutral: assemble packets and synthesize, but don't also count yourself as a debating seat. If you must, say so in the handoff and use a minority report to check chair bias (`references/epistemics.md`).
 - When the source is a repo or local files, decide once how seats reach it and record it in `run-metadata.md`: either every CLI reads the same shared path, or you build one source packet and hand identical bytes to each seat. Use one method for all seats so they review the same thing.
+- Seats are agentic — they may web-search and read their working directory, which usually *helps* (live grounding). When you need a clean outside view or isolation, control the working directory and network and hand each seat one neutral source packet. (Running seats from a non-git folder also requires Codex's `--skip-git-repo-check`.)
 
 ## CLI Execution Notes
 
@@ -129,18 +130,18 @@ Claude seat:
 claude -p "<seat prompt>" --model claude-opus-4-8 --permission-mode plan
 ```
 
-`-p` runs non-interactively; `--permission-mode plan` keeps it read-only. Use the strongest reasoning/effort the build exposes (Claude Code defaults to `xhigh`).
+`-p` runs non-interactively; `--permission-mode plan` keeps it read-only. Use the strongest reasoning/effort the build exposes (Claude Code defaults to `xhigh`). On long analytic prompts, `--permission-mode plan` can make the seat return a plan-style *summary* (and even claim it wrote a file) instead of the full review — so tell the seat to output its complete review as its reply and not write any files.
 
 Codex seat:
 
 ```
-codex exec --sandbox read-only \
+codex exec --sandbox read-only --skip-git-repo-check \
   --config model="gpt-5.5" \
   --config model_reasoning_effort="xhigh" \
   "<seat prompt>" </dev/null
 ```
 
-`codex exec` is the non-interactive form; `--sandbox read-only` blocks edits. Close stdin with `</dev/null`: `codex exec` reads stdin until EOF, so without it the call hangs when orchestrated in the background or any non-interactive pipeline.
+`codex exec` is the non-interactive form; `--sandbox read-only` blocks edits. Close stdin with `</dev/null`: `codex exec` reads stdin until EOF, so without it the call hangs when orchestrated in the background or any non-interactive pipeline. Pass `--skip-git-repo-check` so the run doesn't abort with "Not inside a trusted directory" when a seat runs from a neutral, non-git source folder.
 
 Gemini seat:
 
@@ -148,7 +149,7 @@ Gemini seat:
 gemini -p "<seat prompt>" -m "<latest-frontier-gemini-model>"
 ```
 
-Run in a read-only / non-auto-approval mode so the seat can't make edits, and select the highest available thinking level.
+Run in a read-only / non-auto-approval mode so the seat can't make edits, and select the highest available thinking level. The Gemini CLI may print internal errors to stderr (e.g. model-router retries) yet still return a valid review — judge a seat by whether usable content came back, not by stderr noise or a non-zero exit; treat that as a degraded-but-ran seat, not a failure.
 
 ### Gemini thinking level
 

--- a/skills/advisory-board/references/board-composition.md
+++ b/skills/advisory-board/references/board-composition.md
@@ -1,0 +1,26 @@
+# Board Composition
+
+The default board is three seats — Claude, Codex, Gemini. That's a default, not a rule. A seat is a *role* (a lens), not a fixed provider, so you can resize and recompose the board to fit the subject and what's installed.
+
+## Size
+
+- **Minimum: 2 seats.** A board needs at least two independent voices; one model reviewing itself is not a board. Below two GO seats at preflight, stop.
+- **Default: 3.** Enough perspectives to triangulate without ballooning cost.
+- **Up to ~5.** Add seats for high-stakes or broad subjects. Past five, rounds get expensive and the synthesis gets noisy — prefer sharper lenses over more seats.
+
+## Composition
+
+- **Any provider in any seat.** Lenses come from `references/lens-presets.md`; assign them to whatever models you have.
+- **Same provider twice is allowed** — e.g. two Claude seats with different lenses (architecture vs. security). Note it in provenance; two seats on the same model are less independent than two different models.
+- **A human seat** is valid: capture the person's review as that seat's `round-*/` artifact and let the board read it like any other.
+- **A local/offline seat** (e.g. an Ollama model) is valid and is the lever for sensitive material — see `references/data-handling.md`.
+
+## Works with what you have
+
+Don't require three frontier subscriptions to get value:
+
+- **Two seats** (e.g. Claude + Codex) is a real board. Run it and say it was a two-seat board.
+- **API-key fallback.** If a subscription CLI isn't available, an API-key-backed call to the same provider is fine — record the auth mode in provenance (no secrets).
+- **One paid + one local.** A frontier seat plus a strong local model still gives you cross-model challenge.
+
+Record the actual lineup and auth modes in `run-metadata.md`; the handoff should never imply more independence than the run had.

--- a/skills/advisory-board/references/data-handling.md
+++ b/skills/advisory-board/references/data-handling.md
@@ -1,0 +1,29 @@
+# Data Handling
+
+A board sends the **same source material to every seat's provider** — by default Anthropic, OpenAI, and Google. Treat that as an outbound disclosure and handle it before launching, not after.
+
+## Disclose before the first call
+
+If the material is anything but already-public, tell the user plainly what will leave the machine and to whom, and get a go-ahead:
+
+> This review sends your source material to Anthropic (Claude), OpenAI (Codex), and Google (Gemini). Proceed?
+
+Name only the providers actually in the lineup.
+
+## Decide the handling
+
+1. **Public / low-sensitivity** → proceed normally.
+2. **Sensitive but reviewable** → redact before building the source packet (see below), then proceed.
+3. **Must-not-leave** (regulated data, secrets, privileged material) → use a **local-only board**: every seat a local/offline model, or don't run the board. Never silently send it.
+
+## Redaction checklist
+
+When redacting the source packet, strip or mask: credentials, tokens, API keys, cookies; personal data (names, emails, IDs) not needed for the review; customer or third-party identifiers; internal hostnames and infra secrets. Redact once in the shared source packet so every seat sees the same redacted bytes.
+
+## Local-only mode
+
+Swap each seat's CLI for a local model runner (e.g. Ollama). The protocol, lenses, rounds, and artifacts are unchanged — only the model endpoints differ. A local board trades some reasoning strength for keeping the material on the machine; say so in the handoff. Record the mode in `run-metadata.md`.
+
+## Always
+
+Never write secrets into any artifact. Redact keys, tokens, cookies, and private environment values from prompts, packets, metadata, and the handoff.

--- a/skills/advisory-board/references/epistemics.md
+++ b/skills/advisory-board/references/epistemics.md
@@ -1,0 +1,29 @@
+# Epistemics — keeping the verdict honest
+
+A multi-model board fails the same way a human panel does: once the seats read each other, they drift toward agreement. A confident, unanimous, *wrong* verdict is worse than three honest disagreements. These rules keep convergence earned, not social.
+
+## Confidence (every seat, every round)
+
+Each seat tags its verdict with a confidence — **low / medium / high** — plus one line on what would change it. Surface it in the handoff (the HTML round head supports a confidence chip). A "block" at low confidence and a "block" at high confidence are different messages; don't flatten them.
+
+## Independence check (round 2+)
+
+When a seat changes position after reading the others, it must say *why*:
+
+- **evidence** — a specific argument, file, or fact another seat surfaced; or
+- **deference** — "the others agreed."
+
+Deference is not a reason. If a seat can only cite deference, it should hold its prior position and mark the point unresolved. Record evidence-driven changes in the seat's rebuttal and in the verdict-change highlight.
+
+## Minority report (when the board converges)
+
+If the board reaches a **unanimous** verdict, it must still produce the strongest case *against* that verdict before the handoff is final. Assign one seat (or the neutral synthesizer) to argue the other side in good faith. Put it in the handoff's dissent section, flagged as the minority report. If the steelman survives scrutiny, the verdict wasn't as settled as it looked — add a round or lower the confidence.
+
+## Neutral synthesizer
+
+The chair (the orchestrating agent) should not both debate and write the final verdict. Prefer one of:
+
+1. **Separate synthesizer** — a model/seat that did not debate writes the synthesis from the seats' artifacts.
+2. **Blind merge** — each seat drafts the consensus independently; the chair merges mechanically, preferring points that multiple seats reached.
+
+If the chair must also synthesize, say so in the handoff and lean on the minority report to counter chair bias.

--- a/skills/advisory-board/references/handoff-template.html
+++ b/skills/advisory-board/references/handoff-template.html
@@ -3,44 +3,44 @@
   ============================================================================
   ADVISORY BOARD — HANDOFF TEMPLATE
   ============================================================================
-  This is a SELF-CONTAINED HTML template for rendering a finished multi-model
-  advisory board review into a clean, human-readable handoff page.
+  A SELF-CONTAINED HTML template for rendering a finished multi-model advisory
+  board review into a clean, human-readable handoff page.
 
-  HOW TO USE
-  ----------
-  1. Copy this file to your run's output folder (e.g. final-consensus.html).
-  2. Replace every {{TOKEN}} below with real content from the review run.
-     Tokens are documented inline at each insertion point.
-  3. The page is fully self-contained: inline CSS only, no external fonts,
-     CDNs, or JS frameworks. It MUST keep working when opened by double-click
-     (offline). Do not add <link>/<script src> to remote resources.
-  4. HTML-escape any user/model text you inject (& -> &amp;  < -> &lt;
-     > -> &gt;). Inline code can be wrapped in <code>...</code>.
+  OUTPUT CONTRACT (read first)
+  ----------------------------
+  The file you produce MUST:
+    - contain ZERO "{{...}}" placeholders and ZERO authoring comments (the
+      BEGIN/END and OPTIONAL notes below) — strip every one. The "====="
+      section dividers may stay.
+    - be a faithful VIEW of final-consensus.md — the Markdown handoff is the
+      source of truth; the HTML must not contradict it.
+    - stay fully self-contained: inline CSS only, no external fonts, CDNs, JS,
+      <link>, or <script src>. It MUST render offline on a double-click.
+    - HTML-escape every injected string ( & -> &amp;  < -> &lt;  > -> &gt; );
+      wrap inline code in <code>...</code>.
 
-  REPEATABLE BLOCKS
-  -----------------
-  - SEAT CARD: duplicate the block marked "BEGIN SEAT CARD" once per board
-    seat (e.g. Claude / Codex / Gemini). Inside each seat card, duplicate the
-    "BEGIN ROUND" block once per round (Round 1, Round 2, ...).
-  - BLOCKER ITEM: duplicate one <li> per consensus blocker.
-  - DISSENT / QUESTION / ACTION items: duplicate their <li> as needed.
+  TWO KINDS OF PLACEHOLDER
+  ------------------------
+  1. SINGLE TOKEN  — "{{TOKEN}}" appearing once. Replace it in place with text.
+  2. REPEATABLE BLOCK — markup between "BEGIN X" / "END X" comments. Duplicate
+     the whole block once per item and fill its tokens. If there are zero
+     items, delete the sample block (don't leave an empty shell).
 
-  TOP-LEVEL TOKENS
-  ----------------
+  Repeatable blocks here: SEAT CARD (per seat) > ROUND (per round, nested in a
+  seat) ; BLOCKER (per consensus blocker) ; DISSENT (per dissenting point) ;
+  QUESTION (per open question) ; ACTION (per next action).
+
+  SINGLE TOKENS
+  -------------
   {{TITLE}}          Page + banner title, e.g. "Advisory Board Review".
   {{SUBTITLE}}       One-line description of what was reviewed.
   {{DATE}}           Review date, e.g. "2026-06-24".
   {{BOARD}}          Board roster: models + lenses (HTML allowed).
   {{ROUNDS}}         Number of rounds, e.g. "2".
   {{VERDICT}}        Final verdict text, e.g. "Do not ship yet — unanimous".
-  {{VERDICT_CLASS}}  One of: ship | caution | block
-                     -> colors the banner green / amber / red.
+  {{VERDICT_CLASS}}  One of: ship | caution | block  (colors the banner).
   {{VERDICT_NOTE}}   One-line explanation under the verdict headline.
   {{PLAN}}           The plan that was reviewed (HTML allowed; use <p>).
-  {{CONSENSUS_BLOCKERS}}  <li>...</li> items (numbered checklist).
-  {{DISSENT}}        Preserved-dissent block(s) (HTML allowed).
-  {{OPEN_QUESTIONS}} <li>...</li> items.
-  {{NEXT_ACTIONS}}   <li>...</li> items or a <p>.
   {{METADATA}}       Footer provenance (models, flags, paths, timestamps).
   ============================================================================
 -->
@@ -138,6 +138,13 @@
     background: #efeefb; border-radius: 999px; padding: 3px 11px;
   }
   .seat-model { font-size: 13px; color: var(--ink-faint); }
+  .seat-status {
+    font-size: 11.5px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+    border-radius: 999px; padding: 3px 10px;
+  }
+  .seat-status.ran      { background: #efeee8;           color: var(--ink-faint); }
+  .seat-status.degraded { background: var(--caution-bg); color: var(--caution-ink); }
+  .seat-status.dropped  { background: var(--block-bg);   color: var(--block-ink); }
   .round { margin-top: 16px; padding-top: 16px; border-top: 1px dashed var(--line); }
   .round:first-of-type { margin-top: 12px; }
   .round-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 8px; }
@@ -148,6 +155,11 @@
   .vpill.caution { background: var(--caution-bg); color: var(--caution-ink); }
   .vpill.block   { background: var(--block-bg);   color: var(--block-ink); }
   .vpill.moved::after { content: " ↓"; }
+  .conf {
+    font-size: 11.5px; font-weight: 600; color: var(--ink-faint);
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 999px; padding: 2px 9px;
+  }
 
   .review-body { font-size: 15.5px; color: var(--ink); }
   .review-body strong { font-weight: 600; }
@@ -205,6 +217,8 @@
     background: var(--surface-soft); border: 1px solid var(--line);
     border-radius: 12px; padding: 16px 20px; font-size: 15.5px;
   }
+  .actions ol { margin: 0; padding-left: 20px; }
+  .actions li { margin: 6px 0; }
 
   /* ---- footer ---- */
   footer.meta {
@@ -212,6 +226,7 @@
     font-size: 13px; color: var(--ink-faint); line-height: 1.7;
   }
   footer.meta code { background: #efeee8; }
+  footer.meta .prov { display: block; margin-top: 6px; }
 
   /* ---- responsive ---- */
   @media (max-width: 560px) {
@@ -221,6 +236,14 @@
     .verdict .headline { font-size: 20px; }
     .seat, ol.blockers > li { padding-left: 16px; padding-right: 16px; }
     ol.blockers > li { padding-left: 50px; }
+  }
+
+  /* ---- print / PDF (Print -> Save as PDF) ---- */
+  @media print {
+    body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .wrap { max-width: none; padding: 8px 0 0; }
+    .verdict, .plan, .seat, .round, ol.blockers > li, .dissent, .actions { break-inside: avoid; }
+    a { color: inherit; text-decoration: none; }
   }
 </style>
 </head>
@@ -259,32 +282,38 @@
   <section>
     <h2>Board reviews — round by round</h2>
 
-    <!-- ----- BEGIN SEAT CARD (duplicate per seat) ----- -->
+    <!-- BEGIN SEAT CARD (duplicate per seat) -->
     <article class="seat">
       <div class="seat-head">
         <h3 class="seat-name">{{SEAT_NAME}}</h3>
         <span class="seat-lens">{{SEAT_LENS}}</span>
         <span class="seat-model">{{SEAT_MODEL}}</span>
+        <!-- OPTIONAL seat status: class ran | degraded | dropped. Show only for a degraded or dropped seat; delete for a clean run. -->
+        <span class="seat-status {{SEAT_STATUS_CLASS}}">{{SEAT_STATUS}}</span>
       </div>
 
-      <!-- ..... BEGIN ROUND (duplicate per round) ..... -->
+      <!-- BEGIN ROUND (duplicate per round) -->
       <div class="round">
         <div class="round-head">
           <span class="round-tag">{{ROUND_LABEL}}</span>
           <!-- vpill class: ship | caution | block ; add "moved" to show a ↓ when the verdict shifted -->
           <span class="vpill {{ROUND_VERDICT_CLASS}}">{{ROUND_VERDICT}}</span>
+          <!-- OPTIONAL confidence chip: low | medium | high. Delete if confidence wasn't tracked. -->
+          <span class="conf">confidence: {{ROUND_CONFIDENCE}}</span>
         </div>
         <div class="review-body">
+          <!-- {{ROUND_REVIEW}}: this seat's findings as HTML — <p>, <ul>/<li>,
+               <p class="r-title"> sub-heads, <code> for inline code. -->
           {{ROUND_REVIEW}}
         </div>
       </div>
-      <!-- ..... END ROUND ..... -->
+      <!-- END ROUND -->
 
-      <!-- Optional per-seat highlight (e.g. a verdict change worth calling out) -->
+      <!-- OPTIONAL per-seat highlight (e.g. a verdict change). Delete if unused. -->
       <div class="highlight">{{SEAT_HIGHLIGHT}}</div>
 
     </article>
-    <!-- ----- END SEAT CARD ----- -->
+    <!-- END SEAT CARD -->
 
   </section>
 
@@ -292,21 +321,27 @@
   <section>
     <h2>Consensus blockers — must fix before ship</h2>
     <ol class="blockers">
-      <!-- duplicate one <li> per blocker -->
+      <!-- BEGIN BLOCKER (duplicate per blocker; the number is added automatically) -->
       <li>
         <span class="b-title">{{BLOCKER_TITLE}}</span>
         <div class="b-body">{{BLOCKER_BODY}}</div>
       </li>
-      {{CONSENSUS_BLOCKERS}}
+      <!-- END BLOCKER -->
     </ol>
   </section>
 
-  <!-- ===================== PRESERVED DISSENT ===================== -->
+  <!-- ===================== DISSENT / MINORITY REPORT ===================== -->
+  <!-- Records disagreement that survived the debate. If the board was UNANIMOUS, this
+       holds the minority report — the strongest case against the verdict (see
+       references/epistemics.md); set {{DISSENT_FLAG}} to "Minority report". Delete the
+       section only if there is genuinely neither dissent nor a minority report. -->
   <section>
-    <h2>Preserved dissent</h2>
+    <h2>Dissent &amp; minority report</h2>
     <div class="dissent">
-      <span class="d-flag">Dissent on the record</span>
-      {{DISSENT}}
+      <span class="d-flag">{{DISSENT_FLAG}}</span>
+      <!-- BEGIN DISSENT (duplicate per point; name the seat in .who, or use "Minority report") -->
+      <p><span class="who">{{DISSENT_WHO}}:</span> {{DISSENT_BODY}}</p>
+      <!-- END DISSENT -->
     </div>
   </section>
 
@@ -314,7 +349,9 @@
   <section>
     <h2>Open questions</h2>
     <ul class="plain">
-      {{OPEN_QUESTIONS}}
+      <!-- BEGIN QUESTION (duplicate per open question) -->
+      <li>{{QUESTION}}</li>
+      <!-- END QUESTION -->
     </ul>
   </section>
 
@@ -322,7 +359,11 @@
   <section>
     <h2>Next actions</h2>
     <div class="actions">
-      {{NEXT_ACTIONS}}
+      <ol>
+        <!-- BEGIN ACTION (duplicate per next action) -->
+        <li>{{ACTION}}</li>
+        <!-- END ACTION -->
+      </ol>
     </div>
   </section>
 

--- a/skills/advisory-board/references/intake-interview.md
+++ b/skills/advisory-board/references/intake-interview.md
@@ -1,0 +1,22 @@
+# Intake Interview
+
+Instead of running on static defaults, open a board with a short structured interview so the run fits the user's intent and material. This is optional — if the user says "use defaults," skip it and run.
+
+## Engine
+
+If the `grilling` or `grill-with-docs` skills are available, use one as the interview engine — they're built for exactly this kind of focused, adversarial Q&A. Otherwise run the question flow below directly. Ask only what you can't already infer from the request or the material; don't interrogate.
+
+## What to settle
+
+1. **Source** — what's under review (files, repo @ commit, URL, or a goal)? Is it complete, or is context missing?
+2. **Stakes** — quick gut-check or high-stakes decision? Drives rounds and seat count.
+3. **Sensitivity** — can this material go to external providers? (→ `references/data-handling.md`; may force local-only.)
+4. **Subject & lens preset** — which preset fits (`references/lens-presets.md`), or custom lenses?
+5. **Board** — default three seats, or resize / recompose (`references/board-composition.md`)? What's actually installed?
+6. **Rounds & cross-reading** — `1` / `2` / `3` / `auto`; `none` / `summaries` / `full`.
+7. **Output** — quick verdict, full handoff, implementation sequence; plus any derived format (PR comment, Slack, gate `verdict.json`)?
+8. **Decision owner** — who reads the result, and what would make it actionable for them?
+
+## Close
+
+Play back the resulting run plan in one or two lines — board, rounds, cross-reading, sensitivity handling, output — and confirm before spending tokens. Then run preflight (`references/preflight.md`).

--- a/skills/advisory-board/references/lens-presets.md
+++ b/skills/advisory-board/references/lens-presets.md
@@ -1,0 +1,48 @@
+# Advisory Board Lens Presets
+
+A seat's lens is a **role assignment, not a model**. Any provider can sit in any seat — the lens just steers what that seat watches for, so the board covers more ground than three general reviewers would.
+
+Every seat still answers the full brief. The lens reduces blind spots; it doesn't narrow responsibility.
+
+## How to use
+
+1. Choose the preset closest to the material (default: `software-architecture`), or compose your own three lenses.
+2. Assign each lens to a seat. With the default Claude / Codex / Gemini lineup, map by fit; with a different lineup or a different seat count, assign however the lenses land.
+3. Drop the lens into the Round 1 seat prompt's "Role emphasis" slot (see `prompt-templates.md`).
+
+## Presets
+
+### `software-architecture` (default)
+- **Architecture & systems** — design soundness, invariants, failure modes, adversarial review.
+- **Implementation & testing** — repo-grounded execution, migration, test strategy, edge cases.
+- **Product & operations** — rollout, latency, observability, evaluation, user-workflow risk.
+
+### `product-strategy`
+- **Market & user value** — positioning, demand, differentiation, jobs-to-be-done.
+- **Execution & GTM** — feasibility, resourcing, sequencing, go-to-market mechanics.
+- **Second-order & risk** — competitive response, cannibalization, downside and stakeholder risk.
+
+### `research-paper`
+- **Methodology & validity** — design, statistics, threats to validity, confounds.
+- **Novelty & positioning** — contribution, related work, what is actually new.
+- **Reproducibility & impact** — can it be reproduced, stated limitations, who it helps and how.
+
+### `legal-contract`
+- **Risk allocation** — liability, indemnity, limitation of liability, termination, IP.
+- **Enforceability & compliance** — governing law, regulatory fit, ambiguity, gaps.
+- **Commercial practicality** — operational burden, counterparty reality, negotiation leverage.
+- _Directional review to focus a human lawyer — not legal advice._
+
+### `business-decision`
+- **First principles & economics** — does the core logic and the math hold up.
+- **Execution & feasibility** — can this org actually do it, with what and by when.
+- **Second-order & downside** — stakeholders, incentives, what breaks if it works.
+
+### `writing-editing`
+- **Argument & structure** — thesis, logic, evidence, what is load-bearing.
+- **Clarity & style** — concision, flow, precision, tone for the audience.
+- **Audience & impact** — does it land, what is missing, what a skeptic seizes on.
+
+## Custom lenses
+
+No preset fits? Write three lenses that triangulate the subject: one on first-principles soundness, one on execution and feasibility, one on second-order consequences and stakeholder risk. Keep them distinct enough that two seats won't return the same review.

--- a/skills/advisory-board/references/output-formats.md
+++ b/skills/advisory-board/references/output-formats.md
@@ -1,0 +1,24 @@
+# Output Formats
+
+The Markdown + HTML handoff is the default deliverable. From the same run you can derive lighter formats for where the decision actually gets read — without re-running the board.
+
+## Derived from `verdict.json` (deterministic)
+
+`scripts/format_output.py` turns `verdict.json` (see `references/verdict-schema.md`) into:
+
+| Format  | Command                                          | For |
+| ------- | ------------------------------------------------ | --- |
+| `tldr`  | `format_output.py verdict.json --format tldr`    | One-paragraph answer for chat or a commit message |
+| `pr`    | `format_output.py verdict.json --format pr`      | A Markdown PR review comment |
+| `slack` | `format_output.py verdict.json --format slack`   | A Slack-ready message |
+| `json`  | `format_output.py verdict.json --format json`    | Normalized JSON for other tools |
+
+These are mechanical transforms of structured fields — no model call, so they're fast and reproducible.
+
+## Print / PDF
+
+`final-consensus.html` carries a print stylesheet, so **Print → Save as PDF** produces a clean, shareable handoff with no extra tooling. Use it to attach the review to a ticket or send it to someone who won't open a repo.
+
+## Prose summaries (model-written)
+
+For a tailored write-up beyond the deterministic TL;DR — an exec summary, a note to a specific stakeholder — have the chair write it from `final-consensus.md`. Keep it a *view* of the handoff: it must not introduce conclusions the board didn't reach.

--- a/skills/advisory-board/references/preflight.md
+++ b/skills/advisory-board/references/preflight.md
@@ -17,7 +17,7 @@ For each seat in the lineup (Claude, Codex, Gemini, or whatever you're running):
 4. **Smoke ping** — a trivial read-only prompt returns a non-empty answer.
    - Keep it to one word back. This proves auth + model + transport end to end in one shot.
 
-Verify every flag against `<cli> --help` first — CLI syntax drifts between versions, and the commands here are illustrative, not guaranteed current. Close stdin on Codex (`</dev/null`) so `codex exec` can't hang waiting for EOF.
+Verify every flag against `<cli> --help` first — CLI syntax drifts between versions, and the commands here are illustrative, not guaranteed current. Close stdin on Codex (`</dev/null`) so `codex exec` can't hang waiting for EOF, and pass `--skip-git-repo-check` when running outside a git repo. Some CLIs (e.g. Gemini) print internal errors to stderr yet still return a valid answer — judge a seat by whether usable content came back, not by stderr noise alone.
 
 ## Smoke-ping templates
 
@@ -28,7 +28,7 @@ Read-only, one-token answers. Adapt flags to the installed CLI.
 claude -p "Reply with the single word: ready" --model <model> --permission-mode plan
 
 # Codex
-codex exec --sandbox read-only --config model="<model>" "Reply with the single word: ready" </dev/null
+codex exec --sandbox read-only --skip-git-repo-check --config model="<model>" "Reply with the single word: ready" </dev/null
 
 # Gemini
 gemini -p "Reply with the single word: ready" -m "<model>"

--- a/skills/advisory-board/references/preflight.md
+++ b/skills/advisory-board/references/preflight.md
@@ -1,0 +1,54 @@
+# Advisory Board Preflight
+
+Run this before launching a board. Most board failures are environmental — a CLI not installed, expired auth, a renamed model, a hung process — not reasoning. Catch them here, before spending real tokens.
+
+Goal: a go/no-go table. Proceed only when at least two seats are **GO** (a board needs at least two voices). Label any seat that is degraded or dropped in the final handoff.
+
+## What to check, per seat
+
+For each seat in the lineup (Claude, Codex, Gemini, or whatever you're running):
+
+1. **CLI present** — the binary exists and runs.
+   - `claude --version` · `codex --version` · `gemini --version`
+2. **Auth active, subscription-backed where possible** — not API-key-only, not logged out.
+   - Use the CLI's own status / whoami command. Never print tokens, cookies, or keys.
+3. **Requested model resolves** — the model named in the lineup is actually available.
+   - List models if the CLI supports it, or run the smoke ping below with the real model flag and confirm it isn't rejected as unknown.
+4. **Smoke ping** — a trivial read-only prompt returns a non-empty answer.
+   - Keep it to one word back. This proves auth + model + transport end to end in one shot.
+
+Verify every flag against `<cli> --help` first — CLI syntax drifts between versions, and the commands here are illustrative, not guaranteed current. Close stdin on Codex (`</dev/null`) so `codex exec` can't hang waiting for EOF.
+
+## Smoke-ping templates
+
+Read-only, one-token answers. Adapt flags to the installed CLI.
+
+```
+# Claude
+claude -p "Reply with the single word: ready" --model <model> --permission-mode plan
+
+# Codex
+codex exec --sandbox read-only --config model="<model>" "Reply with the single word: ready" </dev/null
+
+# Gemini
+gemini -p "Reply with the single word: ready" -m "<model>"
+```
+
+## Go/no-go table
+
+Record one row per seat, then decide:
+
+| Seat   | CLI | Auth | Model | Smoke | Verdict |
+| ------ | --- | ---- | ----- | ----- | ------- |
+| Claude |  ✓  |  ✓   |   ✓   |   ✓   | GO      |
+| Codex  |  ✓  |  ✓   |   ✓   |   ✓   | GO      |
+| Gemini |  ✓  |  ✗   |   —   |   —   | NO-GO   |
+
+Decision rule:
+
+- **≥ 2 seats GO** → proceed. If a seat is NO-GO, run the smaller board and label the missing seat (and the round it dropped) in the handoff.
+- **< 2 seats GO** → stop and report which checks failed and how to fix them. Do not run a one-voice "board."
+
+## What to capture
+
+Fold the result into `run-metadata.md`: each seat's CLI version, the model that actually answered (not just the one requested), auth mode (subscription / API key — no secrets), and the go/no-go verdict. This is the provenance the final handoff cites.

--- a/skills/advisory-board/references/prompt-templates.md
+++ b/skills/advisory-board/references/prompt-templates.md
@@ -1,6 +1,6 @@
 # Advisory Board Prompt Templates
 
-Use these templates as starting points. Replace placeholders before invoking each model.
+Use these templates as starting points. Replace placeholders before invoking each model. Pair them with `lens-presets.md` (for each seat's role emphasis) and `epistemics.md` (confidence, independence checks, and the minority report).
 
 ## Round 1 Seat Prompt
 
@@ -16,7 +16,7 @@ Source material:
 Work read-only. Review adversarially but constructively. Your job is to strengthen the plan before execution, not to defend it.
 
 Produce:
-1. Verdict.
+1. Verdict, with a confidence level (low / medium / high) and one line on what would change it.
 2. Strongest objections.
 3. Recommended execution sequence.
 4. Invariants and guardrails.
@@ -40,9 +40,9 @@ Review the other seats' findings. Be willing to change your mind, but do not col
 
 Produce:
 1. What another model caught that you missed.
-2. What changed your mind.
+2. What changed your mind — and for each change, whether it was driven by new evidence or argument, or only by the others agreeing (deference is not a reason; if that's all you have, hold your prior view).
 3. What you still reject and why.
-4. Consensus recommendation.
+4. Consensus recommendation, plus your updated verdict and confidence (low / medium / high).
 5. Remaining dissent or blockers.
 6. Revised execution sequence.
 7. Specific evidence or tests needed before implementation.
@@ -62,9 +62,9 @@ Round 2 board packet:
 Converge on the strongest plan possible. Keep hard dissent if it matters.
 
 Produce:
-1. Final position.
+1. Final position, with confidence (low / medium / high).
 2. Consensus items.
-3. Hard dissent.
+3. Hard dissent — or, if the board is unanimous, the strongest case against the consensus (the minority report).
 4. Smallest viable execution plan.
 5. Non-negotiable guardrails.
 6. What should be deferred.
@@ -73,7 +73,7 @@ Produce:
 ## Final Synthesis Prompt
 
 ```text
-You are the advisory board chair. Synthesize all model outputs into a single handoff.
+You are the advisory board chair. Synthesize all model outputs into a single handoff. Ideally a seat that did not debate writes this synthesis; if you also debated, say so and lean on the minority report to check chair bias (see `epistemics.md`).
 
 Source material:
 {source_material}
@@ -82,14 +82,15 @@ Board outputs:
 {all_round_outputs}
 
 Create a working document with:
-1. Executive verdict.
+1. Executive verdict, with the board's confidence (low / medium / high).
 2. Consensus plan.
-3. Key dissent and why it matters.
+3. Key dissent and why it matters — if the board was unanimous, include the minority report (the strongest case against the verdict).
 4. Implementation sequence.
 5. Risks and mitigations.
 6. Tests, validation, and rollback notes.
 7. Open questions.
-8. Source/model provenance.
+8. Source/model provenance (the model that actually answered per seat, not just the one requested).
+9. A machine-readable `verdict.json` alongside the prose, per `verdict-schema.md`.
 
 Do not hide uncertainty. Separate evidence-backed conclusions from judgment calls.
 ```

--- a/skills/advisory-board/references/run-metadata-template.md
+++ b/skills/advisory-board/references/run-metadata-template.md
@@ -1,0 +1,41 @@
+# Run Metadata Template
+
+Copy into `run-metadata.md` for the run and fill it in. This is the provenance the handoff cites — record what *actually* happened, not what was requested. Never include secrets.
+
+```text
+# Run Metadata — <title>
+
+Date: <YYYY-MM-DD>   ·   Rounds run: <n>   ·   Cross-reading: none | summaries | full
+Output: quick verdict | full handoff | implementation sequence
+Lens preset: <preset, or "custom">
+
+## Seats
+
+| Seat   | Lens          | Model requested | Model that answered | Reasoning/effort | Auth mode    | Status            |
+| ------ | ------------- | --------------- | ------------------- | ---------------- | ------------ | ----------------- |
+| Claude | architecture  | claude-opus-4-8 | <id returned>       | xhigh            | subscription | ran               |
+| Codex  | impl/testing  | gpt-5.5         | <id returned>       | xhigh            | subscription | ran               |
+| Gemini | product/ops   | <model>         | <id returned>       | HIGH             | subscription | dropped @ round 2 |
+
+Status is one of: ran · degraded · dropped @ round N. A board needs >= 2 seats that ran.
+
+## Source
+
+Access method: shared path | single source packet
+Source: <paths / repo @ commit / URL / packet file>
+Sensitivity & handling: public | redacted | local-only   (see references/data-handling.md)
+
+## Run
+
+| Stage   | Started | Finished | Wall-clock | Tokens in/out (if known) |
+| ------- | ------- | -------- | ---------- | ------------------------ |
+| Round 1 |         |          |            |                          |
+| Round 2 |         |          |            |                          |
+| Synth   |         |          |            |                          |
+
+Preflight: <go/no-go per seat>
+Commands: <the exact CLI invocations, flags included; no secrets>
+Notes: <substitutions, e.g. "requested gpt-5.5, ran gpt-5.1 — newer unavailable">
+```
+
+Capture the model that *answered*, not just the one requested: model names drift and CLIs silently fall back. The verdict is only as trustworthy as knowing exactly who voted.

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -35,7 +35,8 @@ Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readab
 
 ### Fields
 
-- `verdict` — `ship` | `caution` | `block`. The board's final position.
+- `verdict` — `ship` | `caution` | `block`. The board's final position, and the canonical gate axis.
+- `decision` (optional) — the native call when the decision isn't software-shipping (e.g. `invest` / `hold` / `wind-down`, or `go` / `no-go`). Map it onto `verdict` (invest→ship, hold→caution, wind-down/no-go→block); tooling reads `verdict`, while humans and `scripts/format_output.py` show `decision`.
 - `confidence` — `low` | `medium` | `high`.
 - `unanimous` — did every seat land on `verdict` in the final round.
 - `board[]` — one entry per seat; `round_verdicts` is per-round, `dropped` flags a seat that didn't finish (see `references/run-metadata-template.md`).

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -1,0 +1,57 @@
+# Verdict Schema — `verdict.json`
+
+Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readable summary so the board's conclusion can drive tooling — most usefully a **CI / launch gate** ("block the merge when the board says block"). It is a *view* of `final-consensus.md`; the two must agree.
+
+## Schema (`advisory-board/verdict@1`)
+
+```json
+{
+  "schema": "advisory-board/verdict@1",
+  "title": "Payments API idempotency keys",
+  "date": "2026-06-24",
+  "verdict": "block",
+  "confidence": "high",
+  "unanimous": true,
+  "rounds": 2,
+  "board": [
+    {
+      "seat": "Claude",
+      "model": "claude-opus-4-8",
+      "lens": "architecture",
+      "round_verdicts": ["block", "block"],
+      "dropped": false
+    }
+  ],
+  "blockers": [
+    { "title": "Atomic dedup", "body": "SET NX claim with an in-progress sentinel ..." }
+  ],
+  "dissent": [
+    { "who": "Codex", "body": "..." }
+  ],
+  "open_questions": ["..."],
+  "next_actions": ["..."]
+}
+```
+
+### Fields
+
+- `verdict` — `ship` | `caution` | `block`. The board's final position.
+- `confidence` — `low` | `medium` | `high`.
+- `unanimous` — did every seat land on `verdict` in the final round.
+- `board[]` — one entry per seat; `round_verdicts` is per-round, `dropped` flags a seat that didn't finish (see `references/run-metadata-template.md`).
+- `blockers[]` / `dissent[]` / `open_questions[]` / `next_actions[]` — the same content the handoff shows.
+
+Required: `schema`, `verdict`, `confidence`, `board`, `rounds`. The rest are recommended.
+
+## Using it as a gate
+
+`scripts/board_verdict.py` validates the file and, with `--gate`, exits non-zero when the verdict meets a threshold:
+
+```
+python3 scripts/board_verdict.py verdict.json --gate                    # fail on block
+python3 scripts/board_verdict.py verdict.json --gate --fail-on caution  # fail on caution or block
+```
+
+Exit codes: `0` pass · `1` gate fail · `2` usage/schema error. Drop it into CI to hold a merge or launch until the board clears it.
+
+See `references/output-formats.md` for turning the same file into a PR comment, Slack message, or TL;DR.

--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -1,0 +1,23 @@
+# Advisory Board Scripts
+
+Optional helpers for a board run. The skill works without them — they make two roadmap features concrete. Python 3 standard library only; no install step.
+
+| Script | Does | Reference |
+| ------ | ---- | --------- |
+| `board_verdict.py` | Validate `verdict.json`; gate CI on the verdict (`--gate`). | `references/verdict-schema.md` |
+| `format_output.py` | Render `verdict.json` as a TL;DR, PR comment, Slack message, or normalized JSON. | `references/output-formats.md` |
+
+## Quick start
+
+```
+# validate and summarize
+python3 scripts/board_verdict.py path/to/verdict.json
+
+# gate a merge: non-zero exit when the board says "block"
+python3 scripts/board_verdict.py path/to/verdict.json --gate
+
+# turn the verdict into a PR comment
+python3 scripts/format_output.py path/to/verdict.json --format pr
+```
+
+Both read the `verdict.json` a run emits next to `final-consensus.md`. See `examples/payments-idempotency-review/verdict.json` for a filled-in sample.

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -56,7 +56,9 @@ def summarize(data: dict) -> str:
     return "\n".join(
         [
             f"title      : {data.get('title', '(untitled)')}",
-            f"verdict    : {data['verdict']}  ({data['confidence']} confidence)",
+            f"verdict    : {data['verdict']}"
+            + (f" ({data['decision']})" if data.get("decision") else "")
+            + f"  ({data['confidence']} confidence)",
             f"unanimous  : {data.get('unanimous', 'n/a')}",
             f"rounds     : {data['rounds']}",
             f"seats      : {seats_line}",

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate an advisory-board verdict.json and optionally gate CI on it.
+
+Examples:
+  board_verdict.py verdict.json                            validate + print a summary
+  board_verdict.py verdict.json --gate                     exit 1 if verdict is "block"
+  board_verdict.py verdict.json --gate --fail-on caution   exit 1 if "caution" or "block"
+  board_verdict.py verdict.json --json                     echo normalized JSON
+
+Exit codes: 0 ok / gate pass, 1 gate fail, 2 usage or schema error.
+Standard library only; no third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+SEVERITY = {"ship": 0, "caution": 1, "block": 2}
+REQUIRED = ("schema", "verdict", "confidence", "board", "rounds")
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        die(f"{path}: not found")
+    except json.JSONDecodeError as exc:
+        die(f"{path}: invalid JSON ({exc})")
+    if not isinstance(data, dict):
+        die(f"{path}: top level must be a JSON object")
+    missing = [key for key in REQUIRED if key not in data]
+    if missing:
+        die(f"{path}: missing required field(s): {', '.join(missing)}")
+    if data["verdict"] not in SEVERITY:
+        die(f"verdict must be one of {', '.join(SEVERITY)}; got {data['verdict']!r}")
+    if not isinstance(data["board"], list) or not data["board"]:
+        die("board must be a non-empty list of seats")
+    return data
+
+
+def summarize(data: dict) -> str:
+    board = data["board"]
+    ran = [s for s in board if not s.get("dropped")]
+    dropped = [s for s in board if s.get("dropped")]
+    seats_line = f"{len(ran)} ran"
+    if dropped:
+        names = ", ".join(s.get("seat", "?") for s in dropped)
+        seats_line += f", {len(dropped)} dropped ({names})"
+    return "\n".join(
+        [
+            f"title      : {data.get('title', '(untitled)')}",
+            f"verdict    : {data['verdict']}  ({data['confidence']} confidence)",
+            f"unanimous  : {data.get('unanimous', 'n/a')}",
+            f"rounds     : {data['rounds']}",
+            f"seats      : {seats_line}",
+            f"blockers   : {len(data.get('blockers', []))}",
+        ]
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Validate / gate an advisory-board verdict.json.")
+    parser.add_argument("path", nargs="?", default="verdict.json", help="path to verdict.json (default: verdict.json)")
+    parser.add_argument("--gate", action="store_true", help="exit 1 when the verdict meets the fail threshold")
+    parser.add_argument(
+        "--fail-on", choices=("caution", "block"), default="block", help="threshold for --gate (default: block)"
+    )
+    parser.add_argument("--json", dest="as_json", action="store_true", help="echo normalized JSON and exit")
+    args = parser.parse_args(argv)
+
+    data = load(args.path)
+
+    if args.as_json:
+        json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+        return 0
+
+    print(summarize(data))
+
+    if args.gate:
+        if SEVERITY[data["verdict"]] >= SEVERITY[args.fail_on]:
+            print(
+                f"gate: FAIL - verdict '{data['verdict']}' meets threshold '{args.fail_on}'",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"gate: pass - verdict '{data['verdict']}' is below threshold '{args.fail_on}'")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -36,8 +36,8 @@ def load(path: str) -> dict:
 
 def verdict_line(data: dict) -> str:
     stance = "unanimous" if data.get("unanimous") else "split board"
-    label = LABEL.get(data.get("verdict"), str(data.get("verdict")))
-    return f"{label} ({data.get('confidence', '?')} confidence, {stance})"
+    label = data.get("decision") or LABEL.get(data.get("verdict"), str(data.get("verdict")))
+    return f"{label.upper()} ({data.get('confidence', '?')} confidence, {stance})"
 
 
 def as_tldr(data: dict) -> str:

--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Render an advisory-board verdict.json into a shareable format.
+
+Usage:
+  format_output.py verdict.json --format tldr|pr|slack|json
+
+Reads the verdict.json described in references/verdict-schema.md and writes the
+chosen format to stdout. Deterministic - no model call. Standard library only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+LABEL = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP"}
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        die(f"{path}: not found")
+    except json.JSONDecodeError as exc:
+        die(f"{path}: invalid JSON ({exc})")
+    if "verdict" not in data:
+        die(f"{path}: missing required field 'verdict'")
+    return data
+
+
+def verdict_line(data: dict) -> str:
+    stance = "unanimous" if data.get("unanimous") else "split board"
+    label = LABEL.get(data.get("verdict"), str(data.get("verdict")))
+    return f"{label} ({data.get('confidence', '?')} confidence, {stance})"
+
+
+def as_tldr(data: dict) -> str:
+    blockers = data.get("blockers", [])
+    tops = "; ".join(b.get("title", "blocker") for b in blockers[:3]) if blockers else ""
+    title = data.get("title", "Review")
+    tail = f" Top blockers: {tops}." if blockers else ""
+    return f"{title}: {verdict_line(data)}.{tail}"
+
+
+def as_pr(data: dict) -> str:
+    out = [f"## Advisory board: {verdict_line(data)}", ""]
+    if data.get("title"):
+        out += [f"_{data['title']}_", ""]
+    blockers = data.get("blockers", [])
+    if blockers:
+        out.append("### Blockers")
+        for b in blockers:
+            body = f" - {b['body']}" if b.get("body") else ""
+            out.append(f"- [ ] **{b.get('title', 'blocker')}**{body}")
+        out.append("")
+    dissent = data.get("dissent", [])
+    if dissent:
+        out.append("### Dissent")
+        for d in dissent:
+            out.append(f"- _{d.get('who', '-')}:_ {d.get('body', '')}")
+        out.append("")
+    actions = data.get("next_actions", [])
+    if actions:
+        out.append("### Next actions")
+        out += [f"1. {a}" for a in actions]
+        out.append("")
+    seats = ", ".join(f"{s.get('seat', '?')} ({s.get('model', '?')})" for s in data.get("board", []))
+    rounds = data.get("rounds", "?")
+    plural = "" if rounds == 1 else "s"
+    out.append(f"<sub>Board: {seats} - {rounds} round{plural}.</sub>")
+    return "\n".join(out)
+
+
+def as_slack(data: dict) -> str:
+    out = [f"*Advisory board: {verdict_line(data)}*"]
+    if data.get("title"):
+        out.append(f"_{data['title']}_")
+    blockers = data.get("blockers", [])
+    if blockers:
+        out.append("*Blockers:*")
+        out += [f"• {b.get('title', 'blocker')}" for b in blockers]
+    actions = data.get("next_actions", [])
+    if actions:
+        out.append("*Next:* " + "; ".join(actions))
+    return "\n".join(out)
+
+
+RENDERERS = {"tldr": as_tldr, "pr": as_pr, "slack": as_slack}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Render verdict.json into a shareable format.")
+    parser.add_argument("path", nargs="?", default="verdict.json")
+    parser.add_argument("--format", choices=("tldr", "pr", "slack", "json"), default="tldr")
+    args = parser.parse_args(argv)
+
+    data = load(args.path)
+    if args.format == "json":
+        json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+        return 0
+    print(RENDERERS[args.format](data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Hardens and expands the multi-model `advisory-board` skill — a 16-item improvement roadmap, now complete (v1). The skill still works as portable instructions; the new executable helpers in `scripts/` are optional and dependency-free (Python 3 stdlib).

## What's new

**Template & output contract**
- Single-placeholder convention (single tokens vs. duplicate-me blocks) plus a self-contained, zero-token output contract.
- Seat-status pill (ran / degraded / dropped), per-round confidence chip, minority-report framing, and a print/PDF stylesheet.

**New references**
- `preflight`, `lens-presets`, `board-composition`, `data-handling`, `epistemics`, `run-metadata-template`, `verdict-schema`, `output-formats`, `intake-interview`.

**Scripts (Python 3 stdlib)**
- `board_verdict.py` — validate `verdict.json`; gate CI on the verdict (`--gate`, `--fail-on`).
- `format_output.py` — render `verdict.json` as a TL;DR, PR comment, Slack message, or JSON.

**SKILL.md**
- Optional intake interview; `rounds: auto` + adaptive rounds; board composition (2–5 seats, local/human seats, minimal lineups); data-handling / egress gating; confidence, independence, minority report, and a neutral synthesizer in the protocol; `verdict.json` + `run-metadata.md` as standard artifacts; a sensitivity stop condition.

**Docs & examples**
- README "See it in action" + live-view link; docs + index updates; CONTRIBUTING `scripts/` convention; a sample `verdict.json`; and `ROADMAP.html`, a self-contained tracker.

## Verified

- Scripts exercised against the sample fixture (gate exit codes 0/1/2; all four formats).
- **Live end-to-end smoke run** with all three CLIs (claude 2.1.177, codex 0.135.0 / gpt-5.5, gemini 0.38.2): preflight 3/3 GO; three independent lensed reviews of a deliberately-flawed sample plan, all `block` / high confidence; synthesized `verdict.json`; `--gate` correctly exited non-zero; PR / Slack / TL;DR rendered.

## Notes

- `ROADMAP.html` lives at repo root as a working tracker — happy to drop or relocate it if you'd rather it not ship.
- The README live-view link resolves once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
