### PR TITLE
Harden advisory-board (eval batch 1): validation, consent, write policy, epistemics

### DIFF
--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -12,7 +12,7 @@ Bring an idea, problem, plan, or architecture to a board of frontier models sitt
 - Use subscription CLIs by default, not provider API keys.
 - Run read-only unless the user explicitly asks for edits.
 - Rounds: 2. Cross-reading: summaries. Final artifact: full handoff (Markdown plus a self-contained HTML view).
-- Save artifacts in a timestamped folder near the reviewed material, or in `/tmp/advisory-board-*` if there is no obvious project folder.
+- Write run artifacts to a timestamped `/tmp/advisory-board-*` folder by default. Writing them into the reviewed project is itself a write, even on a read-only review: do that only when the user asks or agrees, prefer a dedicated `advisory-board/<timestamp>/` (or `docs/advisory-board/<timestamp>/`) folder, and never write into a tracked git tree without naming the location first.
 - Quick pass: 1 round with `summaries`. High-stakes: 3 rounds with `full` cross-reading. Three frontier models at high reasoning across several rounds can take minutes and meaningful tokens — flag a large run to the user before launching it.
 
 ## Upfront Choices
@@ -27,7 +27,7 @@ Optionally open with the intake interview (`references/intake-interview.md`) —
 6. Sensitivity: can the material go to external providers? (`references/data-handling.md` — may force a local-only board.)
 7. Board: seats and size, from `references/board-composition.md` (default: three seats — Claude, Codex, Gemini).
 
-If the user says "use defaults", stop asking and run.
+If the user says "use defaults", stop asking the *optional* setup questions and run with the defaults — with one exception. The data-handling check (choice 6) is mandatory: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`). "Use defaults" settles the optional choices; it never waives that consent.
 
 ## Model Lineup
 
@@ -91,7 +91,7 @@ A board sends the same source material to every seat's provider. Before the firs
 
 - After the last round, write the handoff: consensus, dissent (and why it matters), revised plan, risks, invariants, evidence, and next actions.
 - Prefer a neutral synthesizer — a seat that didn't debate, or a blind merge — so the chair doesn't grade its own work (`references/epistemics.md`). If the board is unanimous, include a minority report: the strongest case against the verdict.
-- Label model and round provenance (the model that actually answered, not just the one requested), and keep evidence-backed conclusions separate from judgment calls.
+- Label model and round provenance (the model that actually answered, not just the one requested), and split the findings into three explicit buckets: **evidence-backed** (tied to a file, fact, run, or citation), **judgment calls** (reasoned but unproven here), and **couldn't-verify** (claims the board leaned on but didn't check, plus the shared blind spots no seat could see). For each load-bearing conclusion, note what would change it. The couldn't-verify bucket is the main guard against a confident, unanimous, *wrong* call — three models can converge on the same missing fact (`references/epistemics.md`).
 - Emit `verdict.json` alongside the prose (`references/verdict-schema.md`) so the result can drive a gate or other tooling.
 
 ## Artifact Standard

--- a/skills/advisory-board/references/epistemics.md
+++ b/skills/advisory-board/references/epistemics.md
@@ -19,6 +19,16 @@ Deference is not a reason. If a seat can only cite deference, it should hold its
 
 If the board reaches a **unanimous** verdict, it must still produce the strongest case *against* that verdict before the handoff is final. Assign one seat (or the neutral synthesizer) to argue the other side in good faith. Put it in the handoff's dissent section, flagged as the minority report. If the steelman survives scrutiny, the verdict wasn't as settled as it looked — add a round or lower the confidence.
 
+## Known vs. inferred vs. unverified (shared blind spots)
+
+The minority report attacks the verdict from *inside* the board's knowledge. The larger danger sits outside it: a fact every seat assumed and none checked. Three models sharing one blind spot converge confidently and are still wrong — and the convergence reads as authority. The mitigation is to make the boundary of what was actually checked explicit, so the synthesis separates three things:
+
+- **Evidence-backed** — tied to a specific file, fact, run, or citation a seat produced.
+- **Judgment calls** — reasoned positions the board holds but can't prove in this run.
+- **Couldn't-verify** — claims the board *relied on* but did not check: assumptions taken on faith, anything outside what any seat could see (live data, production config, the real code when only a plan was reviewed), and what would flip the verdict if it turned out false.
+
+A handoff that can't name a single thing it couldn't verify is usually overconfident, not thorough. The HTML handoff carries a dedicated "What the board couldn't verify" section; fill it. Drop it only when the board genuinely verified everything load-bearing — and then say so explicitly rather than deleting it silently.
+
 ## Neutral synthesizer
 
 The chair (the orchestrating agent) should not both debate and write the final verdict. Prefer one of:

--- a/skills/advisory-board/references/handoff-template.html
+++ b/skills/advisory-board/references/handoff-template.html
@@ -28,7 +28,8 @@
 
   Repeatable blocks here: SEAT CARD (per seat) > ROUND (per round, nested in a
   seat) ; BLOCKER (per consensus blocker) ; DISSENT (per dissenting point) ;
-  QUESTION (per open question) ; ACTION (per next action).
+  CAVEAT (per couldn't-verify item) ; QUESTION (per open question) ;
+  ACTION (per next action).
 
   SINGLE TOKENS
   -------------
@@ -209,6 +210,17 @@
   .dissent p { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
   .dissent .who { font-weight: 700; color: var(--caution-ink); }
 
+  /* ---- what the board couldn't verify (epistemic caveats) ---- */
+  .caveats {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--ink-faint); border-radius: 0 12px 12px 0;
+    padding: 16px 20px;
+  }
+  .caveats ul { margin: 0; padding-left: 22px; }
+  .caveats li { margin: 7px 0; font-size: 15.5px; }
+  .caveats .c-claim { font-weight: 600; }
+  .caveats .c-change { color: var(--ink-soft); }
+
   /* ---- simple lists ---- */
   ul.plain { margin: 0; padding-left: 22px; }
   ul.plain li { margin: 7px 0; font-size: 15.5px; }
@@ -342,6 +354,24 @@
       <!-- BEGIN DISSENT (duplicate per point; name the seat in .who, or use "Minority report") -->
       <p><span class="who">{{DISSENT_WHO}}:</span> {{DISSENT_BODY}}</p>
       <!-- END DISSENT -->
+    </div>
+  </section>
+
+  <!-- ===================== WHAT THE BOARD COULDN'T VERIFY ===================== -->
+  <!-- Claims the board relied on but did NOT check, and shared blind spots: facts every
+       seat assumed, things outside what any seat could see (live data, prod config, the
+       real code when only a plan was reviewed), and what would flip the verdict if false.
+       Guards against a confident, unanimous, wrong call (see references/epistemics.md).
+       Delete this section only if the board verified everything load-bearing — rare; say
+       so in the verdict note instead of dropping it silently. -->
+  <section>
+    <h2>What the board couldn't verify</h2>
+    <div class="caveats">
+      <ul>
+        <!-- BEGIN CAVEAT (duplicate per couldn't-verify item) -->
+        <li><span class="c-claim">{{CAVEAT_CLAIM}}</span> — <span class="c-change">{{CAVEAT_IMPACT}}</span></li>
+        <!-- END CAVEAT -->
+      </ul>
     </div>
   </section>
 

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -44,6 +44,18 @@ Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readab
 
 Required: `schema`, `verdict`, `confidence`, `board`, `rounds`. The rest are recommended.
 
+## What `board_verdict.py` enforces
+
+Validation is strict so a malformed verdict can't quietly pass a gate. Beyond the required fields, `scripts/board_verdict.py` checks:
+
+- `schema` is exactly `advisory-board/verdict@1`.
+- `verdict` ∈ {ship, caution, block}; `confidence` ∈ {low, medium, high}; `rounds` is a positive integer.
+- each `board[]` seat has `seat`, `model`, and a non-empty `round_verdicts` (every entry ∈ {ship, caution, block}); `lens` and `dropped` are type-checked when present.
+- at least **two** seats actually ran — a seat with `dropped: true` doesn't count, because a one-voice board isn't a board.
+- if `unanimous` is present, it matches the seats' final-round verdicts (claiming unanimity the votes don't support is rejected).
+
+A schema violation exits `2`, distinct from a clean file that simply fails the gate (`1`).
+
 ## Using it as a gate
 
 `scripts/board_verdict.py` validates the file and, with `--gate`, exits non-zero when the verdict meets a threshold:

--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -20,4 +20,6 @@ python3 scripts/board_verdict.py path/to/verdict.json --gate
 python3 scripts/format_output.py path/to/verdict.json --format pr
 ```
 
+> Paths above are relative to the **skill directory** — `skills/advisory-board/` in this repo, or the installed skill root (e.g. `~/.codex/skills/advisory-board/`) — the same convention as every `references/…` path in the skill. Run the scripts from there, or prefix them with that directory; `scripts/board_verdict.py` won't resolve from the repo root.
+
 Both read the `verdict.json` a run emits next to `final-consensus.md`. See `examples/payments-idempotency-review/verdict.json` for a filled-in sample.

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -17,7 +17,10 @@ import json
 import sys
 
 SEVERITY = {"ship": 0, "caution": 1, "block": 2}
+CONFIDENCE = {"low", "medium", "high"}
+SCHEMA = "advisory-board/verdict@1"
 REQUIRED = ("schema", "verdict", "confidence", "board", "rounds")
+SEAT_REQUIRED = ("seat", "model", "round_verdicts")
 
 
 def die(message: str) -> None:
@@ -35,14 +38,68 @@ def load(path: str) -> dict:
         die(f"{path}: invalid JSON ({exc})")
     if not isinstance(data, dict):
         die(f"{path}: top level must be a JSON object")
+    validate(data)
+    return data
+
+
+def validate(data: dict) -> None:
+    """Strict schema check: a malformed verdict must not quietly pass a gate."""
     missing = [key for key in REQUIRED if key not in data]
     if missing:
-        die(f"{path}: missing required field(s): {', '.join(missing)}")
+        die(f"missing required field(s): {', '.join(missing)}")
+
+    if data["schema"] != SCHEMA:
+        die(f"schema must be {SCHEMA!r}; got {data['schema']!r}")
     if data["verdict"] not in SEVERITY:
         die(f"verdict must be one of {', '.join(SEVERITY)}; got {data['verdict']!r}")
-    if not isinstance(data["board"], list) or not data["board"]:
+    if data["confidence"] not in CONFIDENCE:
+        die(f"confidence must be one of {', '.join(sorted(CONFIDENCE))}; got {data['confidence']!r}")
+
+    rounds = data["rounds"]
+    if isinstance(rounds, bool) or not isinstance(rounds, int) or rounds < 1:
+        die(f"rounds must be a positive integer; got {rounds!r}")
+
+    board = data["board"]
+    if not isinstance(board, list) or not board:
         die("board must be a non-empty list of seats")
-    return data
+
+    for index, seat in enumerate(board):
+        where = f"board[{index}]"
+        if not isinstance(seat, dict):
+            die(f"{where} must be an object")
+        name = seat.get("seat", where)
+        seat_missing = [key for key in SEAT_REQUIRED if key not in seat]
+        if seat_missing:
+            die(f"{where} ({name}) missing field(s): {', '.join(seat_missing)}")
+        for key in ("seat", "model"):
+            if not isinstance(seat[key], str) or not seat[key].strip():
+                die(f"{where} ({name}): {key} must be a non-empty string")
+        if "lens" in seat and not isinstance(seat["lens"], str):
+            die(f"{where} ({name}): lens must be a string")
+        if "dropped" in seat and not isinstance(seat["dropped"], bool):
+            die(f"{where} ({name}): dropped must be true or false")
+        verdicts = seat["round_verdicts"]
+        if not isinstance(verdicts, list) or not verdicts:
+            die(f"{where} ({name}): round_verdicts must be a non-empty list")
+        bad = [v for v in verdicts if v not in SEVERITY]
+        if bad:
+            die(f"{where} ({name}): round_verdicts has invalid value(s): {', '.join(map(repr, bad))}")
+
+    ran = [seat for seat in board if not seat.get("dropped")]
+    if len(ran) < 2:
+        die(f"a board needs >= 2 seats that ran; found {len(ran)} (dropped seats don't count)")
+
+    if "unanimous" in data:
+        if not isinstance(data["unanimous"], bool):
+            die(f"unanimous must be true or false; got {data['unanimous']!r}")
+        finals = {seat["round_verdicts"][-1] for seat in ran}
+        actually_unanimous = finals == {data["verdict"]}
+        if data["unanimous"] != actually_unanimous:
+            die(
+                f"unanimous={str(data['unanimous']).lower()} contradicts the seats that ran: "
+                f"their final-round verdicts are {sorted(finals)} vs the overall verdict "
+                f"{data['verdict']!r}"
+            )
 
 
 def summarize(data: dict) -> str:


### PR DESCRIPTION
Folds in the first, high-confidence batch from an external evaluation of the `advisory-board` skill (inspected commit `5588a9a`). Each change was verified against the actual code before applying; a few of the evaluator's suggestions were refined or declined where they didn't hold up (see below).

## What's in this batch

**1. Verdict validation (eval Patch 4) — the load-bearing change.**
`scripts/board_verdict.py` only checked required-keys + verdict enum + non-empty board, so a malformed verdict could pass a CI gate. `load()` now delegates to a strict `validate()` that also enforces:
- `schema` is exactly `advisory-board/verdict@1`
- `confidence` ∈ {low, medium, high}; `rounds` is a positive integer
- each seat has `seat` / `model` / non-empty `round_verdicts` (every entry a valid verdict); `lens` / `dropped` type-checked when present
- **≥ 2 seats actually ran** (`dropped` don't count) — the "a board needs two voices" rule the protocol already states but the script didn't enforce
- if `unanimous` is present, it matches the seats' final-round verdicts (a unanimity claim the votes don't support is rejected)

Invalid files exit `2` (schema error), distinct from a clean file that fails the gate (`1`).

**2. Consent guard (eval Patch 1).** `"use defaults"` previously said "stop asking and run," which could be read to skip the mandatory data-handling disclosure. It now settles *optional* choices only and never waives consent for non-public material.

**3. Artifact write policy (eval Patch 2).** Artifacts now default to `/tmp/advisory-board-*`. Writing into the reviewed project is called out as a write (even on a read-only review), gated on user agreement, and never silent into a tracked git tree.

**4. Epistemic split / shared-blind-spot guard (eval Patch 8).** Synthesis now requires a third bucket beyond evidence-vs-judgment: **couldn't-verify** — claims the board leaned on but didn't check, plus blind spots no seat could see. Added guidance in `epistemics.md` and a dedicated "What the board couldn't verify" section in `handoff-template.html` so it can't silently drop out of the rendered view. This targets the deepest risk of a multi-model board: three models converging confidently on the same missing fact.

**5. Script-path note (eval Patch 3, refined).** The evaluator hit `scripts/board_verdict.py` failing from the repo root and proposed rewriting paths to `skills/advisory-board/scripts/...` — but that breaks the *installed* copy at `~/.codex/skills/advisory-board/`. Instead: a one-line note that script paths are skill-relative, the same convention as every `references/…` path. Validator behavior is also now documented in `verdict-schema.md`.

## Verification
- Example `verdict.json` still validates and gates (`block` → exit 1).
- Malformed inputs (bad confidence, one-seat board, false unanimity, non-positive rounds, bad round verdict) now exit 2 with precise messages.
- `format_output.py` unaffected; HTML template still self-contained (inline CSS only, no remote refs) with balanced sections.

## Deliberately not in this batch
- **Execution-harness reference (Patch 5)** and **deterministic HTML renderer (Patch 6)** — real but larger; partially covered already by `preflight.md` / `run-metadata-template.md` and the HTML output contract. Queued as a second pass.
- **Moving model names to a reference file (Patch 7)** — declined. The skill already says "target the strongest model each provider offers" *and* "verify / never substitute silently"; concrete named targets with that caveat prevent agents from "correcting" current model IDs downward. Burying them risks more rot, not less.
- The committed example under `examples/` was **not** retrofitted with the new couldn't-verify section (it predates it); regenerating the example to demonstrate it is a follow-up, kept out to avoid inventing board findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)