### PR TITLE
Toolchain preflight: self-healing CLI currency + model-id self-heal

### DIFF
--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -52,6 +52,7 @@ Model names and flags move fast — verify them against the installed CLIs or of
 
 Preflight — run `references/preflight.md` before launching: for each seat, check the CLI is present, auth is active (subscription-backed where possible), the requested model resolves, and a one-token smoke ping returns. Proceed only with at least two seats GO; label any degraded or dropped seat in the handoff. In summary:
 
+- **Toolchain currency first** — `run_board.py toolchain` checks each CLI against its latest release and (`--update`, consent-gated) upgrades stale ones. A stale CLI is the usual reason a freshly-renamed frontier model id 404s; updating first keeps the board from half-failing. Model ids stay pinned — if one still won't resolve, preflight *proposes* a working fallback rather than swapping silently.
 - Confirm Claude subscription auth is active.
 - Confirm Codex is on ChatGPT/subscription auth, not API-key-only, when possible.
 - Confirm Gemini auth and model/config support.

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -52,7 +52,8 @@ Model names and flags move fast — verify them against the installed CLIs or of
 
 Preflight — run `references/preflight.md` before launching: for each seat, check the CLI is present, auth is active (subscription-backed where possible), the requested model resolves, and a one-token smoke ping returns. Proceed only with at least two seats GO; label any degraded or dropped seat in the handoff. In summary:
 
-- **Toolchain currency first** — `run_board.py toolchain` checks each CLI against its latest release and (`--update`, consent-gated) upgrades stale ones. A stale CLI is the usual reason a freshly-renamed frontier model id 404s; updating first keeps the board from half-failing. Model ids stay pinned — if one still won't resolve, preflight *proposes* a working fallback rather than swapping silently.
+- **Toolchain currency first** — `run_board.py toolchain` checks each CLI against its latest release and (`--update`, consent-gated) upgrades stale ones; `--install` installs absent ones (account/auth still required). A stale CLI is the usual reason a freshly-renamed frontier model id 404s; updating first keeps the board from half-failing. Model ids stay pinned — if one still won't resolve, preflight *proposes* a working fallback rather than swapping silently.
+- **Graceful degradation** — if fewer than two seats are usable (a downloaded skill on a machine with only one provider's CLI/account), preflight doesn't dead-end: it distinguishes *not installed* (prints the install command) from *installed-but-unauthed*, and points to the fallbacks — a same-provider multi-lens board or a local/human seat (`references/board-composition.md`). You never need all three providers to get value.
 - Confirm Claude subscription auth is active.
 - Confirm Codex is on ChatGPT/subscription auth, not API-key-only, when possible.
 - Confirm Gemini auth and model/config support.

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -70,7 +70,7 @@ For non-software subjects (strategy, research, writing, business, policy), assig
 
 Every seat still answers the full brief; the lens reduces blind spots, it doesn't narrow responsibility.
 
-The board defaults to three seats but isn't fixed at three — for sizing (2–5), the same provider in two seats, a human or local-model seat, and minimal "works with what you have" lineups, see `references/board-composition.md`.
+The board defaults to three seats but isn't fixed at three — for sizing (2–5), the same provider in two seats, a human or local-model seat, an **Antigravity** seat (Google's `agy` CLI, the successor to the sunset gemini-cli), and minimal "works with what you have" lineups, see `references/board-composition.md`.
 
 ## Data Handling
 

--- a/skills/advisory-board/references/board-composition.md
+++ b/skills/advisory-board/references/board-composition.md
@@ -14,6 +14,7 @@ The default board is three seats — Claude, Codex, Gemini. That's a default, no
 - **Same provider twice is allowed** — e.g. two Claude seats with different lenses (architecture vs. security). Note it in provenance; two seats on the same model are less independent than two different models.
 - **A human seat** is valid: capture the person's review as that seat's `round-*/` artifact and let the board read it like any other.
 - **A local/offline seat** (e.g. an Ollama model) is valid and is the lever for sensitive material — see `references/data-handling.md`.
+- **An Antigravity seat** (`--board claude,codex,antigravity`) is registered as Google's agent-first successor to gemini-cli, which was sunset for consumer tiers on 2026-06-18. The `antigravity` seat drives the `agy` CLI headless (`agy -p --model "<display name>" --sandbox`). Two cautions, both reflected in the adapter: pin an **exact** model display name from `agy models` (an unknown name is *silently substituted*, never rejected), and treat it as networked like gemini (an agentic harness whose web/grounding isn't removable). Keep gemini available while your gemini auth still works (enterprise / paid API key); prefer antigravity going forward.
 
 ## Works with what you have
 

--- a/skills/advisory-board/references/board-composition.md
+++ b/skills/advisory-board/references/board-composition.md
@@ -13,7 +13,7 @@ The default board is three seats — Claude, Codex, Gemini. That's a default, no
 - **Any provider in any seat.** Lenses come from `references/lens-presets.md`; assign them to whatever models you have.
 - **Same provider twice is allowed** — e.g. two Claude seats with different lenses (architecture vs. security). Note it in provenance; two seats on the same model are less independent than two different models.
 - **A human seat** is valid: capture the person's review as that seat's `round-*/` artifact and let the board read it like any other.
-- **A local/offline seat** (e.g. an Ollama model) is valid and is the lever for sensitive material — see `references/data-handling.md`.
+- **A local/offline seat** is valid and is the lever for sensitive material — see `references/data-handling.md`. The `ollama` seat is registered and runnable: `--board claude,ollama` (or any lineup), with `--model ollama=<model>` to pick a pulled model (`ollama list`). It drives a local model headless (`ollama run <model>`, prompt on stdin), counts as `provider: local` — so it **never egresses** (excluded from the egress manifest and the disclosure) and needs no account. That on-machine-only property is exactly why a local board is the lever for must-not-leave material.
 - **An Antigravity seat** (`--board claude,codex,antigravity`) is registered as Google's agent-first successor to gemini-cli, which was sunset for consumer tiers on 2026-06-18. The `antigravity` seat drives the `agy` CLI headless (`agy -p --model "<display name>" --sandbox`). Two cautions, both reflected in the adapter: pin an **exact** model display name from `agy models` (an unknown name is *silently substituted*, never rejected), and treat it as networked like gemini (an agentic harness whose web/grounding isn't removable). Keep gemini available while your gemini auth still works (enterprise / paid API key); prefer antigravity going forward.
 
 ## Works with what you have
@@ -22,6 +22,6 @@ Don't require three frontier subscriptions to get value:
 
 - **Two seats** (e.g. Claude + Codex) is a real board. Run it and say it was a two-seat board.
 - **API-key fallback.** If a subscription CLI isn't available, an API-key-backed call to the same provider is fine — record the auth mode in provenance (no secrets).
-- **One paid + one local.** A frontier seat plus a strong local model still gives you cross-model challenge.
+- **One paid + one local.** A frontier seat plus a strong local model still gives you cross-model challenge — e.g. `--board claude,ollama` (only the claude prompt egresses; the local seat stays on-machine).
 
 Record the actual lineup and auth modes in `run-metadata.md`; the handoff should never imply more independence than the run had.

--- a/skills/advisory-board/references/data-handling.md
+++ b/skills/advisory-board/references/data-handling.md
@@ -22,7 +22,7 @@ When redacting the source packet, strip or mask: credentials, tokens, API keys, 
 
 ## Local-only mode
 
-Swap each seat's CLI for a local model runner (e.g. Ollama). The protocol, lenses, rounds, and artifacts are unchanged — only the model endpoints differ. A local board trades some reasoning strength for keeping the material on the machine; say so in the handoff. Record the mode in `run-metadata.md`.
+Swap each seat's CLI for a local model runner. The `ollama` seat is registered for exactly this (`--board ...,ollama`, `--model ollama=<model>`): it carries `provider: local`, so the conductor never egresses its prompt and excludes it from the egress manifest and the disclosure — the material stays on the machine. The protocol, lenses, rounds, and artifacts are unchanged — only the model endpoints differ. A local board trades some reasoning strength for keeping the material on the machine; say so in the handoff. Record the mode in `run-metadata.md`.
 
 ## Always
 

--- a/skills/advisory-board/references/preflight.md
+++ b/skills/advisory-board/references/preflight.md
@@ -11,11 +11,23 @@ A stale seat CLI is the single most common reason a board half-fails: a frontier
 ```
 run_board.py toolchain            # read-only: installed vs latest, per seat
 run_board.py toolchain --update   # update stale CLIs (confirms first; --yes to skip the prompt)
+run_board.py toolchain --install  # install absent CLIs (consent-gated; auth still required)
 ```
 
-- **Check** is read-only — it never mutates anything. It reads the installed version (`<cli> --version`) and the latest published version (npm for claude/codex, Homebrew for gemini), and flags anything behind, plus a *flag-drift* advisory when the installed CLI is newer than the version its argv flags were last grounded against (re-verify `--help`).
+- **Check** is read-only — it never mutates anything. It reads the installed version (`<cli> --version`) and the latest published version (npm for claude/codex, Homebrew for gemini/antigravity), and reports each seat as **current / STALE / missing / unknown**, plus a *flag-drift* advisory when the installed CLI is newer than the version its argv flags were last grounded against (re-verify `--help`).
 - **Update is consent-gated** (`detect → confirm → update`): it lists what's stale and updates only what you approve. `--yes` approves unattended; a non-interactive shell without `--yes` is a no-op, not an error.
+- **Missing CLIs**: an absent binary is reported as `missing` (distinct from `unknown`), and the exact install command is printed. `--install` runs it on consent. **Installing a CLI does not grant an account** — you still need provider auth, so it's only worth installing a CLI you can log into.
 - `run --update-tools` folds Step 0 into a run: check + (gated) update, then preflight, then the board.
+
+## When the board can't form (fewer than 2 usable seats)
+
+A board needs at least two independent voices. Rather than dead-ending, preflight (and `run`) print actionable guidance: which seats are *not installed* (with the install command) vs *installed but unusable* (auth/login or model), and the realistic ways to still run a board:
+
+- **Install + authenticate another provider** (the commands are printed).
+- **A same-provider, multi-lens board** — two seats on the same model with different lenses. Lower independence than two providers, so flag it in provenance. See `references/board-composition.md`.
+- **A human or local-model seat** — no extra account needed. See `references/board-composition.md`.
+
+So a user who only has one provider (say, only Anthropic) is never stuck: they can run a same-provider multi-lens board or add a local/human seat, and the skill says so instead of just refusing.
 
 **Model ids stay pinned, never auto-swapped.** If a pinned model id still doesn't resolve after the CLI is current, preflight probes that seat's known fallbacks and **proposes** a resolvable id (surfaced in the preflight table and `run-metadata.md`) — it does not silently switch models. Apply it yourself with `--model <seat>=<id>` or by updating the registry.
 

--- a/skills/advisory-board/references/preflight.md
+++ b/skills/advisory-board/references/preflight.md
@@ -14,7 +14,7 @@ run_board.py toolchain --update   # update stale CLIs (confirms first; --yes to 
 run_board.py toolchain --install  # install absent CLIs (consent-gated; auth still required)
 ```
 
-- **Check** is read-only — it never mutates anything. It reads the installed version (`<cli> --version`) and the latest published version (npm for claude/codex, Homebrew for gemini/antigravity), and reports each seat as **current / STALE / missing / unknown**, plus a *flag-drift* advisory when the installed CLI is newer than the version its argv flags were last grounded against (re-verify `--help`).
+- **Check** is read-only — it never mutates anything. It reads the installed version (`<cli> --version`) and the latest published version (npm for claude/codex, Homebrew for gemini/antigravity/ollama), and reports each seat as **current / STALE / missing / unknown**, plus a *flag-drift* advisory when the installed CLI is newer than the version its argv flags were last grounded against (re-verify `--help`).
 - **Update is consent-gated** (`detect → confirm → update`): it lists what's stale and updates only what you approve. `--yes` approves unattended; a non-interactive shell without `--yes` is a no-op, not an error.
 - **Missing CLIs**: an absent binary is reported as `missing` (distinct from `unknown`), and the exact install command is printed. `--install` runs it on consent. **Installing a CLI does not grant an account** — you still need provider auth, so it's only worth installing a CLI you can log into.
 - `run --update-tools` folds Step 0 into a run: check + (gated) update, then preflight, then the board.

--- a/skills/advisory-board/references/preflight.md
+++ b/skills/advisory-board/references/preflight.md
@@ -4,6 +4,21 @@ Run this before launching a board. Most board failures are environmental — a C
 
 Goal: a go/no-go table. Proceed only when at least two seats are **GO** (a board needs at least two voices). Label any seat that is degraded or dropped in the final handoff.
 
+## Step 0: toolchain currency (run this first)
+
+A stale seat CLI is the single most common reason a board half-fails: a frontier model gets renamed (e.g. `gemini-3-flash-preview` → `gemini-3.5-flash` on GA) and the pinned id suddenly 404s on a CLI too old to know the new route. So the conductor checks each CLI against its latest release *before* probing models, and offers to update the stale ones.
+
+```
+run_board.py toolchain            # read-only: installed vs latest, per seat
+run_board.py toolchain --update   # update stale CLIs (confirms first; --yes to skip the prompt)
+```
+
+- **Check** is read-only — it never mutates anything. It reads the installed version (`<cli> --version`) and the latest published version (npm for claude/codex, Homebrew for gemini), and flags anything behind, plus a *flag-drift* advisory when the installed CLI is newer than the version its argv flags were last grounded against (re-verify `--help`).
+- **Update is consent-gated** (`detect → confirm → update`): it lists what's stale and updates only what you approve. `--yes` approves unattended; a non-interactive shell without `--yes` is a no-op, not an error.
+- `run --update-tools` folds Step 0 into a run: check + (gated) update, then preflight, then the board.
+
+**Model ids stay pinned, never auto-swapped.** If a pinned model id still doesn't resolve after the CLI is current, preflight probes that seat's known fallbacks and **proposes** a resolvable id (surfaced in the preflight table and `run-metadata.md`) — it does not silently switch models. Apply it yourself with `--model <seat>=<id>` or by updating the registry.
+
 ## What to check, per seat
 
 For each seat in the lineup (Claude, Codex, Gemini, or whatever you're running):

--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -12,11 +12,12 @@
 ## Quick start
 
 ```
-# check each seat CLI vs its latest release (read-only)
+# check each seat CLI vs its latest release (read-only): current / STALE / missing / unknown
 python3 scripts/run_board.py toolchain
 
-# update stale CLIs first (consent-gated; --yes approves unattended), then run as usual
+# update stale CLIs and/or install absent ones (consent-gated; --yes approves unattended)
 python3 scripts/run_board.py toolchain --update
+python3 scripts/run_board.py toolchain --install   # installs absent CLIs (account/auth still required)
 
 # preview a run — config, run-card, preflight plan, egress manifest, artifact tree (no spawn)
 python3 scripts/run_board.py run --source plan.md --dry-run

--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -4,7 +4,7 @@
 
 | Script | Does | Reference |
 | ------ | ---- | --------- |
-| `run_board.py` | The **conductor** (M1+M2): deterministic seat-adapter registry, `--dry-run`, executable preflight (GO/NO-GO), and a hash-bound egress/quarantine gate before any provider call. Calls the scripts below; never reimplements them. | `design/run-board-conductor.md` |
+| `run_board.py` | The **conductor** (M1+M2): deterministic seat-adapter registry, `--dry-run`, toolchain currency (`toolchain` — check/update stale CLIs, propose fallback model ids), executable preflight (GO/NO-GO), and a hash-bound egress/quarantine gate before any provider call. Calls the scripts below; never reimplements them. | `design/run-board-conductor.md` |
 | `board_verdict.py` | Validate `verdict.json`; gate CI on the verdict (`--gate`). | `references/verdict-schema.md` |
 | `format_output.py` | Render `verdict.json` as a TL;DR, PR comment, Slack message, or normalized JSON. | `references/output-formats.md` |
 | `render_handoff.py` | Render `final-consensus.html` from a `handoff-data.json` — deterministic, fails on any leftover placeholder. | `references/handoff-template.html` |
@@ -12,6 +12,12 @@
 ## Quick start
 
 ```
+# check each seat CLI vs its latest release (read-only)
+python3 scripts/run_board.py toolchain
+
+# update stale CLIs first (consent-gated; --yes approves unattended), then run as usual
+python3 scripts/run_board.py toolchain --update
+
 # preview a run — config, run-card, preflight plan, egress manifest, artifact tree (no spawn)
 python3 scripts/run_board.py run --source plan.md --dry-run
 

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -272,13 +272,39 @@ def antigravity_version():
     return ["agy", "--version"]
 
 
+def ollama_argv(model, prompt, *, reasoning="default", workdir=None, network=False):
+    # Ollama runs the model entirely on-machine, so there is NO external egress —
+    # which is exactly why a local seat is the privacy lever for sensitive material
+    # (references/data-handling.md), reflected as provider="local" + isolates_network=True.
+    # `ollama run <model>` reads the prompt on STDIN to EOF, prints the completion,
+    # and exits (the non-interactive form; a piped stdin suppresses the REPL). The
+    # prompt rides stdin (prompt_on_stdin=True), so it never lands in argv and never
+    # needs shell-escaping.
+    #
+    # `network`/`workdir`/`reasoning` are accepted for a uniform adapter signature but
+    # are NOT flags here: a local model has no web/grounding tools to remove (network
+    # isolation is intrinsic), no dir-scoping flag (fs scoping is the subprocess cwd at
+    # spawn), and no reasoning-effort knob.
+    #
+    # NOTE: grounded against Ollama's documented/stable CLI, NOT a live local install
+    # (ollama was absent on the dev box). The `ollama run <model>` stdin form has been
+    # stable across releases; flags_verified_version is left empty (no live grounding to
+    # claim) — re-verify `ollama run --help` before a large run.
+    return ["ollama", "run", model]
+
+
+def ollama_version():
+    return ["ollama", "--version"]
+
+
 # --------------------------------------------------------------------------- #
 # Toolchain currency (design §7a). Each seat CLI is installed by a different
 # package manager, so "what is the latest version" and "update it" live here,
 # per seat, next to that CLI's other quirks. The whole point is self-healing: a
 # stale CLI is the single most common reason a freshly-renamed frontier model id
 # (gemini-3-flash-preview -> gemini-3.5-flash) suddenly 404s. Grounded against
-# the installed managers on 2026-06-25: npm for claude/codex, Homebrew for gemini.
+# the installed managers on 2026-06-25: npm for claude/codex, Homebrew for gemini
+# (formula), antigravity (cask), and ollama (formula).
 # --------------------------------------------------------------------------- #
 
 def claude_latest_argv():  return ["npm", "view", "@anthropic-ai/claude-code", "version"]
@@ -296,6 +322,10 @@ def gemini_install_argv(): return ["brew", "install", "gemini-cli"]
 def antigravity_latest_argv():  return ["brew", "info", "--json=v2", "--cask", "antigravity-cli"]
 def antigravity_update_argv():  return ["brew", "upgrade", "--cask", "antigravity-cli"]
 def antigravity_install_argv(): return ["brew", "install", "--cask", "antigravity-cli"]
+
+def ollama_latest_argv():  return ["brew", "info", "--json=v2", "ollama"]   # ships as a brew formula
+def ollama_update_argv():  return ["brew", "upgrade", "ollama"]
+def ollama_install_argv(): return ["brew", "install", "ollama"]
 
 
 _SEMVER_RE = re.compile(r"\d+(?:\.\d+)+")
@@ -482,6 +512,34 @@ REGISTRY: dict = {
         pkg_label="brew --cask antigravity-cli",
         flags_verified_version="1.0.12",
         fallback_models=(),      # agy never 404s a model (it silently substitutes) — no probe to do
+    ),
+    "ollama": SeatAdapter(
+        name="ollama",
+        # A local model is user-chosen — this is a sensible, broadly-pullable default
+        # to override with `--model ollama=<your pulled model>` (see `ollama list`).
+        # Pinned inline per the model-id policy; no fallback probing, because what
+        # resolves depends entirely on what the user has pulled locally, not on a
+        # renamable hosted id (fallback_models=()).
+        default_model="llama3.3",
+        provider="local",          # NOT external egress — the privacy lever (data-handling.md)
+        default_reasoning="default",   # local models have no reasoning-effort knob
+        build_argv=ollama_argv,
+        version_argv=ollama_version,
+        prompt_on_stdin=True,      # `ollama run <model>` reads the prompt on stdin (like claude)
+        close_stdin=False,
+        stderr_is_fatal=False,     # ollama prints model-load / pull progress to stderr — not fatal
+        supports_isolation=True,   # fs scoping via cwd; a local model has nothing external to scope
+        isolates_network=True,     # local model: no external network at all (intrinsic, not a flag)
+        model_answered=_model_answered_none,
+        latest_argv=ollama_latest_argv,
+        parse_latest=parse_brew_latest,
+        update_argv=ollama_update_argv,
+        install_argv=ollama_install_argv,
+        auth_hint="no account needed — local models stay on your machine; pull one with "
+                  "`ollama pull <model>` (see `ollama list`)",
+        pkg_label="brew ollama",
+        flags_verified_version="",  # ollama absent on the dev box — no live grounding to claim
+        fallback_models=(),
     ),
 }
 
@@ -1498,7 +1556,10 @@ def render_board_guidance(preflight: list, config: RunConfig) -> str:
         lines.append(f"  • Same-provider, multi-lens board with what works ({', '.join(p.seat for p in go)}): "
                      "two seats on the same model with different lenses. Less independent — flag it in "
                      "provenance. See references/board-composition.md.")
-    lines.append("  • Add a human or local-model seat (no extra account needed). "
+    lines.append("  • Add a local-model seat — runnable now, no account or egress: "
+                 "`brew install ollama`, pull a model (`ollama pull <model>`), then add it "
+                 "with `--board " + (",".join(p.seat for p in go) + "," if go else "") +
+                 "ollama --model ollama=<model>`. Or capture a human review as a seat. "
                  "See references/board-composition.md.")
     return "\n".join(lines)
 
@@ -1519,10 +1580,20 @@ class EgressApproval:
 
 def render_egress_manifest(config: RunConfig, blobs: list, content_hash: str) -> str:
     consent = consent_mode_for(config.sensitivity)
+    # Only external blobs actually leave the machine; a local seat (provider="local",
+    # e.g. ollama) is materialized on disk but never egresses, so it must NOT appear
+    # under "Files leaving this machine". Split them up front so even the intro line
+    # never overstates what egresses (a fully-local board sends nothing).
+    external = sorted((b for b in blobs if b.provider != "local"), key=lambda x: x.relpath)
+    local = sorted((b for b in blobs if b.provider == "local"), key=lambda x: x.relpath)
+    intro = ("This run will send the bytes below to external providers. Review before approving."
+             if external else
+             "This run sends NOTHING to external providers (local-only board); the prompts below "
+             "stay on this machine.")
     lines = [
         f"# Egress Manifest — {config.title}",
         "",
-        "This run will send the bytes below to external providers. Review before approving.",
+        intro,
         "",
         f"Packet content hash (sha256): {content_hash}",
         f"Sensitivity: {config.sensitivity}",
@@ -1539,11 +1610,21 @@ def render_egress_manifest(config: RunConfig, blobs: list, content_hash: str) ->
         "| File                          | Bytes | Lines | Goes to |",
         "| ----------------------------- | ----- | ----- | ------- |",
     ]
-    for b in sorted(blobs, key=lambda x: x.relpath):
-        lines.append(f"| {b.relpath:<29} | {b.nbytes:>5} | {b.nlines:>5} | {b.provider} ({b.seat}) |")
+    if external:
+        for b in external:
+            lines.append(f"| {b.relpath:<29} | {b.nbytes:>5} | {b.nlines:>5} | {b.provider} ({b.seat}) |")
+    else:
+        lines.append("| (none — local-only board)     |       |       |         |")
+    if local:
+        lines += ["", "## Stays on this machine (local seats — no egress)", ""]
+        for b in local:
+            lines.append(f"- {b.relpath} — {b.seat} (local model, on-machine; never sent)")
     lines += ["", "## Providers", ""]
-    for b in sorted(blobs, key=lambda x: x.relpath):
-        lines.append(f"- {b.provider} ({b.seat}) — receives {b.relpath}")
+    if external:
+        for b in external:
+            lines.append(f"- {b.provider} ({b.seat}) — receives {b.relpath}")
+    else:
+        lines.append("- (none — no external providers receive any bytes)")
     lines += ["", "Approval: <PENDING — bound to the content hash above>"]
     return "\n".join(lines) + "\n"
 

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -71,6 +71,7 @@ PROVIDERS = {
     "claude": "Anthropic",
     "codex": "OpenAI",
     "gemini": "Google",
+    "antigravity": "Google",
     "ollama": "local",
 }
 
@@ -244,6 +245,28 @@ def gemini_version():
     return ["gemini", "--version"]
 
 
+def antigravity_argv(model, prompt, *, reasoning="High", workdir=None, network=False):
+    # Antigravity CLI (`agy`) is Google's agent-first successor to gemini-cli
+    # (gemini-cli sunset for consumer tiers 2026-06-18). `-p` runs a single prompt
+    # non-interactively and prints the response. --sandbox enables terminal
+    # restrictions for a read-only-ish posture; fs scoping is the subprocess cwd.
+    #
+    # Two verified gotchas (grounded on agy 1.0.12, 2026-06-25):
+    #  * stdin is read to EOF — without close_stdin/DEVNULL the call HANGS (codex-style).
+    #  * an unknown --model is SILENTLY substituted (no error, no 404), so pin an exact
+    #    display name from `agy models` ("Gemini 3.5 Flash (High)") and never trust that
+    #    the requested model answered without a model_answered check (fallback probing is
+    #    pointless here — it never fails loudly).
+    # Effort is baked into the model display name ("... (High)"), so `reasoning` is not
+    # a separate flag. Like gemini, this is an agentic harness whose web/grounding is
+    # not removable, mirrored honestly as isolates_network=False.
+    return ["agy", "-p", prompt, "--model", model, "--sandbox"]
+
+
+def antigravity_version():
+    return ["agy", "--version"]
+
+
 # --------------------------------------------------------------------------- #
 # Toolchain currency (design §7a). Each seat CLI is installed by a different
 # package manager, so "what is the latest version" and "update it" live here,
@@ -261,6 +284,9 @@ def codex_update_argv():   return ["codex", "update"]
 
 def gemini_latest_argv():  return ["brew", "info", "--json=v2", "gemini-cli"]
 def gemini_update_argv():  return ["brew", "upgrade", "gemini-cli"]
+
+def antigravity_latest_argv():  return ["brew", "info", "--json=v2", "--cask", "antigravity-cli"]
+def antigravity_update_argv():  return ["brew", "upgrade", "--cask", "antigravity-cli"]
 
 
 _SEMVER_RE = re.compile(r"\d+(?:\.\d+)+")
@@ -289,6 +315,16 @@ def parse_brew_latest(stdout: str) -> Optional[str]:
     try:
         data = json.loads(stdout)
         return data["formulae"][0]["versions"]["stable"]
+    except (ValueError, KeyError, IndexError, TypeError):
+        return None
+
+
+def parse_brew_cask_latest(stdout: str) -> Optional[str]:
+    # `brew info --json=v2 --cask <cask>` -> casks[0].version (e.g. "1.0.12,6156..."),
+    # so reduce to the dotted-numeric head. antigravity-cli ships as a cask.
+    try:
+        data = json.loads(stdout)
+        return parse_semver(data["casks"][0]["version"])
     except (ValueError, KeyError, IndexError, TypeError):
         return None
 
@@ -407,6 +443,28 @@ REGISTRY: dict = {
         # Ordered fallbacks to PROBE + PROPOSE (not auto-apply) if gemini-3.5-flash
         # 404s on a not-yet-updated CLI: the immediate predecessor first, then Pro.
         fallback_models=("gemini-3-flash-preview", "gemini-3.1-pro", "gemini-3-pro-preview"),
+    ),
+    "antigravity": SeatAdapter(
+        name="antigravity",
+        # Exact display name from `agy models` — agy silently substitutes an unknown
+        # name, so this must match a listed model verbatim (verified on agy 1.0.12).
+        default_model="Gemini 3.5 Flash (High)",
+        provider="Google",
+        default_reasoning="High",   # effort is part of the model name, not a flag
+        build_argv=antigravity_argv,
+        version_argv=antigravity_version,
+        prompt_on_stdin=False,
+        close_stdin=True,        # agy reads stdin to EOF — verified to hang without DEVNULL
+        stderr_is_fatal=False,
+        supports_isolation=True,    # cwd scoping + --sandbox terminal restrictions
+        isolates_network=False,  # agent-first harness; web/grounding not removable — surfaced loudly
+        model_answered=_model_answered_none,
+        latest_argv=antigravity_latest_argv,
+        parse_latest=parse_brew_cask_latest,
+        update_argv=antigravity_update_argv,
+        pkg_label="brew --cask antigravity-cli",
+        flags_verified_version="1.0.12",
+        fallback_models=(),      # agy never 404s a model (it silently substitutes) — no probe to do
     ),
 }
 
@@ -1126,11 +1184,11 @@ def check_toolchain(adapters: list) -> list:
 
 
 def render_toolchain_table(statuses: list) -> str:
-    rows = ["| Seat   | Manager                       | Installed | Latest  | Status  |",
-            "| ------ | ----------------------------- | --------- | ------- | ------- |"]
+    rows = ["| Seat        | Manager                       | Installed | Latest  | Status  |",
+            "| ----------- | ----------------------------- | --------- | ------- | ------- |"]
     for s in statuses:
         status = "current" if s.current else ("STALE" if s.current is False else "unknown")
-        rows.append(f"| {s.seat:<6} | {s.pkg_label:<29} | {(s.installed or '—'):<9} "
+        rows.append(f"| {s.seat:<11} | {s.pkg_label:<29} | {(s.installed or '—'):<9} "
                     f"| {(s.latest or '?'):<7} | {status:<7} |")
     stale = [s for s in statuses if s.current is False]
     rows.append("")
@@ -1288,14 +1346,14 @@ def run_preflight(config: RunConfig) -> list:
 
 
 def render_preflight_table(results: list) -> str:
-    rows = ["| Seat   | CLI | Auth                                          | Model | Smoke    | Verdict |",
-            "| ------ | --- | --------------------------------------------- | ----- | -------- | ------- |"]
+    rows = ["| Seat        | CLI | Auth                                          | Model | Smoke    | Verdict |",
+            "| ----------- | --- | --------------------------------------------- | ----- | -------- | ------- |"]
     for r in results:
         cli = "yes" if r.binary_ok else "no"
         model = "yes" if r.model_ok else "no"
         verdict = "GO" if r.go else "NO-GO"
         rows.append(
-            f"| {r.seat:<6} | {cli:<3} | {r.auth:<45} | {model:<5} "
+            f"| {r.seat:<11} | {cli:<3} | {r.auth:<45} | {model:<5} "
             f"| {r.smoke_status:<8} | {verdict:<7} |"
         )
     go_count = sum(1 for r in results if r.go)
@@ -1652,7 +1710,10 @@ def cmd_preflight(args) -> int:
 
 
 def cmd_toolchain(args) -> int:
-    names = parse_board(getattr(args, "board", None)) or list(REGISTRY.keys())
+    # No --board => check EVERY registered seat CLI (incl. ones outside the default
+    # board, like antigravity), since toolchain currency is about all installed CLIs.
+    board_arg = getattr(args, "board", None)
+    names = parse_board(board_arg) if board_arg else list(REGISTRY.keys())
     unknown = [n for n in names if n not in REGISTRY]
     if unknown:
         die(f"unknown seat(s): {', '.join(unknown)}", EXIT_USAGE)

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -24,10 +24,17 @@ happens in this milestone.
 
 Subcommands:
   init        resolve config and emit run-recipe.yaml + the run-card (no spawn)
+  toolchain   check each seat CLI vs its latest release; --update upgrades stale ones
   preflight   probe each seat (version / smoke ping) and print a GO/NO-GO table
   run         resolve -> preflight -> build packet -> egress gate -> (M3 boundary)
   render      delegate to render_handoff.py (final-consensus.html from data)
   validate    delegate to board_verdict.py (validate / gate verdict.json)
+
+Toolchain currency (the `toolchain` subcommand, also `run --update-tools`) keeps a
+stale CLI from 404-ing a freshly-renamed frontier model id: it reads installed-vs-
+latest per seat and updates stale CLIs on consent (detect -> confirm -> update).
+Model ids stay pinned; a still-unresolvable id yields a *proposed* fallback, never
+an automatic swap.
 
 Standard library only. Tested against mock CLIs on PATH (see ../tests/).
 """
@@ -37,6 +44,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -107,6 +115,7 @@ FAILURE_TIMEOUT = "Timeout"
 FAILURE_AUTH = "AuthFailure"
 FAILURE_INVALID = "InvalidOutput"
 FAILURE_NOOUTPUT = "NoOutput"
+FAILURE_MODEL = "ModelNotFound"   # pinned model id did not resolve on the installed CLI
 
 
 def die(message: str, code: int = EXIT_USAGE) -> "NoReturn":  # type: ignore[name-defined]
@@ -157,6 +166,15 @@ class SeatAdapter:
     isolates_network: bool               # can gate mode actually REMOVE this seat's network via a flag?
     model_answered: Callable[[str, str], Optional[str]]  # (stdout, stderr) -> real model id | None
     timeout_s: int = 900                 # hard cap; §13 default is 15 min (overridden per call)
+    # --- toolchain currency + model self-heal (all optional; a seat without a
+    #     package manager simply reports "unknown" and is never auto-updated) ---
+    latest_argv: Optional[Callable[[], list]] = None     # () -> argv that prints the latest version
+    parse_latest: Optional[Callable[[str], Optional[str]]] = None  # stdout -> version str
+    update_argv: Optional[Callable[[], list]] = None     # () -> argv that updates this CLI
+    pkg_label: str = ""                  # human label for the manager, e.g. "brew gemini-cli"
+    flags_verified_version: str = ""     # CLI version build_argv's flags were last grounded against
+    fallback_models: tuple = ()          # ordered ids to PROBE + PROPOSE if default_model 404s
+                                         # (never auto-applied — model ids stay pinned per policy)
 
 
 def _model_answered_none(stdout: str, stderr: str) -> Optional[str]:
@@ -214,11 +232,113 @@ def gemini_argv(model, prompt, *, reasoning="HIGH", workdir=None, network=False)
     # isolates_network=False below). fs scoping is the subprocess cwd at spawn.
     # `network`/`workdir` are accepted for a uniform signature but not enforceable
     # here — do not pretend otherwise in the consent surface.
-    return ["gemini", "-p", prompt, "-m", model, "--approval-mode", "plan"]
+    #
+    # --skip-trust: gemini-cli >= 0.46 added "trusted folders" — headless runs in
+    # an untrusted dir get approval-mode forced to default and exit 55 with NO
+    # output (verified on 0.46.0). We run read-only (plan) in a scoped throwaway
+    # dir, so trusting that session is safe and required for the board to work.
+    return ["gemini", "-p", prompt, "-m", model, "--approval-mode", "plan", "--skip-trust"]
 
 
 def gemini_version():
     return ["gemini", "--version"]
+
+
+# --------------------------------------------------------------------------- #
+# Toolchain currency (design §7a). Each seat CLI is installed by a different
+# package manager, so "what is the latest version" and "update it" live here,
+# per seat, next to that CLI's other quirks. The whole point is self-healing: a
+# stale CLI is the single most common reason a freshly-renamed frontier model id
+# (gemini-3-flash-preview -> gemini-3.5-flash) suddenly 404s. Grounded against
+# the installed managers on 2026-06-25: npm for claude/codex, Homebrew for gemini.
+# --------------------------------------------------------------------------- #
+
+def claude_latest_argv():  return ["npm", "view", "@anthropic-ai/claude-code", "version"]
+def claude_update_argv():  return ["claude", "update"]
+
+def codex_latest_argv():   return ["npm", "view", "@openai/codex", "version"]
+def codex_update_argv():   return ["codex", "update"]
+
+def gemini_latest_argv():  return ["brew", "info", "--json=v2", "gemini-cli"]
+def gemini_update_argv():  return ["brew", "upgrade", "gemini-cli"]
+
+
+_SEMVER_RE = re.compile(r"\d+(?:\.\d+)+")
+
+
+def parse_semver(text: str) -> Optional[str]:
+    """Pull the first dotted-numeric version out of mixed CLI banner text.
+
+    Robust across the formats the seats actually print: "2.1.177 (Claude Code)",
+    "codex-cli 0.135.0", a bare "0.38.2", or "0.46.0" from a manager.
+    """
+    if not text:
+        return None
+    m = _SEMVER_RE.search(text)
+    return m.group(0) if m else None
+
+
+def parse_npm_latest(stdout: str) -> Optional[str]:
+    # `npm view <pkg> version` prints the bare version on its own line.
+    return parse_semver(stdout)
+
+
+def parse_brew_latest(stdout: str) -> Optional[str]:
+    # `brew info --json=v2 <formula>` -> formulae[0].versions.stable. stdlib json,
+    # no jq. Any shape surprise degrades to "unknown" rather than crashing preflight.
+    try:
+        data = json.loads(stdout)
+        return data["formulae"][0]["versions"]["stable"]
+    except (ValueError, KeyError, IndexError, TypeError):
+        return None
+
+
+def version_tuple(version: Optional[str]) -> tuple:
+    if not version:
+        return ()
+    try:
+        return tuple(int(p) for p in version.split("."))
+    except ValueError:
+        return ()
+
+
+def version_is_current(installed: Optional[str], latest: Optional[str]) -> Optional[bool]:
+    """True if installed >= latest, False if behind, None if either is unknown.
+
+    None ("can't judge") is deliberate: a missing package manager or an offline
+    box must NOT read as "stale" and trigger a spurious update prompt.
+    """
+    iv, lv = version_tuple(installed), version_tuple(latest)
+    if not iv or not lv:
+        return None
+    width = max(len(iv), len(lv))
+    iv += (0,) * (width - len(iv))
+    lv += (0,) * (width - len(lv))
+    return iv >= lv
+
+
+# Model-not-found signatures, grounded against live CLI output on 2026-06-25:
+#   claude (stdout): "...may not exist or you may not have access to it."
+#   codex  (stderr): {"type":"invalid_request_error","message":"The '...' model is not supported..."}
+#   gemini (stderr): "ModelNotFoundError: Requested entity was not found."
+# A pinned id that trips one of these on a smoke ping means the id is stale for
+# the installed CLI — the trigger to update the CLI and/or propose a fallback id.
+_MODEL_NOT_FOUND_SIGNALS = (
+    "modelnotfound",
+    "requested entity was not found",
+    "may not exist or you may not have access",
+    "issue with the selected model",
+    "model is not supported",
+    "is not supported when using codex",
+    "model not found",
+    "no such model",
+    "unknown model",
+)
+
+
+def model_not_found(result: "SpawnResult") -> bool:
+    blob = (result.stdout + "\n" + result.stderr).lower()
+    return any(sig in blob for sig in _MODEL_NOT_FOUND_SIGNALS)
 
 
 REGISTRY: dict = {
@@ -235,6 +355,12 @@ REGISTRY: dict = {
         supports_isolation=True,
         isolates_network=True,   # --disallowed-tools WebSearch WebFetch removes web reach
         model_answered=_model_answered_none,
+        latest_argv=claude_latest_argv,
+        parse_latest=parse_npm_latest,
+        update_argv=claude_update_argv,
+        pkg_label="npm @anthropic-ai/claude-code",
+        flags_verified_version="2.1.177",
+        fallback_models=(),   # Anthropic ids are stable; pin the current one, no guesses
     ),
     "codex": SeatAdapter(
         name="codex",
@@ -249,10 +375,20 @@ REGISTRY: dict = {
         supports_isolation=True,
         isolates_network=True,   # --sandbox read-only has no network (verified: DNS fails inside)
         model_answered=_model_answered_none,
+        latest_argv=codex_latest_argv,
+        parse_latest=parse_npm_latest,
+        update_argv=codex_update_argv,
+        pkg_label="npm @openai/codex",
+        flags_verified_version="0.135.0",
+        fallback_models=(),
     ),
     "gemini": SeatAdapter(
         name="gemini",
-        default_model="gemini-3.1-pro",
+        # GA id confirmed against Google's docs (2026-06-24): Gemini 3 Flash Preview
+        # was renamed gemini-3-flash-preview -> gemini-3.5-flash on GA. The GA id
+        # needs gemini-cli >= 0.46 to resolve; older CLIs 404 it, which is exactly
+        # what the toolchain preflight detects and fixes (update CLI, or fall back).
+        default_model="gemini-3.5-flash",
         provider="Google",
         default_reasoning="HIGH",
         build_argv=gemini_argv,
@@ -263,6 +399,14 @@ REGISTRY: dict = {
         supports_isolation=True,    # fs scoping via cwd; network is NOT removable (below)
         isolates_network=False,  # no known flag disables GoogleSearch grounding — surfaced loudly
         model_answered=_model_answered_none,
+        latest_argv=gemini_latest_argv,
+        parse_latest=parse_brew_latest,
+        update_argv=gemini_update_argv,
+        pkg_label="brew gemini-cli",
+        flags_verified_version="0.46.0",   # -m/-p/--approval-mode plan/--skip-trust verified on 0.46.0 (2026-06-25)
+        # Ordered fallbacks to PROBE + PROPOSE (not auto-apply) if gemini-3.5-flash
+        # 404s on a not-yet-updated CLI: the immediate predecessor first, then Pro.
+        fallback_models=("gemini-3-flash-preview", "gemini-3.1-pro", "gemini-3-pro-preview"),
     ),
 }
 
@@ -933,6 +1077,137 @@ def classify(result: SpawnResult, adapter: SeatAdapter) -> tuple:
 
 
 # --------------------------------------------------------------------------- #
+# Toolchain currency (design §7a) — check each CLI vs latest, update on consent.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ToolStatus:
+    seat: str
+    pkg_label: str
+    installed: Optional[str]
+    latest: Optional[str]
+    current: Optional[bool]        # True up-to-date, False stale, None can't judge
+    update_argv: Optional[list]    # set only when stale and an updater is known
+    note: str = ""                 # advisories (manager missing, flag-drift) — never fatal
+
+
+def check_tool(adapter: SeatAdapter) -> ToolStatus:
+    """Read installed vs latest version for one seat. Read-only, never updates."""
+    iv = spawn(adapter, adapter.version_argv(), timeout=15)
+    installed = parse_semver(iv.stdout + "\n" + iv.stderr) if iv.exit_code == 0 else None
+
+    latest, note = None, ""
+    if adapter.latest_argv and adapter.parse_latest:
+        res = spawn(adapter, adapter.latest_argv(), timeout=45)
+        if res.exit_code == 0:
+            latest = adapter.parse_latest(res.stdout)
+        if latest is None:
+            mgr = adapter.latest_argv()[0]
+            note = f"latest unknown ({mgr} unavailable or unparsable)"
+
+    current = version_is_current(installed, latest)
+
+    # Flag-drift advisory: build_argv's flags were grounded against a specific CLI
+    # version. If the installed CLI is newer, the flags may have moved — surface it
+    # (this is the "re-verify after an 8-version jump" reminder, made automatic).
+    if installed and adapter.flags_verified_version:
+        if version_is_current(adapter.flags_verified_version, installed) is False:
+            drift = f"flags grounded at {adapter.flags_verified_version}, now {installed} — re-verify --help"
+            note = f"{note}; {drift}" if note else drift
+
+    upd = adapter.update_argv() if (adapter.update_argv and current is False) else None
+    return ToolStatus(adapter.name, adapter.pkg_label or adapter.provider,
+                      installed, latest, current, upd, note)
+
+
+def check_toolchain(adapters: list) -> list:
+    return [check_tool(a) for a in adapters]
+
+
+def render_toolchain_table(statuses: list) -> str:
+    rows = ["| Seat   | Manager                       | Installed | Latest  | Status  |",
+            "| ------ | ----------------------------- | --------- | ------- | ------- |"]
+    for s in statuses:
+        status = "current" if s.current else ("STALE" if s.current is False else "unknown")
+        rows.append(f"| {s.seat:<6} | {s.pkg_label:<29} | {(s.installed or '—'):<9} "
+                    f"| {(s.latest or '?'):<7} | {status:<7} |")
+    stale = [s for s in statuses if s.current is False]
+    rows.append("")
+    if stale:
+        rows.append(f"{len(stale)} of {len(statuses)} CLIs behind latest: "
+                    + ", ".join(f"{s.seat} ({s.installed}→{s.latest})" for s in stale))
+        rows.append("update with:  run_board.py toolchain --update")
+    else:
+        rows.append(f"all {len(statuses)} CLIs current (or unknown).")
+    for s in statuses:
+        if s.note:
+            rows.append(f"  note ({s.seat}): {s.note}")
+    return "\n".join(rows)
+
+
+def update_tool(status: ToolStatus) -> tuple:
+    """Run one seat's updater, streaming its output. Returns (ok, detail)."""
+    if not status.update_argv:
+        return True, "nothing to update"
+    print(f"  updating {status.seat} ({status.pkg_label}) "
+          f"{status.installed} → {status.latest} ...")
+    try:
+        completed = subprocess.run(status.update_argv)
+    except FileNotFoundError:
+        return False, f"updater not found: {status.update_argv[0]}"
+    ok = completed.returncode == 0
+    return ok, ("updated" if ok else f"update failed (exit {completed.returncode})")
+
+
+def update_stale_tools(statuses: list, *, assume_yes: bool,
+                       interactive: Optional[bool] = None) -> int:
+    """Consent-gated update of every stale seat (design decision: detect+confirm).
+
+    Mirrors the egress gate's consent posture: --yes approves unattended; an
+    interactive TTY is prompted y/N; a non-TTY without --yes is a no-op (it tells
+    you to re-run with --yes) rather than a hard error. Returns the count of
+    updates that FAILED (0 == all good / nothing to do / declined).
+    """
+    stale = [s for s in statuses if s.current is False and s.update_argv]
+    if not stale:
+        return 0
+    if not assume_yes:
+        is_tty = interactive if interactive is not None else sys.stdin.isatty()
+        if not is_tty:
+            print("stale CLIs found; re-run with --yes (or interactively) to update them.")
+            return 0
+        reply = input(f"\nUpdate {len(stale)} stale CLI(s)? [y/N] ").strip().lower()
+        if reply not in ("y", "yes"):
+            print("no update performed.")
+            return 0
+    failed = 0
+    for s in stale:
+        ok, detail = update_tool(s)
+        print(f"  {s.seat}: {detail}")
+        failed += 0 if ok else 1
+    return failed
+
+
+def propose_model(seat: SeatConfig, *, network_on: bool, workdir: Optional[str],
+                  smoke_timeout: int = 45) -> Optional[str]:
+    """When a seat's pinned model 404s, probe its fallbacks and return the first
+    that resolves — a PROPOSAL for the user, never an automatic swap (model ids
+    stay pinned per the advisory-board-model-policy)."""
+    adapter = seat.adapter
+    for candidate in adapter.fallback_models:
+        if candidate == seat.model:
+            continue
+        argv = adapter.build_argv(candidate, SMOKE_PROMPT, reasoning=seat.reasoning,
+                                  workdir=workdir, network=network_on)
+        smoke = spawn(adapter, argv, prompt=SMOKE_PROMPT, timeout=smoke_timeout, cwd=workdir)
+        status, _ = classify(smoke, adapter)
+        if status in ("ran", "degraded") and not model_not_found(smoke):
+            return candidate
+    return None
+
+
+# --------------------------------------------------------------------------- #
 # Preflight (design §7) — executable GO/NO-GO
 # --------------------------------------------------------------------------- #
 
@@ -946,6 +1221,7 @@ class SeatPreflight:
     smoke_status: str    # ran | degraded | dropped
     go: bool
     detail: str
+    model_proposal: Optional[str] = None  # a resolvable fallback id when the pinned one 404s
 
 
 def preflight_seat(seat: SeatConfig, *, network_on: bool, workdir: Optional[str] = None,
@@ -963,6 +1239,20 @@ def preflight_seat(seat: SeatConfig, *, network_on: bool, workdir: Optional[str]
                               workdir=workdir, network=network_on)
     smoke = spawn(adapter, argv, prompt=prompt, timeout=smoke_timeout, cwd=workdir)
     status, failure = classify(smoke, adapter)
+
+    # A model-not-found signal must override classify(): claude prints the "model
+    # may not exist" notice to stdout with exit 1, which would otherwise look like
+    # "degraded-but-ran". This is a stale-CLI / renamed-id symptom, not auth — so
+    # probe the seat's fallbacks for a resolvable id to PROPOSE (never auto-apply).
+    proposal = None
+    if model_not_found(smoke):
+        proposal = propose_model(seat, network_on=network_on, workdir=workdir,
+                                  smoke_timeout=smoke_timeout)
+        detail = f"version ok; model '{seat.model}' did not resolve ({FAILURE_MODEL})"
+        if proposal:
+            detail += f"; fallback that resolves: {proposal}"
+        return SeatPreflight(seat.name, binary_ok, "unknown (model id did not resolve)",
+                             False, "dropped", False, detail, proposal)
 
     # The smoke ping proves model + transport end to end and that *some* auth is
     # live, but we do NOT run a separate session/whoami probe, so we report the
@@ -1012,6 +1302,11 @@ def render_preflight_table(results: list) -> str:
     rows.append("")
     rows.append(f"{go_count} of {len(results)} seats GO "
                 f"({'proceed' if go_count >= 2 else 'STOP — a board needs >= 2 voices'}).")
+    for r in results:
+        if r.model_proposal:
+            rows.append(f"  proposal ({r.seat}): pinned model did not resolve — "
+                        f"`{r.model_proposal}` works; update the CLI or pass "
+                        f"--model {r.seat}={r.model_proposal}")
     return "\n".join(rows)
 
 
@@ -1294,6 +1589,13 @@ def render_run_metadata(config: RunConfig, preflight: list, approval: EgressAppr
             f"- ⚠ Network NOT isolated for: {', '.join(config.unenforced_network_seats)} "
             "(no CLI flag removes their web/grounding tools); treat as networked despite gate mode."
         )
+    for p in preflight:
+        if getattr(p, "model_proposal", None):
+            lines.append(
+                f"- ⚠ {p.seat}: pinned model did not resolve on the installed CLI; "
+                f"resolvable fallback proposed: {p.model_proposal} "
+                f"(update the CLI via `toolchain --update`, or pass --model {p.seat}={p.model_proposal})."
+            )
     return "\n".join(lines) + "\n"
 
 
@@ -1349,6 +1651,30 @@ def cmd_preflight(args) -> int:
     return EXIT_OK if go >= 2 else EXIT_PREFLIGHT_NOGO
 
 
+def cmd_toolchain(args) -> int:
+    names = parse_board(getattr(args, "board", None)) or list(REGISTRY.keys())
+    unknown = [n for n in names if n not in REGISTRY]
+    if unknown:
+        die(f"unknown seat(s): {', '.join(unknown)}", EXIT_USAGE)
+    statuses = check_toolchain([REGISTRY[n] for n in names])
+    print(render_toolchain_table(statuses))
+    if not getattr(args, "update", False):
+        return EXIT_OK
+    failed = update_stale_tools(statuses, assume_yes=getattr(args, "yes", False))
+    return EXIT_OK if failed == 0 else EXIT_USAGE
+
+
+def _maybe_update_tools(config, args) -> None:
+    """run --update-tools: check currency and (consent-gated) update before the board."""
+    if not getattr(args, "update_tools", False):
+        return
+    print("=== toolchain ===")
+    statuses = check_toolchain([seat.adapter for seat in config.board])
+    print(render_toolchain_table(statuses))
+    update_stale_tools(statuses, assume_yes=getattr(args, "yes", False))
+    print()
+
+
 def cmd_run(args) -> int:
     config = resolve_config(args)
     blobs = build_packet(config)
@@ -1373,6 +1699,10 @@ def cmd_run(args) -> int:
         print(f"[dry-run] no preflight, no packet written, no egress, no spawn. "
               f"content hash = sha256:{content_hash}")
         return EXIT_OK
+
+    # 0. Toolchain currency (opt-in): update stale CLIs before probing, so a
+    #    freshly-renamed model id resolves instead of 404-ing the board.
+    _maybe_update_tools(config, args)
 
     # 1. Preflight — GO/NO-GO before anything else.
     print("=== preflight ===")
@@ -1497,7 +1827,19 @@ def build_parser() -> argparse.ArgumentParser:
                        help="auto-approve egress (still bound to and stamped with the content hash)")
     p_run.add_argument("--skip-sensitivity-gate", dest="skip_sensitivity_gate", action="store_true",
                        help="OVERRIDE: bypass hash-bound approval for non-public material (logged loudly)")
+    p_run.add_argument("--update-tools", dest="update_tools", action="store_true",
+                       help="before preflight, check each CLI vs latest and update stale ones "
+                            "(consent-gated; --yes auto-approves)")
     p_run.set_defaults(func=cmd_run)
+
+    p_tool = sub.add_parser("toolchain",
+                            help="check each seat CLI vs its latest release; --update upgrades stale ones")
+    p_tool.add_argument("--board", help="comma-separated seats (default: all registered seats)")
+    p_tool.add_argument("--update", action="store_true",
+                        help="update stale CLIs (consent-gated: confirms first unless --yes)")
+    p_tool.add_argument("--yes", action="store_true",
+                        help="skip the confirmation prompt (for unattended runs)")
+    p_tool.set_defaults(func=cmd_toolchain)
 
     p_render = sub.add_parser("render", help="delegate to render_handoff.py")
     p_render.add_argument("passthrough", nargs=argparse.REMAINDER)

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -32,9 +32,12 @@ Subcommands:
 
 Toolchain currency (the `toolchain` subcommand, also `run --update-tools`) keeps a
 stale CLI from 404-ing a freshly-renamed frontier model id: it reads installed-vs-
-latest per seat and updates stale CLIs on consent (detect -> confirm -> update).
-Model ids stay pinned; a still-unresolvable id yields a *proposed* fallback, never
-an automatic swap.
+latest per seat (reporting current / STALE / missing / unknown), updates stale CLIs
+and installs absent ones on consent (`--update` / `--install`). Model ids stay
+pinned; a still-unresolvable id yields a *proposed* fallback, never an auto swap.
+When fewer than two seats are usable, preflight/run print actionable guidance
+(install vs auth, plus same-provider / local-seat fallbacks) instead of dead-ending,
+so a single-provider user is never stuck. Installing a CLI never implies an account.
 
 Standard library only. Tested against mock CLIs on PATH (see ../tests/).
 """
@@ -172,6 +175,8 @@ class SeatAdapter:
     latest_argv: Optional[Callable[[], list]] = None     # () -> argv that prints the latest version
     parse_latest: Optional[Callable[[str], Optional[str]]] = None  # stdout -> version str
     update_argv: Optional[Callable[[], list]] = None     # () -> argv that updates this CLI
+    install_argv: Optional[Callable[[], list]] = None    # () -> argv that installs this CLI when absent
+    auth_hint: str = ""                  # how to authenticate after install (no secrets)
     pkg_label: str = ""                  # human label for the manager, e.g. "brew gemini-cli"
     flags_verified_version: str = ""     # CLI version build_argv's flags were last grounded against
     fallback_models: tuple = ()          # ordered ids to PROBE + PROPOSE if default_model 404s
@@ -278,15 +283,19 @@ def antigravity_version():
 
 def claude_latest_argv():  return ["npm", "view", "@anthropic-ai/claude-code", "version"]
 def claude_update_argv():  return ["claude", "update"]
+def claude_install_argv(): return ["npm", "install", "-g", "@anthropic-ai/claude-code"]
 
 def codex_latest_argv():   return ["npm", "view", "@openai/codex", "version"]
 def codex_update_argv():   return ["codex", "update"]
+def codex_install_argv():  return ["npm", "install", "-g", "@openai/codex"]
 
 def gemini_latest_argv():  return ["brew", "info", "--json=v2", "gemini-cli"]
 def gemini_update_argv():  return ["brew", "upgrade", "gemini-cli"]
+def gemini_install_argv(): return ["brew", "install", "gemini-cli"]
 
 def antigravity_latest_argv():  return ["brew", "info", "--json=v2", "--cask", "antigravity-cli"]
 def antigravity_update_argv():  return ["brew", "upgrade", "--cask", "antigravity-cli"]
+def antigravity_install_argv(): return ["brew", "install", "--cask", "antigravity-cli"]
 
 
 _SEMVER_RE = re.compile(r"\d+(?:\.\d+)+")
@@ -394,6 +403,8 @@ REGISTRY: dict = {
         latest_argv=claude_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=claude_update_argv,
+        install_argv=claude_install_argv,
+        auth_hint="run `claude` once and sign in (Claude subscription, or set ANTHROPIC_API_KEY)",
         pkg_label="npm @anthropic-ai/claude-code",
         flags_verified_version="2.1.177",
         fallback_models=(),   # Anthropic ids are stable; pin the current one, no guesses
@@ -414,6 +425,8 @@ REGISTRY: dict = {
         latest_argv=codex_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=codex_update_argv,
+        install_argv=codex_install_argv,
+        auth_hint="run `codex` once and sign in with your ChatGPT account (subscription preferred)",
         pkg_label="npm @openai/codex",
         flags_verified_version="0.135.0",
         fallback_models=(),
@@ -438,6 +451,8 @@ REGISTRY: dict = {
         latest_argv=gemini_latest_argv,
         parse_latest=parse_brew_latest,
         update_argv=gemini_update_argv,
+        install_argv=gemini_install_argv,
+        auth_hint="run `gemini` once and authenticate (Google account; consumer tiers sunset 2026-06-18 — enterprise/API only)",
         pkg_label="brew gemini-cli",
         flags_verified_version="0.46.0",   # -m/-p/--approval-mode plan/--skip-trust verified on 0.46.0 (2026-06-25)
         # Ordered fallbacks to PROBE + PROPOSE (not auto-apply) if gemini-3.5-flash
@@ -462,6 +477,8 @@ REGISTRY: dict = {
         latest_argv=antigravity_latest_argv,
         parse_latest=parse_brew_cask_latest,
         update_argv=antigravity_update_argv,
+        install_argv=antigravity_install_argv,
+        auth_hint="run `agy` once and sign in (Google account; the gemini-cli successor)",
         pkg_label="brew --cask antigravity-cli",
         flags_verified_version="1.0.12",
         fallback_models=(),      # agy never 404s a model (it silently substitutes) — no probe to do
@@ -1148,11 +1165,23 @@ class ToolStatus:
     current: Optional[bool]        # True up-to-date, False stale, None can't judge
     update_argv: Optional[list]    # set only when stale and an updater is known
     note: str = ""                 # advisories (manager missing, flag-drift) — never fatal
+    present: bool = True           # is the CLI binary installed at all? (False => "missing")
+    install_argv: Optional[list] = None  # how to install it when absent
+    auth_hint: str = ""            # how to authenticate after install
 
 
 def check_tool(adapter: SeatAdapter) -> ToolStatus:
     """Read installed vs latest version for one seat. Read-only, never updates."""
     iv = spawn(adapter, adapter.version_argv(), timeout=15)
+    # exit 127 == binary not found (spawn maps FileNotFoundError -> 127). Distinguish
+    # "not installed" (offer to install) from "installed but version unreadable".
+    present = iv.exit_code != 127
+    install = adapter.install_argv() if adapter.install_argv else None
+    if not present:
+        # note stays empty — the "missing" status + the install section already say it.
+        return ToolStatus(adapter.name, adapter.pkg_label or adapter.provider,
+                          None, None, None, None, "",
+                          present=False, install_argv=install, auth_hint=adapter.auth_hint)
     installed = parse_semver(iv.stdout + "\n" + iv.stderr) if iv.exit_code == 0 else None
 
     latest, note = None, ""
@@ -1176,28 +1205,46 @@ def check_tool(adapter: SeatAdapter) -> ToolStatus:
 
     upd = adapter.update_argv() if (adapter.update_argv and current is False) else None
     return ToolStatus(adapter.name, adapter.pkg_label or adapter.provider,
-                      installed, latest, current, upd, note)
+                      installed, latest, current, upd, note,
+                      present=True, install_argv=None, auth_hint=adapter.auth_hint)
 
 
 def check_toolchain(adapters: list) -> list:
     return [check_tool(a) for a in adapters]
 
 
+def _tool_status_label(s: ToolStatus) -> str:
+    if not s.present:
+        return "missing"
+    return "current" if s.current else ("STALE" if s.current is False else "unknown")
+
+
 def render_toolchain_table(statuses: list) -> str:
     rows = ["| Seat        | Manager                       | Installed | Latest  | Status  |",
             "| ----------- | ----------------------------- | --------- | ------- | ------- |"]
     for s in statuses:
-        status = "current" if s.current else ("STALE" if s.current is False else "unknown")
         rows.append(f"| {s.seat:<11} | {s.pkg_label:<29} | {(s.installed or '—'):<9} "
-                    f"| {(s.latest or '?'):<7} | {status:<7} |")
-    stale = [s for s in statuses if s.current is False]
+                    f"| {(s.latest or '?'):<7} | {_tool_status_label(s):<7} |")
+    stale = [s for s in statuses if s.current is False and s.present]
+    missing = [s for s in statuses if not s.present]
     rows.append("")
     if stale:
         rows.append(f"{len(stale)} of {len(statuses)} CLIs behind latest: "
                     + ", ".join(f"{s.seat} ({s.installed}→{s.latest})" for s in stale))
         rows.append("update with:  run_board.py toolchain --update")
-    else:
+    elif not missing:
         rows.append(f"all {len(statuses)} CLIs current (or unknown).")
+    # Not-installed seats: print the exact install command (guidance by default).
+    if missing:
+        rows.append("")
+        rows.append(f"{len(missing)} seat CLI(s) not installed:")
+        for s in missing:
+            cmd = " ".join(s.install_argv) if s.install_argv else "(no installer known)"
+            rows.append(f"  {s.seat:<11} install: {cmd}")
+            if s.auth_hint:
+                rows.append(f"  {'':<11} then:    {s.auth_hint}")
+        rows.append("install with:  run_board.py toolchain --install   "
+                    "(note: installing a CLI does NOT grant an account — you still need provider auth)")
     for s in statuses:
         if s.note:
             rows.append(f"  note ({s.seat}): {s.note}")
@@ -1243,6 +1290,46 @@ def update_stale_tools(statuses: list, *, assume_yes: bool,
     for s in stale:
         ok, detail = update_tool(s)
         print(f"  {s.seat}: {detail}")
+        failed += 0 if ok else 1
+    return failed
+
+
+def install_tool(status: ToolStatus) -> tuple:
+    """Install one absent seat CLI, streaming its output. Returns (ok, detail)."""
+    if not status.install_argv:
+        return True, "no installer known"
+    print(f"  installing {status.seat} ({status.pkg_label}): "
+          f"{' '.join(status.install_argv)} ...")
+    try:
+        completed = subprocess.run(status.install_argv)
+    except FileNotFoundError:
+        return False, f"installer not found: {status.install_argv[0]}"
+    ok = completed.returncode == 0
+    return ok, ("installed" if ok else f"install failed (exit {completed.returncode})")
+
+
+def install_missing_tools(statuses: list, *, assume_yes: bool,
+                          interactive: Optional[bool] = None) -> int:
+    """Consent-gated install of absent seat CLIs (same posture as update). Note: a
+    successful install still does not grant a provider account — auth is separate.
+    Returns the count of installs that FAILED (0 == all good / nothing to do / declined)."""
+    missing = [s for s in statuses if not s.present and s.install_argv]
+    if not missing:
+        return 0
+    if not assume_yes:
+        is_tty = interactive if interactive is not None else sys.stdin.isatty()
+        if not is_tty:
+            print("missing CLIs found; re-run with --yes (or interactively) to install them.")
+            return 0
+        reply = input(f"\nInstall {len(missing)} missing CLI(s)? [y/N] ").strip().lower()
+        if reply not in ("y", "yes"):
+            print("no install performed.")
+            return 0
+    failed = 0
+    for s in missing:
+        ok, detail = install_tool(s)
+        print(f"  {s.seat}: {detail}"
+              + ("  (now authenticate — install ≠ account)" if ok else ""))
         failed += 0 if ok else 1
     return failed
 
@@ -1366,6 +1453,54 @@ def render_preflight_table(results: list) -> str:
                         f"`{r.model_proposal}` works; update the CLI or pass "
                         f"--model {r.seat}={r.model_proposal}")
     return "\n".join(rows)
+
+
+def render_board_guidance(preflight: list, config: RunConfig) -> str:
+    """When a board can't form (<2 usable seats), turn the dead-end into a path:
+    separate not-installed seats (offer the install command) from installed-but-
+    unusable ones (auth/model), then surface the documented fallbacks so a single-
+    provider user is never stuck. Returns "" when the board CAN form."""
+    go = [p for p in preflight if p.go]
+    if len(go) >= 2:
+        return ""
+
+    by_name = {s.name: s for s in config.board}
+    missing, unusable = [], []
+    for p in preflight:
+        if p.go:
+            continue
+        (missing if not p.binary_ok else unusable).append(p.seat)
+
+    lines = [f"Only {len(go)} of {len(preflight)} seats are usable — a board needs at "
+             "least 2 independent voices. Here's how to get there:"]
+
+    if missing:
+        lines.append("")
+        lines.append("CLIs not installed (install ≠ account — you still need provider auth):")
+        for name in missing:
+            seat = by_name.get(name)
+            adapter = seat.adapter if seat else None
+            cmd = " ".join(adapter.install_argv()) if (adapter and adapter.install_argv) else "(no installer known)"
+            line = f"  {name}: {cmd}"
+            if adapter and adapter.auth_hint:
+                line += f"  ·  then {adapter.auth_hint}"
+            lines.append(line)
+        lines.append("  (or let the skill do it: run_board.py toolchain --install)")
+
+    if unusable:
+        lines.append("")
+        lines.append("Installed but not usable right now (check auth/login or model availability): "
+                     + ", ".join(unusable))
+
+    lines.append("")
+    lines.append("Other ways to still run a board:")
+    if go:
+        lines.append(f"  • Same-provider, multi-lens board with what works ({', '.join(p.seat for p in go)}): "
+                     "two seats on the same model with different lenses. Less independent — flag it in "
+                     "provenance. See references/board-composition.md.")
+    lines.append("  • Add a human or local-model seat (no extra account needed). "
+                 "See references/board-composition.md.")
+    return "\n".join(lines)
 
 
 # --------------------------------------------------------------------------- #
@@ -1706,7 +1841,12 @@ def cmd_preflight(args) -> int:
     results = run_preflight(config)
     print(render_preflight_table(results))
     go = sum(1 for r in results if r.go)
-    return EXIT_OK if go >= 2 else EXIT_PREFLIGHT_NOGO
+    if go < 2:
+        guidance = render_board_guidance(results, config)
+        if guidance:
+            print("\n" + guidance)
+        return EXIT_PREFLIGHT_NOGO
+    return EXIT_OK
 
 
 def cmd_toolchain(args) -> int:
@@ -1719,10 +1859,15 @@ def cmd_toolchain(args) -> int:
         die(f"unknown seat(s): {', '.join(unknown)}", EXIT_USAGE)
     statuses = check_toolchain([REGISTRY[n] for n in names])
     print(render_toolchain_table(statuses))
-    if not getattr(args, "update", False):
-        return EXIT_OK
-    failed = update_stale_tools(statuses, assume_yes=getattr(args, "yes", False))
-    return EXIT_OK if failed == 0 else EXIT_USAGE
+    rc = EXIT_OK
+    assume_yes = getattr(args, "yes", False)
+    if getattr(args, "install", False):
+        if install_missing_tools(statuses, assume_yes=assume_yes) != 0:
+            rc = EXIT_USAGE
+    if getattr(args, "update", False):
+        if update_stale_tools(statuses, assume_yes=assume_yes) != 0:
+            rc = EXIT_USAGE
+    return rc
 
 
 def _maybe_update_tools(config, args) -> None:
@@ -1771,6 +1916,9 @@ def cmd_run(args) -> int:
     print(render_preflight_table(preflight))
     go = sum(1 for r in preflight if r.go)
     if go < 2:
+        guidance = render_board_guidance(preflight, config)
+        if guidance:
+            print("\n" + guidance)
         die("fewer than two seats are GO — not running a one-voice board", EXIT_PREFLIGHT_NOGO)
 
     # 2. Egress gate — the pre-spawn hard stop. Nothing has left the machine yet;
@@ -1898,6 +2046,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_tool.add_argument("--board", help="comma-separated seats (default: all registered seats)")
     p_tool.add_argument("--update", action="store_true",
                         help="update stale CLIs (consent-gated: confirms first unless --yes)")
+    p_tool.add_argument("--install", action="store_true",
+                        help="install absent CLIs (consent-gated; an account/auth is still required)")
     p_tool.add_argument("--yes", action="store_true",
                         help="skip the confirmation prompt (for unattended runs)")
     p_tool.set_defaults(func=cmd_toolchain)

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -23,8 +23,8 @@ needed beyond a Python 3 interpreter.
 | Path | Purpose |
 | ---- | ------- |
 | `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, `--from-recipe`, delegation, toolchain currency + model self-heal) |
-| `mocks/{claude,codex,gemini}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`) |
-| `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`/`MOCK_BREW_GEMINI`, default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
+| `mocks/{claude,codex,gemini,agy}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version) |
+| `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`/`MOCK_BREW_GEMINI` formula, `MOCK_BREW_CASK` for the antigravity cask; default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
 | `fixtures/sample-plan.md` | a small, stable source for deterministic runs |
 
 ## The safety properties the suite locks

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -22,8 +22,9 @@ needed beyond a Python 3 interpreter.
 
 | Path | Purpose |
 | ---- | ------- |
-| `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, `--from-recipe`, delegation) |
-| `mocks/{claude,codex,gemini}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`) and argv captured to `MOCK_ARGV_LOG` |
+| `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, `--from-recipe`, delegation, toolchain currency + model self-heal) |
+| `mocks/{claude,codex,gemini}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`) |
+| `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`/`MOCK_BREW_GEMINI`, default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
 | `fixtures/sample-plan.md` | a small, stable source for deterministic runs |
 
 ## The safety properties the suite locks
@@ -41,3 +42,8 @@ These are the M2 invariants — if any regresses, a test fails:
   blocks for hash-bound approval, local-only refuses external egress outright.
 - **The run-recipe round-trips** through the restricted YAML codec
   (`TestYamlCodec`).
+- **Toolchain updates are consent-gated and model ids stay pinned**
+  (`TestToolchainUpdate`, `TestModelProposal`) — a missing package manager reads
+  "unknown" not "stale" (never a spurious update), a non-TTY without `--yes` is a
+  no-op, and an unresolvable pinned id yields a *proposed* fallback, not a silent
+  swap.

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -47,3 +47,8 @@ These are the M2 invariants — if any regresses, a test fails:
   "unknown" not "stale" (never a spurious update), a non-TTY without `--yes` is a
   no-op, and an unresolvable pinned id yields a *proposed* fallback, not a silent
   swap.
+- **Graceful degradation for partial setups** (`TestGracefulDegradation`) — an
+  absent CLI reads `missing` (not `unknown`) and prints its install command;
+  `--install` is consent-gated and never implies an account; and when fewer than
+  two seats are usable, preflight/run emit actionable guidance (install vs auth,
+  same-provider / local-seat fallbacks) instead of dead-ending.

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -23,8 +23,8 @@ needed beyond a Python 3 interpreter.
 | Path | Purpose |
 | ---- | ------- |
 | `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, `--from-recipe`, delegation, toolchain currency + model self-heal) |
-| `mocks/{claude,codex,gemini,agy}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version) |
-| `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`/`MOCK_BREW_GEMINI` formula, `MOCK_BREW_CASK` for the antigravity cask; default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
+| `mocks/{claude,codex,gemini,agy,ollama}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version. `ollama` is the local seat — prompt on stdin, no `model_not_found`/`update` arms; `MOCK_OLLAMA_VERSION` sets its reported version, default `0.5.0`) |
+| `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`, `MOCK_BREW_GEMINI`/`MOCK_BREW_OLLAMA` formulae, `MOCK_BREW_CASK` for the antigravity cask; default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
 | `fixtures/sample-plan.md` | a small, stable source for deterministic runs |
 
 ## The safety properties the suite locks

--- a/skills/advisory-board/tests/mocks/agy
+++ b/skills/advisory-board/tests/mocks/agy
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Mock `agy` (Antigravity CLI). Handles `agy --version`, `agy models`, `agy update`,
+# and `agy -p <prompt>` smoke. MOCK_AGY_MODE: go | nogo_version | nogo_smoke |
+# empty | degraded | timeout. MOCK_AGY_VERSION sets the reported version (default
+# 1.0.0). `agy update` fails with MOCK_AGY_UPDATE_FAIL=1. Real agy reads stdin to
+# EOF, so the conductor must close it (close_stdin -> DEVNULL) or the call hangs.
+set -u
+
+if [ -n "${MOCK_ARGV_LOG:-}" ]; then
+  printf 'agy\t%s\n' "$*" >>"$MOCK_ARGV_LOG"
+fi
+
+mode="${MOCK_AGY_MODE:-go}"
+
+if [ "${1:-}" = "--version" ]; then
+  if [ "$mode" = "nogo_version" ]; then exit 1; fi
+  echo "${MOCK_AGY_VERSION:-1.0.0}"
+  exit 0
+fi
+
+if [ "${1:-}" = "models" ]; then
+  printf 'Gemini 3.5 Flash (High)\nGemini 3.1 Pro (High)\nClaude Opus 4.6 (Thinking)\n'
+  exit 0
+fi
+
+if [ "${1:-}" = "update" ]; then
+  if [ "${MOCK_AGY_UPDATE_FAIL:-}" = "1" ]; then echo "update failed" >&2; exit 1; fi
+  echo "agy updated"
+  exit 0
+fi
+
+# Otherwise `agy -p ...`. Real agy reads stdin to EOF; drain it so a regression that
+# leaves stdin open hangs and the conductor's timeout fires (the bug a test should catch).
+cat >/dev/null 2>&1
+
+case "$mode" in
+  nogo_smoke) echo "auth error" >&2; exit 1 ;;
+  empty)      exit 0 ;;
+  timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
+  degraded)   echo "harness note" >&2; echo "ready"; exit 1 ;;
+  *)          echo "ready"; exit 0 ;;
+esac

--- a/skills/advisory-board/tests/mocks/brew
+++ b/skills/advisory-board/tests/mocks/brew
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 # Mock `brew` for toolchain-currency tests. Handles:
 #   brew info --json=v2 gemini-cli            -> formula json with versions.stable
+#   brew info --json=v2 ollama                -> formula json (separate env knob)
 #   brew info --json=v2 --cask antigravity-cli-> cask json with version
 #   brew upgrade [--cask] <name>              -> exit 0 (or 1 if MOCK_BREW_UPGRADE_FAIL=1)
-# Latest is env-controlled: MOCK_BREW_GEMINI (formula) / MOCK_BREW_CASK (cask),
-# both default 9.9.9 => stale.
+# Latest is env-controlled: MOCK_BREW_GEMINI / MOCK_BREW_OLLAMA (formulae),
+# MOCK_BREW_CASK (cask); all default 9.9.9 => stale.
 set -u
 
 case "${1:-}" in
   info)
     is_cask=0
-    for a in "$@"; do [ "$a" = "--cask" ] && is_cask=1; done
+    is_ollama=0
+    for a in "$@"; do
+      [ "$a" = "--cask" ] && is_cask=1
+      [ "$a" = "ollama" ] && is_ollama=1
+    done
     if [ "$is_cask" = "1" ]; then
       printf '{"casks":[{"version":"%s"}]}\n' "${MOCK_BREW_CASK:-9.9.9}"
+    elif [ "$is_ollama" = "1" ]; then
+      printf '{"formulae":[{"versions":{"stable":"%s"}}]}\n' "${MOCK_BREW_OLLAMA:-9.9.9}"
     else
       printf '{"formulae":[{"versions":{"stable":"%s"}}]}\n' "${MOCK_BREW_GEMINI:-9.9.9}"
     fi

--- a/skills/advisory-board/tests/mocks/brew
+++ b/skills/advisory-board/tests/mocks/brew
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Mock `brew` for toolchain-currency tests. Handles:
+#   brew info --json=v2 gemini-cli   -> minimal json=v2 with versions.stable
+#   brew upgrade gemini-cli          -> exit 0 (or 1 if MOCK_BREW_UPGRADE_FAIL=1)
+# MOCK_BREW_GEMINI sets the "latest" stable version (default 9.9.9 => stale).
+set -u
+
+case "${1:-}" in
+  info)
+    printf '{"formulae":[{"versions":{"stable":"%s"}}]}\n' "${MOCK_BREW_GEMINI:-9.9.9}"
+    exit 0 ;;
+  upgrade)
+    if [ "${MOCK_BREW_UPGRADE_FAIL:-}" = "1" ]; then
+      echo "Error: mock brew upgrade failed" >&2
+      exit 1
+    fi
+    echo "==> Upgrading ${2:-formula}"
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac

--- a/skills/advisory-board/tests/mocks/brew
+++ b/skills/advisory-board/tests/mocks/brew
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 # Mock `brew` for toolchain-currency tests. Handles:
-#   brew info --json=v2 gemini-cli   -> minimal json=v2 with versions.stable
-#   brew upgrade gemini-cli          -> exit 0 (or 1 if MOCK_BREW_UPGRADE_FAIL=1)
-# MOCK_BREW_GEMINI sets the "latest" stable version (default 9.9.9 => stale).
+#   brew info --json=v2 gemini-cli            -> formula json with versions.stable
+#   brew info --json=v2 --cask antigravity-cli-> cask json with version
+#   brew upgrade [--cask] <name>              -> exit 0 (or 1 if MOCK_BREW_UPGRADE_FAIL=1)
+# Latest is env-controlled: MOCK_BREW_GEMINI (formula) / MOCK_BREW_CASK (cask),
+# both default 9.9.9 => stale.
 set -u
 
 case "${1:-}" in
   info)
-    printf '{"formulae":[{"versions":{"stable":"%s"}}]}\n' "${MOCK_BREW_GEMINI:-9.9.9}"
+    is_cask=0
+    for a in "$@"; do [ "$a" = "--cask" ] && is_cask=1; done
+    if [ "$is_cask" = "1" ]; then
+      printf '{"casks":[{"version":"%s"}]}\n' "${MOCK_BREW_CASK:-9.9.9}"
+    else
+      printf '{"formulae":[{"versions":{"stable":"%s"}}]}\n' "${MOCK_BREW_GEMINI:-9.9.9}"
+    fi
     exit 0 ;;
   upgrade)
     if [ "${MOCK_BREW_UPGRADE_FAIL:-}" = "1" ]; then
       echo "Error: mock brew upgrade failed" >&2
       exit 1
     fi
-    echo "==> Upgrading ${2:-formula}"
+    echo "==> Upgrading ${@: -1}"
     exit 0 ;;
   *)
     exit 0 ;;

--- a/skills/advisory-board/tests/mocks/claude
+++ b/skills/advisory-board/tests/mocks/claude
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Mock `claude` CLI for testing the conductor without burning tokens or network.
 # Banner-accurate enough for preflight; behavior switched by MOCK_CLAUDE_MODE.
-#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout
+#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout | model_not_found
+# `claude update` is mocked too (MOCK_CLAUDE_UPDATE_FAIL=1 to force a failure).
 # If MOCK_ARGV_LOG is set, the full argv is appended for end-to-end assertions.
 set -u
 
@@ -19,7 +20,16 @@ for a in "$@"; do
   fi
 done
 
+# `claude update` — toolchain self-update path.
+if [ "${1:-}" = "update" ]; then
+  if [ "${MOCK_CLAUDE_UPDATE_FAIL:-}" = "1" ]; then echo "update failed" >&2; exit 1; fi
+  echo "claude updated"
+  exit 0
+fi
+
 case "$mode" in
+  # Unknown model: claude prints this to STDOUT with exit 1 (grounded 2026-06-25).
+  model_not_found) echo "There's an issue with the selected model. It may not exist or you may not have access to it."; exit 1 ;;
   nogo_smoke) exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill

--- a/skills/advisory-board/tests/mocks/codex
+++ b/skills/advisory-board/tests/mocks/codex
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Mock `codex` CLI. Handles `codex --version` and `codex exec ... <prompt>`.
-# MOCK_CODEX_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout
+# Mock `codex` CLI. Handles `codex --version`, `codex update`, `codex exec ... <prompt>`.
+# MOCK_CODEX_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout | model_not_found
+# `codex update` is mocked too (MOCK_CODEX_UPDATE_FAIL=1 to force a failure).
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -12,6 +13,13 @@ mode="${MOCK_CODEX_MODE:-go}"
 if [ "${1:-}" = "--version" ]; then
   if [ "$mode" = "nogo_version" ]; then exit 1; fi
   echo "codex-cli 0.30.0 (mock)"
+  exit 0
+fi
+
+# `codex update` — toolchain self-update path.
+if [ "${1:-}" = "update" ]; then
+  if [ "${MOCK_CODEX_UPDATE_FAIL:-}" = "1" ]; then echo "update failed" >&2; exit 1; fi
+  echo "codex updated"
   exit 0
 fi
 
@@ -27,5 +35,7 @@ case "$mode" in
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
   degraded)   echo "warning: sandbox note" >&2; echo "ready"; exit 1 ;;
+  # Unknown model: codex emits an invalid_request_error to STDERR (grounded 2026-06-25).
+  model_not_found) echo '{"type":"error","error":{"type":"invalid_request_error","message":"The model is not supported when using Codex with a ChatGPT account."}}' >&2; exit 1 ;;
   *)          echo "ready"; exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/gemini
+++ b/skills/advisory-board/tests/mocks/gemini
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Mock `gemini` CLI. Gemini routinely prints router noise to stderr yet returns a
 # valid answer; the `degraded` mode exercises that "degraded-but-ran" path.
-# MOCK_GEMINI_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout
+# MOCK_GEMINI_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout | model_proposal
+#   model_proposal: the pinned id (gemini-3.5-flash) 404s but a fallback resolves,
+#   exercising the model-not-found -> propose-fallback path.
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -10,10 +12,18 @@ fi
 
 mode="${MOCK_GEMINI_MODE:-go}"
 
+# Extract the requested model (-m/--model <id>) so a mode can branch on it.
+model=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-m" ] || [ "$prev" = "--model" ]; then model="$a"; fi
+  prev="$a"
+done
+
 for a in "$@"; do
   if [ "$a" = "--version" ] || [ "$a" = "-v" ]; then
     if [ "$mode" = "nogo_version" ]; then exit 1; fi
-    echo "0.12.0 (mock)"
+    echo "0.46.0 (mock)"
     exit 0
   fi
 done
@@ -23,6 +33,12 @@ case "$mode" in
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
   degraded)   echo "[router] retrying with fallback" >&2; echo "ready"; exit 1 ;;
+  model_proposal)
+    case "$model" in
+      # The pinned GA id 404s on a (simulated) stale CLI; a fallback id resolves.
+      *3.5-flash*) echo "ModelNotFoundError: Requested entity was not found." >&2; exit 1 ;;
+      *)           echo "ready"; exit 0 ;;
+    esac ;;
   # go (default): router noise on stderr but a valid review on stdout, exit 0:
   *)          echo "[router] retrying with fallback" >&2; echo "ready"; exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/npm
+++ b/skills/advisory-board/tests/mocks/npm
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Mock `npm` for toolchain-currency tests. Handles `npm view <pkg> version`.
+# The "latest" returned is env-controlled so a test can force stale vs current:
+#   MOCK_NPM_CLAUDE / MOCK_NPM_CODEX (default 9.9.9 => stale vs the mock CLIs).
+set -u
+
+if [ "${1:-}" = "view" ]; then
+  pkg="${2:-}"
+  case "$pkg" in
+    *claude-code*) echo "${MOCK_NPM_CLAUDE:-9.9.9}" ;;
+    *codex*)       echo "${MOCK_NPM_CODEX:-9.9.9}" ;;
+    *)             echo "0.0.0" ;;
+  esac
+  exit 0
+fi
+exit 0

--- a/skills/advisory-board/tests/mocks/ollama
+++ b/skills/advisory-board/tests/mocks/ollama
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Mock `ollama` CLI — a local-model seat that runs entirely on-machine (no tokens,
+# no network). Like claude, the prompt arrives on STDIN (which this stub ignores).
+# Behavior switched by MOCK_OLLAMA_MODE:
+#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout
+# `ollama` itself has no self-update subcommand (currency is via brew), so there is
+# no `update` arm here. Reported version: MOCK_OLLAMA_VERSION (default 0.5.0).
+# If MOCK_ARGV_LOG is set, the full argv is appended for end-to-end assertions.
+set -u
+
+if [ -n "${MOCK_ARGV_LOG:-}" ]; then
+  printf 'ollama\t%s\n' "$*" >>"$MOCK_ARGV_LOG"
+fi
+
+mode="${MOCK_OLLAMA_MODE:-go}"
+
+for a in "$@"; do
+  if [ "$a" = "--version" ] || [ "$a" = "-v" ]; then
+    if [ "$mode" = "nogo_version" ]; then exit 1; fi
+    echo "ollama version is ${MOCK_OLLAMA_VERSION:-0.5.0}"
+    exit 0
+  fi
+done
+
+# `ollama run <model>` — the smoke ping / round-1 form. Prompt is on stdin (ignored).
+case "$mode" in
+  nogo_smoke) echo "Error: could not connect to ollama server" >&2; exit 1 ;;
+  empty)      exit 0 ;;
+  timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
+  degraded)   echo "loading model" >&2; echo "ready"; exit 1 ;;  # stderr noise, usable stdout
+  *)          echo "ready"; exit 0 ;;
+esac

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -119,6 +119,13 @@ class TestRegistry(unittest.TestCase):
         self.assertIn("gemini-3.1-pro", argv)
         self.assertIn("--approval-mode", argv)
         self.assertIn("plan", argv)
+        # gemini-cli >= 0.46 "trusted folders": headless runs in an untrusted dir
+        # exit 55 with no output without this. Pin it so the fix can't regress.
+        self.assertIn("--skip-trust", argv)
+
+    def test_gemini_default_model_is_ga_id(self):
+        # The GA id (gemini-3.5-flash) needs CLI >= 0.46 to resolve; pinned inline.
+        self.assertEqual(rb.REGISTRY["gemini"].default_model, "gemini-3.5-flash")
 
     def test_stdin_modes(self):
         self.assertTrue(rb.REGISTRY["claude"].prompt_on_stdin)
@@ -877,6 +884,182 @@ class TestCodexMockGuardsStdin(EnvMixin):
             os.close(w)
         self.assertFalse(result.timed_out)
         self.assertIn("ready", result.stdout)
+
+
+# --------------------------------------------------------------------------- #
+# Toolchain currency + model self-heal (§7a)
+# --------------------------------------------------------------------------- #
+
+
+def _capture(fn, *, stdin=None):
+    """Run fn() capturing (return_value, stdout), optionally feeding stdin."""
+    out = io.StringIO()
+    old_stdin = sys.stdin
+    if stdin is not None:
+        sys.stdin = io.StringIO(stdin)
+    try:
+        with contextlib.redirect_stdout(out):
+            rv = fn()
+    finally:
+        sys.stdin = old_stdin
+    return rv, out.getvalue()
+
+
+class TestVersionHelpers(unittest.TestCase):
+    def test_parse_semver_across_banner_formats(self):
+        self.assertEqual(rb.parse_semver("2.1.177 (Claude Code)"), "2.1.177")
+        self.assertEqual(rb.parse_semver("codex-cli 0.135.0"), "0.135.0")
+        self.assertEqual(rb.parse_semver("0.46.0"), "0.46.0")
+        self.assertIsNone(rb.parse_semver("no version here"))
+        self.assertIsNone(rb.parse_semver(""))
+
+    def test_version_is_current(self):
+        self.assertIs(rb.version_is_current("2.1.191", "2.1.191"), True)
+        self.assertIs(rb.version_is_current("2.2.0", "2.1.191"), True)    # ahead
+        self.assertIs(rb.version_is_current("2.1.177", "2.1.191"), False)
+        self.assertIsNone(rb.version_is_current(None, "2.1.191"))         # unknown installed
+        self.assertIsNone(rb.version_is_current("2.1.177", None))         # unknown latest
+        self.assertIs(rb.version_is_current("0.46", "0.46.0"), True)      # padded, not string-len
+
+    def test_parse_brew_latest(self):
+        self.assertEqual(rb.parse_brew_latest('{"formulae":[{"versions":{"stable":"0.46.0"}}]}'), "0.46.0")
+        self.assertIsNone(rb.parse_brew_latest("not json"))
+        self.assertIsNone(rb.parse_brew_latest("{}"))
+
+
+class TestModelNotFoundDetector(unittest.TestCase):
+    def _r(self, out="", err=""):
+        return rb.SpawnResult(1, out, err, 0.0, False)
+
+    def test_detects_each_providers_grounded_signature(self):
+        self.assertTrue(rb.model_not_found(self._r(err="ModelNotFoundError: Requested entity was not found.")))
+        self.assertTrue(rb.model_not_found(self._r(out="It may not exist or you may not have access to it.")))
+        self.assertTrue(rb.model_not_found(self._r(err='"message":"The model is not supported when using Codex"')))
+
+    def test_clean_output_is_not_flagged(self):
+        self.assertFalse(rb.model_not_found(self._r(out="ready")))
+
+
+class TestToolchainCheck(EnvMixin):
+    def test_all_stale_by_default(self):
+        # mock npm/brew report "latest" 9.9.9, far ahead of the mock CLIs' versions.
+        code, out, _ = run_cli(["toolchain"])
+        self.assertEqual(code, rb.EXIT_OK)
+        for seat in ("claude", "codex", "gemini"):
+            self.assertIn(seat, out)
+        self.assertIn("STALE", out)
+        self.assertIn("behind latest", out)
+
+    def test_current_when_versions_match(self):
+        os.environ["MOCK_NPM_CLAUDE"] = "2.0.0"
+        os.environ["MOCK_NPM_CODEX"] = "0.30.0"
+        os.environ["MOCK_BREW_GEMINI"] = "0.46.0"
+        code, out, _ = run_cli(["toolchain"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertNotIn("STALE", out)
+        self.assertIn("current", out)
+
+    def test_board_subset_only_checks_those_seats(self):
+        code, out, _ = run_cli(["toolchain", "--board", "claude,gemini"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("claude", out)
+        self.assertIn("gemini", out)
+        # codex row absent (only its name as a seat label would appear)
+        self.assertNotIn("@openai/codex", out)
+
+    def test_missing_manager_reads_unknown_not_stale(self):
+        import dataclasses
+        bad = dataclasses.replace(rb.REGISTRY["claude"],
+                                  latest_argv=lambda: ["definitely-no-such-tool-xyz", "view"])
+        st = rb.check_tool(bad)
+        self.assertIsNone(st.current)       # cannot judge -> not "stale"
+        self.assertIsNone(st.update_argv)   # and therefore never auto-updated
+        self.assertIn("unknown", st.note)
+
+    def test_flag_drift_note_when_cli_newer_than_grounding(self):
+        import dataclasses
+        a = dataclasses.replace(rb.REGISTRY["claude"], flags_verified_version="1.0.0")
+        st = rb.check_tool(a)   # mock claude --version is 2.0.0 > 1.0.0
+        self.assertIn("re-verify", st.note)
+
+
+class TestToolchainUpdate(EnvMixin):
+    def _stale_statuses(self):
+        return rb.check_toolchain([rb.REGISTRY[n] for n in ("claude", "codex", "gemini")])
+
+    def test_interactive_decline_does_not_update(self):
+        log = os.path.join(tempfile.mkdtemp(), "argv.log")
+        os.environ["MOCK_ARGV_LOG"] = log
+        statuses = self._stale_statuses()
+        rv, out = _capture(
+            lambda: rb.update_stale_tools(statuses, assume_yes=False, interactive=True),
+            stdin="n\n")
+        self.assertEqual(rv, 0)
+        self.assertIn("no update performed", out)
+        logged = ""
+        if os.path.exists(log):
+            with open(log) as fh:
+                logged = fh.read()
+        self.assertNotIn("\tupdate", logged)   # no `claude update` / `codex update` ran
+
+    def test_interactive_accept_updates_each_stale_seat(self):
+        log = os.path.join(tempfile.mkdtemp(), "argv.log")
+        os.environ["MOCK_ARGV_LOG"] = log
+        statuses = self._stale_statuses()
+        rv, out = _capture(
+            lambda: rb.update_stale_tools(statuses, assume_yes=False, interactive=True),
+            stdin="y\n")
+        self.assertEqual(rv, 0)
+        for seat in ("claude", "codex", "gemini"):
+            self.assertIn(f"{seat}: updated", out)
+        with open(log) as fh:
+            logged = fh.read()
+        self.assertIn("claude\tupdate", logged)
+        self.assertIn("codex\tupdate", logged)
+
+    def test_yes_flag_skips_prompt(self):
+        code, out, _ = run_cli(["toolchain", "--update", "--yes"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("claude: updated", out)
+
+    def test_nontty_without_yes_is_a_noop(self):
+        code, out, _ = run_cli(["toolchain", "--update"], stdin="")
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("re-run with --yes", out)
+
+    def test_update_failure_sets_nonzero_exit(self):
+        os.environ["MOCK_BREW_UPGRADE_FAIL"] = "1"
+        code, out, _ = run_cli(["toolchain", "--update", "--yes"])
+        self.assertEqual(code, rb.EXIT_USAGE)
+        self.assertIn("update failed", out)
+
+
+class TestModelProposal(EnvMixin):
+    def test_pinned_model_404_proposes_resolvable_fallback(self):
+        # gemini's pinned id (gemini-3.5-flash) 404s; a fallback resolves.
+        os.environ["MOCK_GEMINI_MODE"] = "model_proposal"
+        code, out, _ = run_cli(["preflight", "--source", SAMPLE])
+        # claude + codex still GO -> board can proceed (>= 2 voices)
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("proposal (gemini)", out)
+        self.assertIn("gemini-3-flash-preview", out)
+
+    def test_propose_model_returns_first_resolvable(self):
+        os.environ["MOCK_GEMINI_MODE"] = "model_proposal"
+        seat = next(s for s in _config().board if s.name == "gemini")
+        proposal = rb.propose_model(seat, network_on=False, workdir=None)
+        self.assertEqual(proposal, "gemini-3-flash-preview")
+
+
+class TestRunUpdateToolsFlag(EnvMixin):
+    def test_run_update_tools_runs_toolchain_then_proceeds(self):
+        out = tempfile.mkdtemp(prefix="board-upd-")
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out,
+                                 "--update-tools", "--yes"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("=== toolchain ===", text)
+        self.assertIn("=== preflight ===", text)
+        self.assertIn("M3", text)   # still stops at the documented spawn boundary
 
 
 if __name__ == "__main__":

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -1102,5 +1102,72 @@ class TestAntigravitySeat(EnvMixin):
         self.assertIn("3 of 3 seats GO", out)
 
 
+class TestGracefulDegradation(EnvMixin):
+    def _absent(self, seat):
+        import dataclasses
+        return dataclasses.replace(rb.REGISTRY[seat],
+                                   version_argv=lambda: ["no-such-binary-xyz", "--version"])
+
+    def test_absent_cli_is_missing_not_unknown(self):
+        st = rb.check_tool(self._absent("antigravity"))
+        self.assertFalse(st.present)
+        self.assertEqual(rb._tool_status_label(st), "missing")     # distinct from "unknown"
+        self.assertEqual(st.install_argv, rb.antigravity_install_argv())
+        self.assertTrue(st.auth_hint)
+
+    def test_table_lists_install_command_and_auth_caveat(self):
+        missing = rb.check_tool(self._absent("codex"))
+        out = rb.render_toolchain_table([missing])
+        self.assertIn("not installed", out)
+        self.assertIn("npm install -g @openai/codex", out)
+        self.assertIn("does NOT grant an account", out)            # install ≠ auth caveat
+
+    def test_install_missing_decline_then_accept(self):
+        log = os.path.join(tempfile.mkdtemp(), "argv.log")
+        os.environ["MOCK_ARGV_LOG"] = log
+        statuses = [rb.check_tool(self._absent("codex"))]
+        # decline
+        rv, out = _capture(lambda: rb.install_missing_tools(statuses, assume_yes=False,
+                                                            interactive=True), stdin="n\n")
+        self.assertEqual(rv, 0)
+        self.assertIn("no install performed", out)
+        # accept (mock npm returns 0 for `npm install ...`)
+        rv, out = _capture(lambda: rb.install_missing_tools(statuses, assume_yes=False,
+                                                            interactive=True), stdin="y\n")
+        self.assertEqual(rv, 0)
+        self.assertIn("codex: installed", out)
+        self.assertIn("install ≠ account", out)
+
+    def test_toolchain_install_is_noop_when_all_present(self):
+        # all mock CLIs are present, so --install finds nothing to do
+        code, out, _ = run_cli(["toolchain", "--install", "--yes"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertNotIn("not installed", out)
+
+    def test_board_guidance_empty_when_board_can_form(self):
+        pf = [rb.SeatPreflight("claude", True, "ok", True, "ran", True, "ok"),
+              rb.SeatPreflight("codex", True, "ok", True, "ran", True, "ok")]
+        self.assertEqual(rb.render_board_guidance(pf, _config()), "")  # >=2 GO -> no guidance
+
+    def test_degraded_preflight_prints_actionable_guidance(self):
+        os.environ["MOCK_CODEX_MODE"] = "nogo_smoke"
+        os.environ["MOCK_GEMINI_MODE"] = "nogo_smoke"
+        code, out, _ = run_cli(["preflight", "--source", SAMPLE])
+        self.assertEqual(code, rb.EXIT_PREFLIGHT_NOGO)
+        self.assertIn("at least 2 independent voices", out)
+        self.assertIn("board-composition.md", out)
+        self.assertIn("Same-provider", out)                        # the single-provider fallback
+
+    def test_run_degraded_prints_guidance_before_stopping(self):
+        os.environ["MOCK_CODEX_MODE"] = "nogo_smoke"
+        os.environ["MOCK_GEMINI_MODE"] = "nogo_smoke"
+        out_dir = tempfile.mkdtemp(prefix="board-degraded-")
+        code, out, _ = run_cli(["run", "--source", SAMPLE, "--out", out_dir], stdin="")
+        self.assertEqual(code, rb.EXIT_PREFLIGHT_NOGO)
+        self.assertIn("board-composition.md", out)
+        # nothing materialized — degraded stop is before the egress gate
+        self.assertFalse(os.path.exists(os.path.join(out_dir, "prompts")))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -57,7 +57,7 @@ class EnvMixin(unittest.TestCase):
         os.environ["PATH"] = MOCKS + os.pathsep + os.environ.get("PATH", "")
         os.environ["ADVISORY_BOARD_NOW"] = "2026-06-25"
         os.environ["ADVISORY_BOARD_NOW_TS"] = "2026-06-25T12:00:00"
-        for seat in ("CLAUDE", "CODEX", "GEMINI", "AGY"):
+        for seat in ("CLAUDE", "CODEX", "GEMINI", "AGY", "OLLAMA"):
             os.environ[f"MOCK_{seat}_MODE"] = "go"
         os.environ.pop("MOCK_ARGV_LOG", None)
 
@@ -73,7 +73,7 @@ class EnvMixin(unittest.TestCase):
 
 class TestRegistry(unittest.TestCase):
     def test_seats_registered(self):
-        self.assertEqual(set(rb.REGISTRY), {"claude", "codex", "gemini", "antigravity"})
+        self.assertEqual(set(rb.REGISTRY), {"claude", "codex", "gemini", "antigravity", "ollama"})
 
     def test_antigravity_flags(self):
         a = rb.REGISTRY["antigravity"]
@@ -967,6 +967,7 @@ class TestToolchainCheck(EnvMixin):
         os.environ["MOCK_NPM_CODEX"] = "0.30.0"
         os.environ["MOCK_BREW_GEMINI"] = "0.46.0"
         os.environ["MOCK_BREW_CASK"] = "1.0.0"   # matches the mock agy --version
+        os.environ["MOCK_BREW_OLLAMA"] = "0.5.0"  # matches the mock ollama --version
         code, out, _ = run_cli(["toolchain"])
         self.assertEqual(code, rb.EXIT_OK)
         self.assertNotIn("STALE", out)
@@ -1100,6 +1101,74 @@ class TestAntigravitySeat(EnvMixin):
         self.assertEqual(code, rb.EXIT_OK)
         self.assertIn("antigravity", out)
         self.assertIn("3 of 3 seats GO", out)
+
+
+class TestOllamaSeat(EnvMixin):
+    """The local-model seat: the documented single-provider / sensitive-material
+    fallback, now actually runnable (`--board claude,ollama`)."""
+
+    def test_default_board_excludes_ollama(self):
+        names = [s.name for s in _config().board]
+        self.assertEqual(names, ["claude", "codex", "gemini"])
+        self.assertNotIn("ollama", names)   # opt-in via --board, never default
+
+    def test_ollama_flags_and_local_isolation(self):
+        a = rb.REGISTRY["ollama"]
+        argv = a.build_argv("llama3.3", "PROMPT", network=False)
+        self.assertEqual(argv, ["ollama", "run", "llama3.3"])  # prompt is on stdin, not argv
+        self.assertNotIn("PROMPT", argv)
+        self.assertTrue(a.prompt_on_stdin)      # `ollama run` reads the prompt on stdin
+        self.assertFalse(a.close_stdin)
+        self.assertEqual(a.provider, "local")   # NOT external egress
+        self.assertTrue(a.isolates_network)     # local model: no external network, intrinsic
+        self.assertEqual(a.default_model, "llama3.3")
+
+    def test_local_seat_is_not_external_egress(self):
+        # A claude+ollama board: only the claude prompt is external; ollama stays local.
+        c = _config(board="claude,ollama")
+        blobs = rb.build_packet(c)
+        by_seat = {b.seat: b for b in blobs}
+        self.assertEqual(by_seat["ollama"].provider, "local")
+        external = [b for b in blobs if b.provider != "local"]
+        self.assertEqual([b.seat for b in external], ["claude"])   # ollama excluded
+        # disclosure names only the external provider, never the local seat.
+        disclosure = rb.disclosure_line(c)
+        self.assertIn("Anthropic", disclosure)
+        self.assertNotIn("local", disclosure)
+
+    def test_egress_gate_treats_local_blob_as_no_egress(self):
+        # Even a single local seat with must-not-leave sensitivity is allowed: nothing
+        # leaves the machine, so the gate approves it (the privacy lever, end to end).
+        c = _config(board="ollama", sensitivity="local-only")
+        blobs = rb.build_packet(c)
+        with contextlib.redirect_stdout(io.StringIO()):
+            ap = rb.enforce_egress_gate(c, blobs, assume_yes=False, skip_gate=False,
+                                        interactive=False)
+        self.assertTrue(ap.approved)
+        self.assertEqual(ap.mode, "disclosure")
+        self.assertIn("no external egress", ap.detail)
+
+    def test_manifest_does_not_list_local_seat_as_leaving(self):
+        c = _config(board="claude,ollama")
+        blobs = rb.build_packet(c)
+        manifest = rb.render_egress_manifest(c, blobs, rb.packet_hash(blobs))
+        self.assertIn("Anthropic (claude)", manifest)         # claude prompt leaves
+        self.assertNotIn("local (ollama)", manifest)          # ollama is NOT in the leaving/providers list
+        self.assertIn("Stays on this machine", manifest)      # local seat is accounted for separately
+        self.assertIn("ollama-round-1.prompt", manifest)
+
+    def test_board_with_ollama_preflights(self):
+        code, out, _ = run_cli(["preflight", "--source", SAMPLE, "--board", "claude,ollama"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("ollama", out)
+        self.assertIn("2 of 2 seats GO", out)
+
+    def test_toolchain_includes_ollama_via_formula(self):
+        code, out, _ = run_cli(["toolchain", "--board", "ollama"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("ollama", out)
+        self.assertIn("brew ollama", out)   # formula manager label
+        self.assertIn("STALE", out)         # mock ollama 0.5.0 < formula latest 9.9.9
 
 
 class TestGracefulDegradation(EnvMixin):

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -57,7 +57,7 @@ class EnvMixin(unittest.TestCase):
         os.environ["PATH"] = MOCKS + os.pathsep + os.environ.get("PATH", "")
         os.environ["ADVISORY_BOARD_NOW"] = "2026-06-25"
         os.environ["ADVISORY_BOARD_NOW_TS"] = "2026-06-25T12:00:00"
-        for seat in ("CLAUDE", "CODEX", "GEMINI"):
+        for seat in ("CLAUDE", "CODEX", "GEMINI", "AGY"):
             os.environ[f"MOCK_{seat}_MODE"] = "go"
         os.environ.pop("MOCK_ARGV_LOG", None)
 
@@ -72,8 +72,20 @@ class EnvMixin(unittest.TestCase):
 
 
 class TestRegistry(unittest.TestCase):
-    def test_three_seats_registered(self):
-        self.assertEqual(set(rb.REGISTRY), {"claude", "codex", "gemini"})
+    def test_seats_registered(self):
+        self.assertEqual(set(rb.REGISTRY), {"claude", "codex", "gemini", "antigravity"})
+
+    def test_antigravity_flags(self):
+        a = rb.REGISTRY["antigravity"]
+        argv = a.build_argv("Gemini 3.5 Flash (High)", "PROMPT", network=False)
+        self.assertEqual(argv[:2], ["agy", "-p"])
+        self.assertIn("PROMPT", argv)
+        self.assertIn("--model", argv)
+        self.assertIn("Gemini 3.5 Flash (High)", argv)
+        self.assertIn("--sandbox", argv)
+        self.assertTrue(a.close_stdin)        # agy reads stdin to EOF — must be closed
+        self.assertFalse(a.isolates_network)  # agentic harness; network not removable
+        self.assertEqual(a.default_model, "Gemini 3.5 Flash (High)")
 
     def test_claude_gate_isolation_flags(self):
         a = rb.REGISTRY["claude"]
@@ -945,7 +957,7 @@ class TestToolchainCheck(EnvMixin):
         # mock npm/brew report "latest" 9.9.9, far ahead of the mock CLIs' versions.
         code, out, _ = run_cli(["toolchain"])
         self.assertEqual(code, rb.EXIT_OK)
-        for seat in ("claude", "codex", "gemini"):
+        for seat in ("claude", "codex", "gemini", "antigravity"):
             self.assertIn(seat, out)
         self.assertIn("STALE", out)
         self.assertIn("behind latest", out)
@@ -954,6 +966,7 @@ class TestToolchainCheck(EnvMixin):
         os.environ["MOCK_NPM_CLAUDE"] = "2.0.0"
         os.environ["MOCK_NPM_CODEX"] = "0.30.0"
         os.environ["MOCK_BREW_GEMINI"] = "0.46.0"
+        os.environ["MOCK_BREW_CASK"] = "1.0.0"   # matches the mock agy --version
         code, out, _ = run_cli(["toolchain"])
         self.assertEqual(code, rb.EXIT_OK)
         self.assertNotIn("STALE", out)
@@ -1060,6 +1073,33 @@ class TestRunUpdateToolsFlag(EnvMixin):
         self.assertIn("=== toolchain ===", text)
         self.assertIn("=== preflight ===", text)
         self.assertIn("M3", text)   # still stops at the documented spawn boundary
+
+
+class TestAntigravitySeat(EnvMixin):
+    def test_default_board_excludes_antigravity(self):
+        names = [s.name for s in _config().board]
+        self.assertEqual(names, ["claude", "codex", "gemini"])
+        self.assertNotIn("antigravity", names)
+
+    def test_parse_brew_cask_latest(self):
+        good = '{"casks":[{"version":"1.0.12,6156052174077952"}]}'
+        self.assertEqual(rb.parse_brew_cask_latest(good), "1.0.12")  # comma-revision stripped
+        self.assertIsNone(rb.parse_brew_cask_latest("not json"))
+        self.assertIsNone(rb.parse_brew_cask_latest('{"formulae":[]}'))
+
+    def test_toolchain_check_includes_antigravity_via_cask(self):
+        code, out, _ = run_cli(["toolchain", "--board", "antigravity"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("antigravity", out)
+        self.assertIn("--cask antigravity-cli", out)   # brew-cask manager label
+        self.assertIn("STALE", out)                    # mock agy 1.0.0 < cask latest 9.9.9
+
+    def test_board_with_antigravity_preflight_go(self):
+        code, out, _ = run_cli(["preflight", "--source", SAMPLE,
+                                "--board", "claude,codex,antigravity"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("antigravity", out)
+        self.assertIn("3 of 3 seats GO", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacks on **#6** (M1+M2). Base is `claude/run-board-m1m2` so the diff shows only this change; rebase onto `main` once #6 merges.

## What & why
A stale seat CLI is the usual reason a board half-fails: a frontier model gets renamed (`gemini-3-flash-preview` → `gemini-3.5-flash` on GA) and the pinned id 404s on a CLI too old to route it. This adds a "step 0" that keeps the toolchain current and self-heals model ids.

## Changes
- **`toolchain` subcommand** (+ `run --update-tools`): per-seat installed-vs-latest check (npm for claude/codex, Homebrew for gemini); updates stale CLIs **on consent** (detect → confirm → update; `--yes` unattended; non-TTY is a no-op, not an error). A missing package manager reads **unknown**, never **stale** (no spurious updates).
- **Model self-heal**: a pinned id that 404s triggers a fallback probe that **proposes** a resolvable id (shown in the preflight table + `run-metadata.md`). Ids stay **pinned and never auto-swapped**, per the `advisory-board-model-policy`.
- **gemini default → `gemini-3.5-flash`** (GA id, confirmed against Google docs and **verified live** on gemini-cli 0.46.0) with ordered fallbacks.
- **`--skip-trust`** for the gemini adapter: gemini-cli ≥ 0.46 "trusted folders" otherwise forces approval-mode to default and exits 55 with no output in headless mode.
- **Grounded** model-not-found signatures for all three providers; **flag-drift advisory** when the installed CLI outruns the version its flags were grounded against.

## Verification
- `python3 -m unittest test_run_board` → **104 tests, all green** (+19), hermetic against mock `npm`/`brew` + extended seat mocks.
- Live `run_board.py preflight` → **3/3 seats GO** (gemini on `gemini-3.5-flash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)