### PR TITLE
Conductor M3: round-1 fan-out — real spawn, failure protocol, per-seat artifacts

### DIFF
--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -4,7 +4,7 @@
 
 | Script | Does | Reference |
 | ------ | ---- | --------- |
-| `run_board.py` | The **conductor** (M1+M2): deterministic seat-adapter registry, `--dry-run`, toolchain currency (`toolchain` — check/update stale CLIs, propose fallback model ids), executable preflight (GO/NO-GO), and a hash-bound egress/quarantine gate before any provider call. Calls the scripts below; never reimplements them. | `design/run-board-conductor.md` |
+| `run_board.py` | The **conductor** (M1–M3): deterministic seat-adapter registry, `--dry-run`, toolchain currency (`toolchain` — check/update stale CLIs, propose fallback model ids), executable preflight (GO/NO-GO), a hash-bound egress/quarantine gate before any provider call, and the **round-1 fan-out** (real spawn, §13 failure protocol, per-seat `round-1/` artifacts). Calls the scripts below; never reimplements them. | `design/run-board-conductor.md` |
 | `board_verdict.py` | Validate `verdict.json`; gate CI on the verdict (`--gate`). | `references/verdict-schema.md` |
 | `format_output.py` | Render `verdict.json` as a TL;DR, PR comment, Slack message, or normalized JSON. | `references/output-formats.md` |
 | `render_handoff.py` | Render `final-consensus.html` from a `handoff-data.json` — deterministic, fails on any leftover placeholder. | `references/handoff-template.html` |
@@ -25,7 +25,8 @@ python3 scripts/run_board.py run --source plan.md --dry-run
 # probe the seats (GO/NO-GO); exits non-zero if fewer than two are GO
 python3 scripts/run_board.py preflight --source plan.md
 
-# resolve config + preflight + egress gate (stops at the M3 spawn boundary for now)
+# full run: preflight + egress gate + round-1 fan-out -> round-1/<seat>.md + .raw
+# (stops at the round-1 boundary; synthesis -> verdict.json is M4/M5)
 python3 scripts/run_board.py run --source plan.md --sensitivity public
 
 # validate and summarize
@@ -43,4 +44,4 @@ python3 scripts/render_handoff.py path/to/handoff-data.json -o final-consensus.h
 
 > Paths above are relative to the **skill directory** — `skills/advisory-board/` in this repo, or the installed skill root (e.g. `~/.codex/skills/advisory-board/`) — the same convention as every `references/…` path in the skill. Run the scripts from there, or prefix them with that directory; `scripts/board_verdict.py` won't resolve from the repo root.
 
-`board_verdict.py` and `format_output.py` read the `verdict.json` a *completed* run emits next to `final-consensus.md` (produced once the conductor reaches synthesis — M5). The M1+M2 `run_board.py` stops at the egress gate, before any seat is spawned, so it does not yet emit a verdict. See the repo-root `examples/payments-idempotency-review/verdict.json` for a filled-in sample, and `references/verdict-schema.md` for the schema.
+`board_verdict.py` and `format_output.py` read the `verdict.json` a *completed* run emits next to `final-consensus.md` (produced once the conductor reaches synthesis — M5). `run_board.py` currently stops at the **round-1 boundary**: it spawns the board and captures each seat's review under `round-1/`, but does not yet synthesize a `verdict.json` (M4 packets, M5 verdict). See the repo-root `examples/payments-idempotency-review/verdict.json` for a filled-in sample, and `references/verdict-schema.md` for the schema.

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -1,32 +1,37 @@
 #!/usr/bin/env python3
-"""run_board.py — the Advisory Board conductor (M1 + M2).
+"""run_board.py — the Advisory Board conductor (M1 + M2 + M3).
 
 The skill's controls used to be prose addressed to the very agent that wants to
 run the board. This conductor turns the load-bearing mechanics into code: a
 deterministic seat-adapter registry (one place that knows each CLI's quirks), an
 executable preflight (GO/NO-GO), and — before a single byte of source material
 leaves the machine — a hash-bound egress gate with a mode-dependent quarantine
-posture.
+posture, followed by a real Round-1 fan-out with a defined failure protocol.
 
-This file implements milestones M1 and M2 of design/run-board-conductor.md:
+This file implements milestones M1, M2 and M3 of design/run-board-conductor.md:
 
   M1  skeleton + arg parsing + config/mode resolution + the SeatAdapter registry
       (claude / codex / gemini) + run-recipe/run-card render + `--dry-run`.
   M2  executable preflight (GO/NO-GO) + the egress manifest (consent bound to a
       content hash) + the pre-spawn hard stop + gate-mode isolation flags wired
       through the registry.
+  M3  Round-1 fan-out: real subprocess spawn (process-group-killed on timeout),
+      isolation enforced at spawn, the §13 failure protocol (success-shape check,
+      Timeout|AuthFailure|InvalidOutput|NoOutput|ModelNotFound classes, one retry
+      on Timeout|InvalidOutput), and per-seat artifacts — round-1/<seat>.md, the
+      .raw black-box recorder (input/source/packet hashes + answered model), and
+      logs/<seat>-round-1.stderr.
 
-What is deliberately NOT here yet (later milestones): the real Round-1 fan-out
-and capture (M3), Round 2 / packets (M4), the canonical verdict + resolved
-evidence (M5). `run` performs everything up to and including the egress gate,
-then stops at the spawn boundary and says so. No board spawn, no source egress,
-happens in this milestone.
+What is deliberately NOT here yet (later milestones): Round 2 / packets (M4) and
+the canonical verdict + resolved evidence (M5). `run` stops at the round-1
+boundary and hands the clean per-seat reviews to the synthesizer (§11) rather
+than flattening them in code.
 
 Subcommands:
   init        resolve config and emit run-recipe.yaml + the run-card (no spawn)
   toolchain   check each seat CLI vs its latest release; --update upgrades stale ones
   preflight   probe each seat (version / smoke ping) and print a GO/NO-GO table
-  run         resolve -> preflight -> build packet -> egress gate -> (M3 boundary)
+  run         resolve -> preflight -> egress gate -> round-1 fan-out -> artifacts
   render      delegate to render_handoff.py (final-consensus.html from data)
   validate    delegate to board_verdict.py (validate / gate verdict.json)
 
@@ -49,6 +54,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -184,12 +190,61 @@ class SeatAdapter:
 
 
 def _model_answered_none(stdout: str, stderr: str) -> Optional[str]:
-    """Placeholder model-answered parser (refined per provider in M3).
+    """Deliberately-unknown model-answered parser.
 
-    Honest default: return None ("unknown — flag it"), never assume the
-    requested model answered. M3 wires real banner/JSON parsing per provider.
+    Returns None ("unknown — flag it"), never "assume the requested model
+    answered". Used where the CLI cannot report the answering model reliably:
+    antigravity silently SUBSTITUTES an unknown model id (rc 0, no banner), so the
+    requested model can never be trusted to have answered (design §16, handoff
+    GOTCHA). The honest provenance is "unknown", surfaced as such everywhere.
     """
     return None
+
+
+# Best-effort "which model actually answered" parser (design §12 provenance, §16
+# "a model_answered miss is 'unknown — flag it', never assume requested"). We scan
+# ONLY stderr: the review prose on stdout routinely contains the word "model" and
+# must never be mined for a false id. Most CLIs do not print the answering model in
+# plain text, so None is the common, honest v1 outcome — never a fabricated id.
+_MODEL_JSON_RE = re.compile(r'"model"\s*:\s*"([^"]+)"')
+_MODEL_BANNER_RE = re.compile(
+    r'^\s*(?:using\s+model|model)\s*[:=]\s*["\']?([A-Za-z0-9][\w.\-/()]*(?: [\w.\-/()]+)*?)["\']?\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def parse_model_answered(stdout: str, stderr: str) -> Optional[str]:
+    """Return the model id a CLI *reports* having used (from stderr), or None."""
+    m = _MODEL_JSON_RE.search(stderr) or _MODEL_BANNER_RE.search(stderr)
+    if not m:
+        return None
+    cand = m.group(1).strip()
+    return cand or None
+
+
+# Round-1 output success criteria (design §13 "the output artifact must contain
+# the round's required sections — a shape/length check"). A genuine 7-section
+# review is long and names several of its sections; a plan-mode summary or an "I
+# saved the review to a file" reply is short and names few. This is the DETECTION
+# half of the {{CLAUDE_OUTPUT_OVERRIDE}} fix (a short/plan-shaped Claude artifact
+# fails here). Heuristic by design: lenient on any real review, strict on stubs.
+ROUND1_MIN_CHARS = 200
+ROUND1_SECTION_CUES = ("verdict", "objection", "execution", "invariant",
+                       "risk", "evidence", "challenge", "guardrail", "assumption")
+ROUND1_MIN_CUES = 3
+
+
+def check_round1_shape(text: str) -> tuple:
+    """(ok, reason). Does this look like a real round-1 review, not a stub?"""
+    body = text.strip()
+    if len(body) < ROUND1_MIN_CHARS:
+        return False, f"too short ({len(body)} chars < {ROUND1_MIN_CHARS}) — plan-mode/stub reply"
+    low = body.lower()
+    hits = sorted({c for c in ROUND1_SECTION_CUES if c in low})
+    if len(hits) < ROUND1_MIN_CUES:
+        return False, (f"missing review sections (found {len(hits)}/{ROUND1_MIN_CUES} "
+                       f"section cues: {', '.join(hits) or 'none'})")
+    return True, ""
 
 
 # v1 is always read-only — every adapter hardcodes its provider's read-only mode
@@ -429,7 +484,7 @@ REGISTRY: dict = {
         stderr_is_fatal=True,
         supports_isolation=True,
         isolates_network=True,   # --disallowed-tools WebSearch WebFetch removes web reach
-        model_answered=_model_answered_none,
+        model_answered=parse_model_answered,
         latest_argv=claude_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=claude_update_argv,
@@ -451,7 +506,7 @@ REGISTRY: dict = {
         stderr_is_fatal=True,
         supports_isolation=True,
         isolates_network=True,   # --sandbox read-only has no network (verified: DNS fails inside)
-        model_answered=_model_answered_none,
+        model_answered=parse_model_answered,
         latest_argv=codex_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=codex_update_argv,
@@ -477,7 +532,7 @@ REGISTRY: dict = {
         stderr_is_fatal=False,   # router retries on stderr are normal; judge by the artifact
         supports_isolation=True,    # fs scoping via cwd; network is NOT removable (below)
         isolates_network=False,  # no known flag disables GoogleSearch grounding — surfaced loudly
-        model_answered=_model_answered_none,
+        model_answered=parse_model_answered,
         latest_argv=gemini_latest_argv,
         parse_latest=parse_brew_latest,
         update_argv=gemini_update_argv,
@@ -1152,36 +1207,68 @@ class SpawnResult:
 
 def spawn(adapter: SeatAdapter, argv: list, *, prompt: Optional[str] = None,
           timeout: Optional[int] = None, cwd: Optional[str] = None) -> SpawnResult:
+    """Run one seat CLI under a hard timeout, capturing stdout/stderr.
+
+    The child is launched in its OWN session (start_new_session=True) so a real
+    seat that forks worker subprocesses can be killed as a process GROUP on
+    timeout — subprocess.run only kills the direct child and would orphan the
+    workers (handoff M3 obligation; the mock `timeout` arm exec's sleep so it has
+    none, but real CLIs do). On timeout we return exit 124 + whatever partial
+    output was captured, never blocking forever on the dead child's pipes.
+    """
     timeout = timeout if timeout is not None else adapter.timeout_s
     start = _clock()
-    stdin_data = None
-    stdin_setting = None
     if adapter.prompt_on_stdin and prompt is not None:
-        stdin_data = prompt
+        stdin_arg, input_data = subprocess.PIPE, prompt
     elif adapter.close_stdin:
-        stdin_setting = subprocess.DEVNULL
+        stdin_arg, input_data = subprocess.DEVNULL, None
+    else:
+        stdin_arg, input_data = None, None   # inherit (e.g. the --version probe)
     try:
-        completed = subprocess.run(
+        proc = subprocess.Popen(
             argv,
-            input=stdin_data,
-            stdin=stdin_setting if stdin_data is None else None,
+            stdin=stdin_arg,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=timeout,
             cwd=cwd,
             text=True,
+            start_new_session=True,
         )
     except FileNotFoundError:
         return SpawnResult(127, "", f"{argv[0]}: command not found", _clock() - start, False)
-    except subprocess.TimeoutExpired as exc:
-        out = exc.stdout or ""
-        err = exc.stderr or ""
-        if isinstance(out, bytes):
-            out = out.decode("utf-8", "replace")
-        if isinstance(err, bytes):
-            err = err.decode("utf-8", "replace")
+    try:
+        out, err = proc.communicate(input=input_data, timeout=timeout)
+        return SpawnResult(proc.returncode, out or "", err or "", _clock() - start, False)
+    except subprocess.TimeoutExpired:
+        out, err = _kill_group_and_collect(proc)
         return SpawnResult(124, out, err, _clock() - start, True)
-    return SpawnResult(completed.returncode, completed.stdout, completed.stderr, _clock() - start, False)
+
+
+def _kill_group_and_collect(proc: "subprocess.Popen") -> tuple:
+    """Terminate the timed-out child's whole process group, then drain its pipes.
+
+    SIGTERM the group, give it 5s to flush and exit; if it clings, SIGKILL the
+    group. Returns (stdout, stderr) — possibly partial, never None.
+    """
+    def _killpg(sig: int) -> None:
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            try:
+                proc.send_signal(sig)   # group gone/denied: fall back to the child
+            except ProcessLookupError:
+                pass
+
+    _killpg(signal.SIGTERM)
+    try:
+        out, err = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        _killpg(signal.SIGKILL)
+        try:
+            out, err = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            out, err = "", ""
+    return out or "", err or ""
 
 
 def _clock() -> float:
@@ -1202,10 +1289,55 @@ def classify(result: SpawnResult, adapter: SeatAdapter) -> tuple:
         return "dropped", FAILURE_NOOUTPUT
     if result.exit_code != 0:
         # Usable content despite a non-zero exit (matches execution-harness.md:
-        # "judge by whether the artifact is usable, not by stderr"). adapter is
-        # threaded for M3 fan-out, where the artifact-shape success check (§13)
-        # and per-provider stderr handling refine this into a hard pass/fail.
+        # "judge by whether the artifact is usable, not by stderr"). This is the
+        # PREFLIGHT smoke classifier — a one-word "ready" is a valid smoke. The
+        # round-1 fan-out adds the artifact-shape check via classify_round1 below.
         return "degraded", None
+    return "ran", None
+
+
+# Failure classes the protocol retries ONCE (design §13). Everything else
+# (AuthFailure, NoOutput, ModelNotFound) is non-recoverable → immediate drop.
+RETRYABLE_FAILURES = frozenset({FAILURE_TIMEOUT, FAILURE_INVALID})
+
+# Auth-failure tells scanned ONLY on stderr (never the review on stdout, which may
+# legitimately discuss auth/401s when the material under review is an auth system).
+_AUTH_FAILURE_SIGNALS = (
+    "not authenticated", "please log in", "please sign in", "authentication failed",
+    "unauthorized", "401 ", "invalid api key", "no api key", "login required",
+    "auth error", "session expired", "expired credentials",
+)
+
+
+def auth_failed(stderr: str) -> bool:
+    blob = stderr.lower()
+    return any(sig in blob for sig in _AUTH_FAILURE_SIGNALS)
+
+
+def classify_round1(result: SpawnResult, adapter: SeatAdapter) -> tuple:
+    """Classify a round-1 fan-out spawn into (status, failure_class|None) — §13.
+
+    Stricter than the preflight classify(): the captured artifact must pass the
+    shape/length check (check_round1_shape), which is how a short plan-mode reply
+    or an "I saved it to a file" stub is caught (the {{CLAUDE_OUTPUT_OVERRIDE}}
+    detection half). Ordering matters — timeout, then model-not-found, then the
+    empty/auth split, then shape, then the usable-but-nonzero degrade.
+    """
+    if result.timed_out:
+        return "dropped", FAILURE_TIMEOUT
+    if model_not_found(result):
+        return "dropped", FAILURE_MODEL
+    if not result.stdout.strip():
+        # No usable stdout: distinguish an actionable auth failure (look only at
+        # stderr) from a bare empty run.
+        if auth_failed(result.stderr):
+            return "dropped", FAILURE_AUTH
+        return "dropped", FAILURE_NOOUTPUT
+    shape_ok, _reason = check_round1_shape(result.stdout)
+    if not shape_ok:
+        return "dropped", FAILURE_INVALID   # retryable once
+    if result.exit_code != 0:
+        return "degraded", None             # usable review despite a non-zero exit
     return "ran", None
 
 
@@ -1815,7 +1947,8 @@ def render_artifact_tree(config: RunConfig) -> str:
     return "\n".join(parts)
 
 
-def render_run_metadata(config: RunConfig, preflight: list, approval: EgressApproval) -> str:
+def render_run_metadata(config: RunConfig, preflight: list, approval: EgressApproval,
+                        round1: Optional[list] = None) -> str:
     lines = [
         f"# Run Metadata — {config.title}",
         "",
@@ -1852,12 +1985,38 @@ def render_run_metadata(config: RunConfig, preflight: list, approval: EgressAppr
         f"- Timestamp    : {approval.timestamp}",
         f"- Providers    : {', '.join(sorted({s.provider for s in config.board if s.provider != 'local'})) or '(none)'}",
         f"- Detail       : {approval.detail}",
+    ]
+    if round1 is not None:
+        usable = sum(1 for r in round1 if r.usable)
+        lines += [
+            "",
+            "## Round 1",
+            "",
+            f"{usable} of {len(round1)} seats produced a usable review.",
+            "",
+            "| Seat   | Status   | Model answered | Attempts | Elapsed | Failure |",
+            "| ------ | -------- | -------------- | -------- | ------- | ------- |",
+        ]
+        for r in round1:
+            answered = r.model_answered or "unknown"
+            lines.append(
+                f"| {r.seat:<6} | {r.status:<8} | {answered} | {r.attempts} "
+                f"| {r.elapsed_s:.1f}s | {r.failure_class or '-'} |"
+            )
+        # Provider-correlation disclosure (§12): "three voices" can be fewer
+        # providers; the answered models above expose it, and antigravity's model
+        # is structurally unknowable (it silently substitutes — never trusted).
+    lines += [
         "",
         "## Notes",
         "",
-        "- Model that *answered* per seat is captured at fan-out (M3), not here.",
-        "- Never record secrets, tokens, cookies, or private environment values.",
     ]
+    if round1 is None:
+        lines.append("- Model that *answered* per seat is captured at the round-1 fan-out, not here.")
+    else:
+        lines.append("- 'Model answered' is what the CLI *reported*; 'unknown' means it reported "
+                     "nothing parseable (never assume the requested model answered).")
+    lines.append("- Never record secrets, tokens, cookies, or private environment values.")
     if config.unenforced_network_seats:
         lines.append(
             f"- ⚠ Network NOT isolated for: {', '.join(config.unenforced_network_seats)} "
@@ -1873,8 +2032,15 @@ def render_run_metadata(config: RunConfig, preflight: list, approval: EgressAppr
     return "\n".join(lines) + "\n"
 
 
-def write_artifacts(config: RunConfig, blobs: list, approval: EgressApproval,
-                    preflight: list, content_hash: str) -> None:
+def write_pre_spawn_artifacts(config: RunConfig, blobs: list, approval: EgressApproval,
+                              content_hash: str) -> None:
+    """Persist the APPROVED packet + recipe/manifest/sensitivity BEFORE any spawn.
+
+    Writing the exact approved bytes up front means an interrupted fan-out still
+    leaves a faithful record of what was approved and would egress (the artifact
+    tree is designed for idempotent per-seat writes, §15). run-metadata is written
+    AFTER the fan-out so it can carry the answered models + per-seat outcome.
+    """
     out = config.out_dir
     os.makedirs(os.path.join(out, "prompts"), exist_ok=True)
     os.makedirs(os.path.join(out, "logs"), exist_ok=True)
@@ -1885,14 +2051,192 @@ def write_artifacts(config: RunConfig, blobs: list, approval: EgressApproval,
            render_egress_manifest(config, blobs, content_hash))
     for b in blobs:
         _write(os.path.join(out, b.relpath), b.text)
-    _write(os.path.join(out, "run-metadata.md"),
-           render_run_metadata(config, preflight, approval))
 
 
 def _write(path: str, text: str) -> None:
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w", encoding="utf-8") as handle:
         handle.write(text)
+
+
+# --------------------------------------------------------------------------- #
+# Round-1 fan-out (design §11/§12/§13, milestone M3) — the first real spawn.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class SeatRoundResult:
+    seat: str
+    provider: str
+    model_requested: str
+    model_answered: Optional[str]
+    status: str                 # ran | degraded | dropped
+    failure_class: Optional[str]
+    attempts: int
+    elapsed_s: float
+    exit_code: int
+    timed_out: bool
+    stdout: str
+    stderr: str
+    prompt_hash: str            # sha256 of the exact bytes THIS seat received
+    source_hash: str            # sha256 of the source material (same across seats)
+    argv_preview: str           # the invocation, prompt elided (the black-box recorder)
+
+    @property
+    def usable(self) -> bool:
+        return self.status in ("ran", "degraded")
+
+
+def _run_seat_round1(seat: SeatConfig, blob: "PacketBlob", config: RunConfig,
+                     *, workdir: Optional[str], timeout: Optional[int]) -> SeatRoundResult:
+    """Spawn one seat on its approved prompt, classify, retry once per §13.
+
+    The prompt fed here is `blob.text` — the SAME canonical string the egress gate
+    hashed — so the bytes that actually leave (codex/gemini carry it in argv,
+    claude on stdin) are exactly the approved bytes. No re-templating happens
+    between consent and spawn.
+    """
+    adapter = seat.adapter
+    seat_timeout = timeout if timeout is not None else adapter.timeout_s
+    prompt = blob.text
+
+    attempts = 0
+    result = None
+    status = failure = None
+    last_argv: list = []
+    for attempt in (1, 2):
+        attempts = attempt
+        last_argv = adapter.build_argv(seat.model, prompt, reasoning=seat.reasoning,
+                                       workdir=workdir, network=config.network_on)
+        result = spawn(adapter, last_argv, prompt=prompt, timeout=seat_timeout, cwd=workdir)
+        status, failure = classify_round1(result, adapter)
+        if status in ("ran", "degraded"):
+            break
+        if attempt == 1 and failure in RETRYABLE_FAILURES:
+            continue   # the one allowed retry (Timeout | InvalidOutput)
+        break
+
+    answered = adapter.model_answered(result.stdout, result.stderr) if status in ("ran", "degraded") else None
+    return SeatRoundResult(
+        seat=seat.name,
+        provider=seat.provider,
+        model_requested=seat.model,
+        model_answered=answered,
+        status=status,
+        failure_class=failure,
+        attempts=attempts,
+        elapsed_s=result.elapsed_s,
+        exit_code=result.exit_code,
+        timed_out=result.timed_out,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        prompt_hash=blob.sha256,
+        source_hash=config.source.sha256,
+        argv_preview=_argv_preview(last_argv),
+    )
+
+
+def run_round1(config: RunConfig, blobs: list, approval: EgressApproval, *,
+               timeout: Optional[int] = None, parallel: bool = True) -> list:
+    """Round-1 fan-out across the board. Returns SeatRoundResult in board order.
+
+    Re-asserts the egress hash one last time before the first spawn: the packet
+    MUST still hash to exactly what consent was bound to, or nothing leaves the
+    machine (the pre-spawn hard stop, restated at the point of no return).
+    """
+    if packet_hash(blobs) != approval.content_hash:
+        die("egress hash drift: the packet no longer matches the approved content "
+            "hash — refusing to spawn the board", EXIT_EGRESS_BLOCKED)
+    by_seat = {b.seat: b for b in blobs}
+
+    # Gate mode confines each seat to a scoped, empty cwd (same posture preflight
+    # used); advisory mode runs in the caller's cwd (your own material, by design).
+    workdir = tempfile.mkdtemp(prefix="advisory-board-round1-") if config.fs_scoped else None
+    try:
+        def _one(seat: SeatConfig) -> SeatRoundResult:
+            return _run_seat_round1(seat, by_seat[seat.name], config,
+                                    workdir=workdir, timeout=timeout)
+
+        results: dict = {}
+        if parallel and len(config.board) > 1:
+            from concurrent.futures import ThreadPoolExecutor
+            with ThreadPoolExecutor(max_workers=len(config.board)) as pool:
+                futures = {pool.submit(_one, s): s for s in config.board}
+                for fut, seat in futures.items():
+                    results[seat.name] = fut.result()
+        else:
+            for seat in config.board:
+                results[seat.name] = _one(seat)
+        return [results[s.name] for s in config.board]
+    finally:
+        if workdir:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _dropped_md(r: SeatRoundResult) -> str:
+    return (f"# {r.seat} — round 1: no usable review\n\n"
+            f"Status: **{r.status}** · failure class: **{r.failure_class or '-'}** · "
+            f"attempts: {r.attempts}.\n\n"
+            f"This seat did not return a usable round-1 review. See "
+            f"`round-1/{r.seat}.raw` for the full invocation record and "
+            f"`logs/{r.seat}-round-1.stderr` for its stderr.\n")
+
+
+def render_raw_record(r: SeatRoundResult, approval: EgressApproval) -> str:
+    """The Black-Box Recorder (§12): the verbatim invocation + the hashes that
+    prove same-material independence and bind it to the egress approval. Honestly
+    'falsifiable-by-inspection', not tamper-proof — it catches empty/lazy/drifted
+    runs, not a determined forger using the same orchestrator."""
+    lines = [
+        f"# Black-box recorder — {r.seat} · round 1",
+        "",
+        f"command         : {r.argv_preview}",
+        f"prompt-source   : prompts/{r.seat}-round-1.prompt",
+        f"source-hash     : sha256:{r.source_hash}   (identical across seats → same-material independence)",
+        f"prompt-hash     : sha256:{r.prompt_hash}   (the exact bytes this seat received)",
+        f"packet-hash     : sha256:{approval.content_hash}   (egress consent was bound to this)",
+        f"model-requested : {r.model_requested}",
+        f"model-answered  : {r.model_answered or 'unknown (CLI reported none — not assumed)'}",
+        f"exit-code       : {r.exit_code}",
+        f"timed-out       : {'yes' if r.timed_out else 'no'}",
+        f"elapsed-s       : {r.elapsed_s:.2f}",
+        f"attempts        : {r.attempts}",
+        f"status          : {r.status}",
+        f"failure-class   : {r.failure_class or '-'}",
+        "",
+        "----------------8<---------------- STDOUT ----------------8<----------------",
+        r.stdout.rstrip("\n"),
+        "----------------8<---------------- STDERR ----------------8<----------------",
+        r.stderr.rstrip("\n"),
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_round1_artifacts(config: RunConfig, results: list, approval: EgressApproval) -> None:
+    out = config.out_dir
+    os.makedirs(os.path.join(out, "round-1"), exist_ok=True)
+    os.makedirs(os.path.join(out, "logs"), exist_ok=True)
+    for r in results:
+        review_md = r.stdout if r.usable else _dropped_md(r)
+        _write(os.path.join(out, "round-1", f"{r.seat}.md"), review_md)
+        _write(os.path.join(out, "round-1", f"{r.seat}.raw"), render_raw_record(r, approval))
+        _write(os.path.join(out, "logs", f"{r.seat}-round-1.stderr"), r.stderr)
+
+
+def render_round1_table(results: list) -> str:
+    rows = ["| Seat   | Status   | Model answered | Attempts | Elapsed | Failure |",
+            "| ------ | -------- | -------------- | -------- | ------- | ------- |"]
+    for r in results:
+        answered = r.model_answered or "unknown"
+        rows.append(
+            f"| {r.seat:<6} | {r.status:<8} | {answered:<14} | {r.attempts:<8} "
+            f"| {r.elapsed_s:>5.1f}s | {r.failure_class or '-'} |"
+        )
+    usable = sum(1 for r in results if r.usable)
+    rows.append("")
+    rows.append(f"{usable} of {len(results)} seats produced a usable round-1 review.")
+    return "\n".join(rows)
 
 
 # --------------------------------------------------------------------------- #
@@ -2026,15 +2370,35 @@ def cmd_run(args) -> int:
                render_sensitivity_json(config, approval))
         die(f"egress blocked — see {config.out_dir}/egress-manifest.md", EXIT_EGRESS_BLOCKED)
 
-    # 3. Approved: write the packet + provenance, then stop at the M3 boundary.
-    # M3 obligation (tracked): the fan-out must re-derive each seat's argv and the
-    # hashed blob from ONE canonical prompt string and re-assert packet_hash(blobs)
-    # == approval.content_hash immediately before subprocess.run, so the bytes that
-    # actually egress (codex/gemini carry the prompt in argv) match what was approved.
-    write_artifacts(config, blobs, approval, preflight, content_hash)
+    # 3. Approved: persist the exact approved packet + provenance BEFORE spawning.
+    write_pre_spawn_artifacts(config, blobs, approval, content_hash)
+
+    # 4. Round-1 fan-out (M3) — the first real spawn. run_round1 re-asserts the
+    #    egress hash one last time, then feeds each seat its approved blob verbatim
+    #    (so the bytes that actually leave equal what consent was bound to), with
+    #    per-seat timeout / one-retry / failure classification (§13).
+    print("\n=== round 1 (fan-out) ===")
+    results = run_round1(config, blobs, approval, timeout=getattr(args, "timeout", None))
+    write_round1_artifacts(config, results, approval)
+    _write(os.path.join(config.out_dir, "run-metadata.md"),
+           render_run_metadata(config, preflight, approval, round1=results))
+    print(render_round1_table(results))
     print(f"\nwrote run dir: {config.out_dir}")
-    print("Round-1 fan-out is not implemented in this milestone (M3). "
-          "The egress gate has passed; the conductor stops here without spawning any seat.")
+
+    usable = [r for r in results if r.usable]
+    if len(usable) < 2:
+        print(f"\nWARNING: only {len(usable)} of {len(results)} seats produced a usable "
+              "round-1 review — that is not a board. Inspect round-1/*.raw and logs/, fix "
+              "the failed seats, and re-run. Synthesis is intentionally NOT attempted on "
+              "fewer than two voices.")
+        return EXIT_PREFLIGHT_NOGO
+
+    # M3 boundary: Round 1 is captured. Round 2 / packets (M4) and the canonical
+    # verdict + resolved evidence (M5) are later milestones — v1 hands the clean
+    # round-1 artifacts to the synthesizer rather than flattening them in code (§11).
+    print(f"\nRound 1 complete: {len(usable)} usable reviews in {config.out_dir}/round-1/. "
+          "Next (M4/M5, not yet automated): synthesize round-1/*.md into verdict.json, "
+          "then `validate` it. The conductor stops at the round-1 boundary.")
     return EXIT_OK
 
 
@@ -2095,8 +2459,8 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="run_board.py",
-        description="The Advisory Board conductor (M1+M2: skeleton, registry, dry-run, "
-                    "preflight, egress/quarantine gate).",
+        description="The Advisory Board conductor (M1-M3: registry, dry-run, preflight, "
+                    "egress/quarantine gate, round-1 fan-out with failure protocol).",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2109,7 +2473,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_run_options(p_pre)
     p_pre.set_defaults(func=cmd_preflight)
 
-    p_run = sub.add_parser("run", help="resolve -> preflight -> packet -> egress gate -> (M3 boundary)")
+    p_run = sub.add_parser("run", help="resolve -> preflight -> egress gate -> round-1 fan-out")
     add_run_options(p_run)
     p_run.add_argument("--dry-run", action="store_true",
                        help="print config + run-card + preflight plan + manifest + tree; no spawn")
@@ -2120,6 +2484,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--update-tools", dest="update_tools", action="store_true",
                        help="before preflight, check each CLI vs latest and update stale ones "
                             "(consent-gated; --yes auto-approves)")
+    p_run.add_argument("--timeout", type=int, default=None, metavar="SECONDS",
+                       help="per-seat hard timeout for the round-1 fan-out "
+                            "(default: the adapter cap, 900s = 15 min)")
     p_run.set_defaults(func=cmd_run)
 
     p_tool = sub.add_parser("toolchain",

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -1,8 +1,9 @@
 # Conductor tests
 
-Tests for `scripts/run_board.py` (the M1+M2 conductor). Python 3 standard library
-only; they run the whole pipeline against **mock CLIs** on `PATH`, so no provider
-tokens are spent and nothing leaves the machine.
+Tests for `scripts/run_board.py` (the M1–M3 conductor). Python 3 standard library
+only; they run the whole pipeline — including the real round-1 fan-out — against
+**mock CLIs** on `PATH`, so no provider tokens are spent and nothing leaves the
+machine.
 
 ## Run
 
@@ -22,8 +23,8 @@ needed beyond a Python 3 interpreter.
 
 | Path | Purpose |
 | ---- | ------- |
-| `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, `--from-recipe`, delegation, toolchain currency + model self-heal) |
-| `mocks/{claude,codex,gemini,agy,ollama}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version. `ollama` is the local seat — prompt on stdin, no `model_not_found`/`update` arms; `MOCK_OLLAMA_VERSION` sets its reported version, default `0.5.0`) |
+| `test_run_board.py` | the suite (registry, YAML codec, config, packet, preflight, egress gate, end-to-end run flow, **round-1 fan-out: shape check, failure classifier, model-answered parser, retry/timeout, hash binding, process-group kill**, `--from-recipe`, delegation, toolchain currency + model self-heal) |
+| `mocks/{claude,codex,gemini,agy,ollama}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`/`stub`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. The smoke ping returns `ready`; a round-1 prompt returns a full multi-section review (with a `model:` banner on stderr) so a single test exercises preflight **and** the fan-out — `stub` returns a short plan-style reply (the §13 shape-check failure). `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version. `ollama` is the local seat — prompt on stdin, no `model_not_found`/`update` arms; `MOCK_OLLAMA_VERSION` sets its reported version, default `0.5.0`) |
 | `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`, `MOCK_BREW_GEMINI`/`MOCK_BREW_OLLAMA` formulae, `MOCK_BREW_CASK` for the antigravity cask; default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
 | `fixtures/sample-plan.md` | a small, stable source for deterministic runs |
 
@@ -52,3 +53,21 @@ These are the M2 invariants — if any regresses, a test fails:
   `--install` is consent-gated and never implies an account; and when fewer than
   two seats are usable, preflight/run emit actionable guidance (install vs auth,
   same-provider / local-seat fallbacks) instead of dead-ending.
+
+The M3 round-1 fan-out adds its own invariants:
+
+- **The egress hash is re-asserted at the point of no return**
+  (`TestRound1FanOut.test_hash_drift_refuses_to_spawn`) — if the packet no longer
+  matches the approved content hash, nothing spawns; each seat is fed the exact
+  approved blob, so the bytes that leave equal what consent was bound to.
+- **The §13 failure protocol** (`TestClassifyRound1`, `TestRound1FanOut`) — a
+  short/plan-shaped reply fails the shape check (`InvalidOutput`, the
+  {{CLAUDE_OUTPUT_OVERRIDE}} detection); `Timeout`/`InvalidOutput` retry once,
+  every other class drops immediately; auth is judged on stderr only so a review
+  that *discusses* 401s is not misread as an auth failure.
+- **Honest provenance** (`TestModelAnsweredParser`) — the answering model is parsed
+  from stderr (never mined from the review prose) and is `None` ("unknown") when
+  unreported; antigravity is structurally `None` (it silently substitutes models).
+- **Hung seats are reaped as a process group**
+  (`TestSpawnProcessGroupKill`) — a timed-out child's backgrounded grandchildren
+  are killed, not orphaned (the gap `subprocess.run(timeout=)` alone would leave).

--- a/skills/advisory-board/tests/mocks/agy
+++ b/skills/advisory-board/tests/mocks/agy
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Mock `agy` (Antigravity CLI). Handles `agy --version`, `agy models`, `agy update`,
-# and `agy -p <prompt>` smoke. MOCK_AGY_MODE: go | nogo_version | nogo_smoke |
-# empty | degraded | timeout. MOCK_AGY_VERSION sets the reported version (default
+# and `agy -p <prompt>`. MOCK_AGY_MODE: go | nogo_version | nogo_smoke | empty |
+# degraded | timeout | stub. MOCK_AGY_VERSION sets the reported version (default
 # 1.0.0). `agy update` fails with MOCK_AGY_UPDATE_FAIL=1. Real agy reads stdin to
 # EOF, so the conductor must close it (close_stdin -> DEVNULL) or the call hangs.
+# A round-1 prompt (contains "MATERIAL UNDER REVIEW") gets a full review; the smoke
+# ping gets "ready". NOTE: agy emits a model banner here, but the conductor never
+# trusts it (antigravity silently substitutes models) — model_answered stays None.
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -33,10 +36,55 @@ fi
 # leaves stdin open hangs and the conductor's timeout fires (the bug a test should catch).
 cat >/dev/null 2>&1
 
+is_review=0
+case "$*" in *"MATERIAL UNDER REVIEW"*) is_review=1 ;; esac
+model=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--model" ]; then model="$a"; fi
+  prev="$a"
+done
+
+emit_review() {
+  echo "model: ${model:-unknown}" >&2
+  cat <<'REVIEW'
+## Verdict
+Conditional go (confidence: medium). Changes it: a documented backfill plan for
+existing in-flight requests.
+
+## Strongest objections
+- The cutover assumes no requests are mid-retry when the constraint lands.
+- Evidence for the "no double charge" claim is asserted, not demonstrated.
+
+## Recommended execution sequence
+1. Freeze writes briefly. 2. Add the constraint. 3. Unfreeze behind a flag.
+
+## Invariants and guardrails
+The (key, request-hash) pair is unique and immutable once written.
+
+## Risks, stale assumptions, missing evidence
+Assumes a clean migration window exists in production — verify the traffic trough.
+
+## Concrete evidence
+Plan does not cite where the idempotency key is generated client-side.
+
+## What I'd ask the other seats
+Challenge the freeze-writes step's blast radius on latency SLOs.
+REVIEW
+}
+
 case "$mode" in
   nogo_smoke) echo "auth error" >&2; exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
-  degraded)   echo "harness note" >&2; echo "ready"; exit 1 ;;
-  *)          echo "ready"; exit 0 ;;
+  stub)
+    if [ "$is_review" = "1" ]; then echo "Reviewed."; else echo "ready"; fi
+    exit 0 ;;
+  degraded)
+    echo "harness note" >&2
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 1 ;;
+  *)
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/claude
+++ b/skills/advisory-board/tests/mocks/claude
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Mock `claude` CLI for testing the conductor without burning tokens or network.
 # Banner-accurate enough for preflight; behavior switched by MOCK_CLAUDE_MODE.
-#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout | model_not_found
-# `claude update` is mocked too (MOCK_CLAUDE_UPDATE_FAIL=1 to force a failure).
-# If MOCK_ARGV_LOG is set, the full argv is appended for end-to-end assertions.
+#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout
+#   | model_not_found | stub
+# The smoke ping ("Reply with the single word: ready") gets "ready"; a round-1
+# prompt (contains "MATERIAL UNDER REVIEW") gets a full multi-section review, so a
+# single test can exercise preflight AND the fan-out. `stub` returns a short
+# plan-style reply to a round-1 prompt — the {{CLAUDE_OUTPUT_OVERRIDE}} failure the
+# §13 shape check must catch. `claude update` is mocked (MOCK_CLAUDE_UPDATE_FAIL=1
+# forces a failure). If MOCK_ARGV_LOG is set, the full argv is logged.
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -11,6 +16,14 @@ if [ -n "${MOCK_ARGV_LOG:-}" ]; then
 fi
 
 mode="${MOCK_CLAUDE_MODE:-go}"
+
+# Requested model (--model <id>), echoed back as the answered-model banner.
+model=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--model" ]; then model="$a"; fi
+  prev="$a"
+done
 
 for a in "$@"; do
   if [ "$a" = "--version" ]; then
@@ -27,12 +40,58 @@ if [ "${1:-}" = "update" ]; then
   exit 0
 fi
 
+# claude -p reads the prompt from stdin; capture it to tell smoke from review.
+prompt="$(cat)"
+is_review=0
+case "$prompt" in *"MATERIAL UNDER REVIEW"*) is_review=1 ;; esac
+
+emit_review() {
+  # A realistic answering-model banner goes to stderr (never mined from stdout).
+  echo "model: ${model:-unknown}" >&2
+  cat <<'REVIEW'
+## Verdict
+Conditional go (confidence: medium). What would change it: a load test of the
+idempotency-key store under concurrent retries.
+
+## Strongest objections
+- The retry path can double-charge if the key TTL expires mid-flight.
+- No invariant pins the (idempotency-key, request-hash) pairing.
+
+## Recommended execution sequence
+1. Add the unique constraint. 2. Backfill existing rows. 3. Ship behind a flag.
+
+## Invariants and guardrails
+Exactly-once settlement per idempotency key, enforced at the storage layer.
+
+## Risks, stale assumptions, missing evidence
+Assumes the store is strongly consistent under partition — verify before rollout.
+
+## Concrete evidence
+Plan section "Key storage" omits the conflict-resolution policy.
+
+## What I'd ask the other seats
+Challenge the TTL choice and the read-after-write guarantee.
+REVIEW
+}
+
 case "$mode" in
   # Unknown model: claude prints this to STDOUT with exit 1 (grounded 2026-06-25).
   model_not_found) echo "There's an issue with the selected model. It may not exist or you may not have access to it."; exit 1 ;;
   nogo_smoke) exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
-  degraded)   echo "model-router retry" >&2; echo "ready"; exit 1 ;;
-  *)          echo "ready"; exit 0 ;;
+  stub)
+    if [ "$is_review" = "1" ]; then
+      echo "I've reviewed the plan and saved my full notes to review.md."   # plan-mode stub
+    else
+      echo "ready"
+    fi
+    exit 0 ;;
+  degraded)
+    echo "model-router retry" >&2
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 1 ;;
+  *)
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/codex
+++ b/skills/advisory-board/tests/mocks/codex
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Mock `codex` CLI. Handles `codex --version`, `codex update`, `codex exec ... <prompt>`.
-# MOCK_CODEX_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout | model_not_found
-# `codex update` is mocked too (MOCK_CODEX_UPDATE_FAIL=1 to force a failure).
+# MOCK_CODEX_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout
+#   | model_not_found | stub
+# A round-1 prompt (contains "MATERIAL UNDER REVIEW") gets a full multi-section
+# review; the smoke ping gets "ready". `stub` returns a short plan-style reply to a
+# round-1 prompt (the §13 shape-check failure). `codex update` is mocked
+# (MOCK_CODEX_UPDATE_FAIL=1 to force a failure).
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -30,12 +34,57 @@ fi
 # which is exactly the failure a test should catch, not hide.
 cat >/dev/null 2>&1
 
+# codex carries the prompt in argv; detect a round-1 prompt and the model id
+# (--config model=<id>), echoed back as the answered-model banner on stderr.
+is_review=0
+case "$*" in *"MATERIAL UNDER REVIEW"*) is_review=1 ;; esac
+model=""
+for a in "$@"; do
+  case "$a" in model=*) model="${a#model=}" ;; esac
+done
+
+emit_review() {
+  echo "model: ${model:-unknown}" >&2
+  cat <<'REVIEW'
+## Verdict
+Go with conditions (confidence: medium). Changes it: evidence the migration is
+backward-compatible during the deploy window.
+
+## Strongest objections
+- Implementation glosses over the dual-write window during the index build.
+- No test covers the concurrent-retry race the plan depends on.
+
+## Recommended execution sequence
+1. Add the index CONCURRENTLY. 2. Dual-read. 3. Cut over. 4. Drop the old path.
+
+## Invariants and guardrails
+A retried request with the same key must never create a second charge row.
+
+## Risks, stale assumptions, missing evidence
+Assumes the ORM serializes the constraint violation cleanly — verify the driver.
+
+## Concrete evidence
+The plan's "Migration" step lacks a CONCURRENTLY note (would lock writes).
+
+## What I'd ask the other seats
+Challenge whether the rollback path is actually exercised in staging.
+REVIEW
+}
+
 case "$mode" in
   nogo_smoke) exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
-  degraded)   echo "warning: sandbox note" >&2; echo "ready"; exit 1 ;;
+  stub)
+    if [ "$is_review" = "1" ]; then echo "Done — wrote the review."; else echo "ready"; fi
+    exit 0 ;;
+  degraded)
+    echo "warning: sandbox note" >&2
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 1 ;;
   # Unknown model: codex emits an invalid_request_error to STDERR (grounded 2026-06-25).
   model_not_found) echo '{"type":"error","error":{"type":"invalid_request_error","message":"The model is not supported when using Codex with a ChatGPT account."}}' >&2; exit 1 ;;
-  *)          echo "ready"; exit 0 ;;
+  *)
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/gemini
+++ b/skills/advisory-board/tests/mocks/gemini
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Mock `gemini` CLI. Gemini routinely prints router noise to stderr yet returns a
 # valid answer; the `degraded` mode exercises that "degraded-but-ran" path.
-# MOCK_GEMINI_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout | model_proposal
+# MOCK_GEMINI_MODE: go | nogo_version | nogo_smoke | empty | degraded | timeout
+#   | model_proposal | stub
 #   model_proposal: the pinned id (gemini-3.5-flash) 404s but a fallback resolves,
 #   exercising the model-not-found -> propose-fallback path.
+# A round-1 prompt (contains "MATERIAL UNDER REVIEW") gets a full review; the smoke
+# ping gets "ready". `stub` returns a short reply to a round-1 prompt (§13 shape
+# check). Gemini reads stdin to EOF (close_stdin); drain it so a regression hangs.
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -12,7 +16,8 @@ fi
 
 mode="${MOCK_GEMINI_MODE:-go}"
 
-# Extract the requested model (-m/--model <id>) so a mode can branch on it.
+# Extract the requested model (-m/--model <id>) so a mode can branch on it and so
+# it can be echoed back as the answered-model banner.
 model=""
 prev=""
 for a in "$@"; do
@@ -28,17 +33,57 @@ for a in "$@"; do
   fi
 done
 
+is_review=0
+case "$*" in *"MATERIAL UNDER REVIEW"*) is_review=1 ;; esac
+
+emit_review() {
+  echo "model: ${model:-unknown}" >&2
+  cat <<'REVIEW'
+## Verdict
+Hold (confidence: medium). Changes it: a rollout/observability plan for the new
+idempotency path.
+
+## Strongest objections
+- The plan ships the storage change without a metric for duplicate settlements.
+- No guardrail caps retry amplification under a downstream outage.
+
+## Recommended execution sequence
+1. Add the duplicate-charge counter. 2. Alert on it. 3. Then enable the new path.
+
+## Invariants and guardrails
+Every settlement is observable and attributable to exactly one idempotency key.
+
+## Risks, stale assumptions, missing evidence
+Assumes traffic shape is steady — a retry storm is the untested failure mode.
+
+## Concrete evidence
+Plan's "Rollout" section names no SLO for the new code path.
+
+## What I'd ask the other seats
+Challenge the assumption that the client never reuses a key across requests.
+REVIEW
+}
+
 case "$mode" in
   nogo_smoke) echo "auth error" >&2; exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
-  degraded)   echo "[router] retrying with fallback" >&2; echo "ready"; exit 1 ;;
+  stub)
+    if [ "$is_review" = "1" ]; then echo "Reviewed; summary follows: looks fine."; else echo "ready"; fi
+    exit 0 ;;
+  degraded)
+    echo "[router] retrying with fallback" >&2
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 1 ;;
   model_proposal)
     case "$model" in
       # The pinned GA id 404s on a (simulated) stale CLI; a fallback id resolves.
       *3.5-flash*) echo "ModelNotFoundError: Requested entity was not found." >&2; exit 1 ;;
       *)           echo "ready"; exit 0 ;;
     esac ;;
-  # go (default): router noise on stderr but a valid review on stdout, exit 0:
-  *)          echo "[router] retrying with fallback" >&2; echo "ready"; exit 0 ;;
+  # go (default): router noise on stderr but a valid answer on stdout, exit 0:
+  *)
+    echo "[router] retrying with fallback" >&2
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 0 ;;
 esac

--- a/skills/advisory-board/tests/mocks/ollama
+++ b/skills/advisory-board/tests/mocks/ollama
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # Mock `ollama` CLI — a local-model seat that runs entirely on-machine (no tokens,
-# no network). Like claude, the prompt arrives on STDIN (which this stub ignores).
-# Behavior switched by MOCK_OLLAMA_MODE:
-#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout
-# `ollama` itself has no self-update subcommand (currency is via brew), so there is
-# no `update` arm here. Reported version: MOCK_OLLAMA_VERSION (default 0.5.0).
-# If MOCK_ARGV_LOG is set, the full argv is appended for end-to-end assertions.
+# no network). Like claude, the prompt arrives on STDIN. Behavior switched by
+# MOCK_OLLAMA_MODE:
+#   go (default) | nogo_version | nogo_smoke | empty | degraded | timeout | stub
+# The smoke ping returns "ready"; a round-1 prompt (contains "MATERIAL UNDER
+# REVIEW") returns a full multi-section review, so a single test exercises preflight
+# AND the fan-out. `stub` returns a short reply (the §13 shape-check failure).
+# `ollama` has no self-update subcommand (currency is via brew), so no `update` arm;
+# and it never 404s a model (you run what you pulled), so no `model_not_found` arm —
+# model_answered stays unknown by design (the conductor uses the None stub for it).
+# Reported version: MOCK_OLLAMA_VERSION (default 0.5.0). Argv -> MOCK_ARGV_LOG.
 set -u
 
 if [ -n "${MOCK_ARGV_LOG:-}" ]; then
@@ -22,11 +26,50 @@ for a in "$@"; do
   fi
 done
 
-# `ollama run <model>` — the smoke ping / round-1 form. Prompt is on stdin (ignored).
+# `ollama run <model>` — the smoke ping / round-1 form. Prompt is on stdin.
+prompt="$(cat)"
+is_review=0
+case "$prompt" in *"MATERIAL UNDER REVIEW"*) is_review=1 ;; esac
+
+emit_review() {
+  cat <<'REVIEW'
+## Verdict
+Conditional go (confidence: medium). Changes it: a benchmark of the local store
+under the concurrent-retry workload.
+
+## Strongest objections
+- The plan trusts a single-node store for an exactly-once guarantee.
+- No invariant is stated for partial-failure replay.
+
+## Recommended execution sequence
+1. Define the uniqueness invariant. 2. Enforce it in storage. 3. Test replay.
+
+## Invariants and guardrails
+One settlement per idempotency key, even across process restarts.
+
+## Risks, stale assumptions, missing evidence
+Assumes clocks are monotonic for the TTL — verify on the target hosts.
+
+## Concrete evidence
+The plan's "Storage" section names no durability guarantee.
+
+## What I'd ask the other seats
+Challenge the single-node assumption and the replay-after-crash path.
+REVIEW
+}
+
 case "$mode" in
   nogo_smoke) echo "Error: could not connect to ollama server" >&2; exit 1 ;;
   empty)      exit 0 ;;
   timeout)    exec sleep 30 ;;   # exec so no orphaned sleep survives the kill
-  degraded)   echo "loading model" >&2; echo "ready"; exit 1 ;;  # stderr noise, usable stdout
-  *)          echo "ready"; exit 0 ;;
+  stub)
+    if [ "$is_review" = "1" ]; then echo "Reviewed locally; looks fine."; else echo "ready"; fi
+    exit 0 ;;
+  degraded)
+    echo "loading model" >&2   # stderr noise, usable stdout
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 1 ;;
+  *)
+    if [ "$is_review" = "1" ]; then emit_review; else echo "ready"; fi
+    exit 0 ;;
 esac

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -509,13 +509,26 @@ class TestRunFlow(EnvMixin):
         self.assertEqual(code, rb.EXIT_OK)
         for rel in ["run-recipe.yaml", "egress-manifest.md", "sensitivity.json",
                     "run-metadata.md", "prompts/claude-round-1.prompt",
-                    "prompts/codex-round-1.prompt", "prompts/gemini-round-1.prompt"]:
+                    "prompts/codex-round-1.prompt", "prompts/gemini-round-1.prompt",
+                    # M3 fan-out artifacts: per-seat review, black-box recorder, stderr log.
+                    "round-1/claude.md", "round-1/claude.raw", "logs/claude-round-1.stderr",
+                    "round-1/codex.md", "round-1/gemini.md"]:
             self.assertTrue(os.path.exists(os.path.join(out, rel)), rel)
         with open(os.path.join(out, "run-metadata.md")) as fh:
             meta = fh.read()
         self.assertIn("APPROVED", meta)
         self.assertIn("sha256:", meta)
-        self.assertIn("M3", text)  # stops at the spawn boundary
+        self.assertIn("## Round 1", meta)                  # fan-out outcome recorded
+        self.assertIn("3 of 3 seats produced a usable round-1 review", text)
+        # The captured review must be the real artifact, not the smoke "ready".
+        with open(os.path.join(out, "round-1", "claude.md")) as fh:
+            self.assertIn("Verdict", fh.read())
+        # The black-box recorder binds the run to the approved hash + source hash.
+        with open(os.path.join(out, "round-1", "claude.raw")) as fh:
+            raw = fh.read()
+        self.assertIn("packet-hash", raw)
+        self.assertIn("source-hash", raw)
+        self.assertIn("model-answered  : claude-opus-4-8", raw)
 
     def test_preflight_gates_before_egress(self):
         # Two seats down -> NO-GO -> must stop BEFORE writing any egress manifest,
@@ -1073,7 +1086,8 @@ class TestRunUpdateToolsFlag(EnvMixin):
         self.assertEqual(code, rb.EXIT_OK)
         self.assertIn("=== toolchain ===", text)
         self.assertIn("=== preflight ===", text)
-        self.assertIn("M3", text)   # still stops at the documented spawn boundary
+        self.assertIn("=== round 1 (fan-out) ===", text)   # proceeds through the fan-out
+        self.assertIn("usable round-1 review", text)
 
 
 class TestAntigravitySeat(EnvMixin):
@@ -1236,6 +1250,248 @@ class TestGracefulDegradation(EnvMixin):
         self.assertIn("board-composition.md", out)
         # nothing materialized — degraded stop is before the egress gate
         self.assertFalse(os.path.exists(os.path.join(out_dir, "prompts")))
+
+
+# --------------------------------------------------------------------------- #
+# M3 — round-1 success shape check + failure classifier + model-answered parser
+# --------------------------------------------------------------------------- #
+
+
+_REAL_REVIEW = (
+    "## Verdict\nConditional go (medium).\n\n## Strongest objections\nThe retry "
+    "path can double charge.\n\n## Recommended execution sequence\n1. Constraint. "
+    "2. Backfill.\n\n## Invariants and guardrails\nExactly-once per key.\n\n## "
+    "Risks\nAssumes strong consistency.\n\n## Concrete evidence\nSee 'Key storage'.\n"
+)
+
+
+class TestRound1ShapeCheck(unittest.TestCase):
+    def test_real_review_passes(self):
+        ok, reason = rb.check_round1_shape(_REAL_REVIEW)
+        self.assertTrue(ok, reason)
+
+    def test_short_stub_fails(self):
+        ok, reason = rb.check_round1_shape("I saved the review to review.md.")
+        self.assertFalse(ok)
+        self.assertIn("too short", reason)
+
+    def test_long_but_sectionless_fails(self):
+        # Long enough, but names no review sections -> not a review.
+        ok, reason = rb.check_round1_shape("lorem ipsum dolor sit amet " * 20)
+        self.assertFalse(ok)
+        self.assertIn("missing review sections", reason)
+
+
+class TestClassifyRound1(unittest.TestCase):
+    def _r(self, **kw):
+        base = dict(exit_code=0, stdout=_REAL_REVIEW, stderr="", elapsed_s=0.1, timed_out=False)
+        base.update(kw)
+        return rb.SpawnResult(**base)
+
+    def test_valid_review_ran(self):
+        self.assertEqual(rb.classify_round1(self._r(), rb.REGISTRY["claude"]), ("ran", None))
+
+    def test_valid_review_nonzero_is_degraded(self):
+        status, fail = rb.classify_round1(self._r(exit_code=1), rb.REGISTRY["gemini"])
+        self.assertEqual((status, fail), ("degraded", None))
+
+    def test_stub_is_invalid_output(self):
+        status, fail = rb.classify_round1(self._r(stdout="saved to file"), rb.REGISTRY["claude"])
+        self.assertEqual((status, fail), ("dropped", rb.FAILURE_INVALID))
+
+    def test_empty_is_no_output(self):
+        status, fail = rb.classify_round1(self._r(stdout="", exit_code=1), rb.REGISTRY["codex"])
+        self.assertEqual((status, fail), ("dropped", rb.FAILURE_NOOUTPUT))
+
+    def test_empty_with_auth_stderr_is_auth_failure(self):
+        status, fail = rb.classify_round1(
+            self._r(stdout="", stderr="auth error: please log in", exit_code=1),
+            rb.REGISTRY["gemini"])
+        self.assertEqual((status, fail), ("dropped", rb.FAILURE_AUTH))
+
+    def test_review_discussing_auth_is_not_auth_failure(self):
+        # A valid review that *mentions* 401/unauthorized on stdout must not be
+        # misread as an auth failure (auth is scanned on stderr only).
+        body = _REAL_REVIEW + "\nThe endpoint returns 401 unauthorized on bad keys.\n"
+        self.assertEqual(rb.classify_round1(self._r(stdout=body), rb.REGISTRY["codex"]),
+                         ("ran", None))
+
+    def test_timeout(self):
+        status, fail = rb.classify_round1(self._r(timed_out=True, exit_code=124),
+                                          rb.REGISTRY["claude"])
+        self.assertEqual((status, fail), ("dropped", rb.FAILURE_TIMEOUT))
+
+    def test_model_not_found(self):
+        out = "There's an issue with the selected model. It may not exist"
+        status, fail = rb.classify_round1(self._r(stdout=out, exit_code=1), rb.REGISTRY["claude"])
+        self.assertEqual((status, fail), ("dropped", rb.FAILURE_MODEL))
+
+    def test_retryable_set(self):
+        self.assertEqual(rb.RETRYABLE_FAILURES, frozenset({rb.FAILURE_TIMEOUT, rb.FAILURE_INVALID}))
+
+
+class TestModelAnsweredParser(unittest.TestCase):
+    def test_banner_on_stderr(self):
+        self.assertEqual(rb.parse_model_answered("review body", "model: gpt-5.5\n"), "gpt-5.5")
+
+    def test_json_field_on_stderr(self):
+        self.assertEqual(rb.parse_model_answered("", '{"model":"claude-opus-4-8"}'),
+                         "claude-opus-4-8")
+
+    def test_none_when_absent(self):
+        self.assertIsNone(rb.parse_model_answered("a long review mentioning the model", ""))
+
+    def test_not_mined_from_stdout_prose(self):
+        # "model:" appearing in the review prose (stdout) must NOT be parsed.
+        self.assertIsNone(rb.parse_model_answered("the data model: users and orders", ""))
+
+    def test_antigravity_is_deliberately_unknown(self):
+        # agy silently substitutes models, so its parser is the None stub by design.
+        self.assertIsNone(rb.REGISTRY["antigravity"].model_answered("model: x", "model: x"))
+
+
+# --------------------------------------------------------------------------- #
+# M3 — round-1 fan-out (against mock CLIs)
+# --------------------------------------------------------------------------- #
+
+
+class TestRound1FanOut(EnvMixin):
+    def _setup(self, **kw):
+        config = _config(**kw)
+        blobs = rb.build_packet(config)
+        approval = rb.EgressApproval(True, "hash-bound", rb.packet_hash(blobs),
+                                     "2026-06-25T12:00:00", "test")
+        return config, blobs, approval
+
+    def test_all_seats_usable_and_models_captured(self):
+        config, blobs, approval = self._setup()
+        results = rb.run_round1(config, blobs, approval)
+        self.assertEqual([r.seat for r in results], ["claude", "codex", "gemini"])
+        self.assertTrue(all(r.usable for r in results))
+        self.assertTrue(all(r.attempts == 1 for r in results))
+        answered = {r.seat: r.model_answered for r in results}
+        self.assertEqual(answered["claude"], "claude-opus-4-8")
+        self.assertEqual(answered["codex"], "gpt-5.5")
+        self.assertEqual(answered["gemini"], "gemini-3.5-flash")
+
+    def test_same_material_independence_and_hash_binding(self):
+        config, blobs, approval = self._setup()
+        results = rb.run_round1(config, blobs, approval)
+        # source-hash identical across seats (same material); prompt-hash differs
+        # (claude carries the output-override, lenses differ) — both honest.
+        self.assertEqual(len({r.source_hash for r in results}), 1)
+        self.assertEqual(len({r.prompt_hash for r in results}), len(results))
+        self.assertEqual(results[0].source_hash, config.source.sha256)
+
+    def test_stub_seat_retries_then_drops_invalid(self):
+        # A seat that passes the preflight smoke ("ready") but returns a plan-mode
+        # stub at fan-out is retried once, then dropped InvalidOutput (the §13 /
+        # {{CLAUDE_OUTPUT_OVERRIDE}} detection).
+        os.environ["MOCK_CLAUDE_MODE"] = "stub"
+        config, blobs, approval = self._setup()
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval)}
+        self.assertEqual(results["claude"].status, "dropped")
+        self.assertEqual(results["claude"].failure_class, rb.FAILURE_INVALID)
+        self.assertEqual(results["claude"].attempts, 2)   # one retry
+        self.assertTrue(results["codex"].usable)
+
+    def test_timeout_seat_retries_then_drops(self):
+        os.environ["MOCK_GEMINI_MODE"] = "timeout"
+        config, blobs, approval = self._setup()
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval, timeout=1)}
+        self.assertEqual(results["gemini"].status, "dropped")
+        self.assertEqual(results["gemini"].failure_class, rb.FAILURE_TIMEOUT)
+        self.assertEqual(results["gemini"].attempts, 2)
+        self.assertTrue(results["gemini"].timed_out)
+
+    def test_auth_failure_is_not_retried(self):
+        os.environ["MOCK_GEMINI_MODE"] = "nogo_smoke"   # "auth error" -> empty stdout
+        config, blobs, approval = self._setup()
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval)}
+        self.assertEqual(results["gemini"].failure_class, rb.FAILURE_AUTH)
+        self.assertEqual(results["gemini"].attempts, 1)   # non-retryable
+
+    def test_degraded_seat_is_usable(self):
+        os.environ["MOCK_CODEX_MODE"] = "degraded"   # valid review, exit 1
+        config, blobs, approval = self._setup()
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval)}
+        self.assertEqual(results["codex"].status, "degraded")
+        self.assertTrue(results["codex"].usable)
+
+    def test_antigravity_model_answered_stays_unknown(self):
+        config, blobs, approval = self._setup(board="claude,codex,antigravity")
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval)}
+        self.assertTrue(results["antigravity"].usable)
+        self.assertIsNone(results["antigravity"].model_answered)   # never trusted
+
+    def test_local_seat_fans_out_and_stays_unknown(self):
+        # The runnable local fallback (ollama) works end-to-end through the fan-out:
+        # a usable review, provider=local (no external egress), model answered
+        # 'unknown' by design.
+        config, blobs, approval = self._setup(board="claude,codex,ollama")
+        results = {r.seat: r for r in rb.run_round1(config, blobs, approval)}
+        self.assertTrue(results["ollama"].usable)
+        self.assertEqual(results["ollama"].provider, "local")
+        self.assertIsNone(results["ollama"].model_answered)
+
+    def test_hash_drift_refuses_to_spawn(self):
+        # If the packet no longer matches the approved hash, nothing spawns.
+        config, blobs, approval = self._setup()
+        blobs[0] = rb.PacketBlob(seat=blobs[0].seat, provider=blobs[0].provider,
+                                 relpath=blobs[0].relpath, text=blobs[0].text + " TAMPERED")
+        with self.assertRaises(SystemExit) as cm:
+            rb.run_round1(config, blobs, approval)
+        self.assertEqual(cm.exception.code, rb.EXIT_EGRESS_BLOCKED)
+
+
+class TestRound1RunLevel(EnvMixin):
+    def test_under_two_usable_warns_but_writes_artifacts(self):
+        # Two seats pass the smoke but stub the review -> only one usable review ->
+        # not a board. The run still writes what it captured, but exits NO-GO.
+        os.environ["MOCK_CODEX_MODE"] = "stub"
+        os.environ["MOCK_GEMINI_MODE"] = "stub"
+        out = tempfile.mkdtemp(prefix="board-1voice-")
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",
+                                 "--timeout", "5"])
+        self.assertEqual(code, rb.EXIT_PREFLIGHT_NOGO)
+        self.assertIn("that is not a board", text)
+        # artifacts for the captured attempts are still present (idempotent writes)
+        self.assertTrue(os.path.exists(os.path.join(out, "round-1", "claude.md")))
+        self.assertTrue(os.path.exists(os.path.join(out, "round-1", "codex.raw")))
+        # the dropped seats' .md records the failure, not a fake review
+        with open(os.path.join(out, "round-1", "codex.md")) as fh:
+            self.assertIn("no usable review", fh.read())
+
+
+class TestSpawnProcessGroupKill(EnvMixin):
+    def test_timed_out_child_group_is_reaped(self):
+        # spawn() launches the child in its own session and kills the whole group
+        # on timeout. A backgrounded grandchild (sleep) must NOT survive — the bug
+        # plain subprocess.run(timeout=) would leave orphaned.
+        import time
+        work = tempfile.mkdtemp(prefix="board-pgkill-")
+        pidfile = os.path.join(work, "child.pid")
+        script = os.path.join(work, "forker.sh")
+        with open(script, "w") as fh:
+            fh.write("#!/usr/bin/env bash\nsleep 30 &\necho $! > '%s'\nwait\n" % pidfile)
+        os.chmod(script, 0o755)
+        result = rb.spawn(rb.REGISTRY["codex"], [script], timeout=1)
+        self.assertTrue(result.timed_out)
+        self.assertEqual(result.exit_code, 124)
+        # poll briefly for the backgrounded grandchild to be gone
+        with open(pidfile) as fh:
+            child = int(fh.read().strip())
+        for _ in range(30):
+            try:
+                os.kill(child, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.1)
+        else:
+            try:
+                os.kill(child, 9)
+            finally:
+                self.fail("grandchild sleep survived the timeout — process group not killed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Builds **milestone M3** of `design/run-board-conductor.md` on top of M1+M2 (PR #6), the toolchain preflight + ollama seat (PR #7). `run` now actually spawns the board for Round 1 and captures each seat's review — instead of stopping at the egress gate.

> **Stacked PR.** Base is `claude/run-board-toolchain-preflight` (PR #7) so this diff is M3-only. Rebase onto `main` once #6 + #7 merge.

## What M3 adds (design §11/§12/§13, §17 M3 row)
- **`spawn()` hardened** — `subprocess.Popen` + `start_new_session=True`, so a timed-out seat is killed as a **process group** (real CLIs fork workers; `subprocess.run` alone orphans them). Returns partial output + exit 124. Regression-tested with a forking child.
- **Round-1 fan-out (`run_round1`)** — re-asserts the egress hash at the point of no return, feeds each seat its **exact approved blob** (the bytes that leave == the bytes consent was bound to; codex/gemini carry the prompt in argv), runs seats in parallel, per-seat hard timeout (`--timeout`, default 900s/15min).
- **§13 failure protocol** — `classify_round1` with a **success shape/length check** (the `{{CLAUDE_OUTPUT_OVERRIDE}}` detection: a short/plan-shaped reply → `InvalidOutput`); classes `Timeout|AuthFailure|InvalidOutput|NoOutput|ModelNotFound`; **one retry** on `Timeout|InvalidOutput`, every other class drops. Auth is judged on **stderr only**, so a review that *discusses* 401s isn't misread as an auth failure.
- **Honest provenance** — `parse_model_answered` reads the answering model from **stderr** (never mined from the review prose), `None` when unreported. antigravity and the local ollama seat are structurally `None` (agy silently substitutes; local has no banner). claude/codex/gemini wired to it.
- **Artifacts (§12)** — `round-1/<seat>.md` (the review), `round-1/<seat>.raw` (the **black-box recorder**: argv with the prompt *elided*, source/prompt/packet hashes, answered model, exit/elapsed/attempts/status), `logs/<seat>-round-1.stderr`. `run-metadata.md` grows a Round 1 table. Pre-spawn artifacts are written *before* the fan-out (idempotent per-seat writes, §15).
- **Boundary** — `run` stops after Round 1 and hands the clean per-seat reviews to the synthesizer (§11). Round 2 / packets (M4) and the canonical verdict (M5) are later milestones; `<2` usable reviews exits NO-GO with guidance.

## Tests — 123 → **151**, all green
Shape check; `classify_round1` (every class); model-answered parser (incl. "not mined from stdout prose"); fan-out (models captured, same-material independence, retry on timeout/invalid, auth-not-retried, degraded-usable, antigravity/local stay unknown, **hash-drift refusal**); run-level `<2`-usable warning; **process-group-kill** regression. Mocks now answer the smoke ping with `ready` and a round-1 prompt with a full review (+ `model:` banner on stderr); new `stub` mode exercises the shape-check failure; ollama participates in the fan-out.

**Live re-verified:** `preflight` against the real claude/codex/gemini CLIs = **3/3 GO** (the spawn refactor works against real binaries). No real fan-out (token-spending egress) was run — that's M6's proof-of-life.

## Verify
```
cd skills/advisory-board
python3 -m unittest discover -s tests          # 151 OK
python3 scripts/run_board.py preflight --source tests/fixtures/sample-plan.md   # 3/3 GO
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)