### PR TITLE
Conductor M5: canonical verdict + resolved evidence (verify → consensus → validate/abstain)

### DIFF
--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -193,7 +193,7 @@ Load `references/prompt-templates.md` when running a board. Use the templates as
 
 ## Scripts
 
-Optional helpers in `scripts/` (Python 3 stdlib, no install): `board_verdict.py` validates `verdict.json` and gates CI on the verdict (`--gate`); `format_output.py` renders it as a TL;DR, PR comment, Slack message, or JSON; `render_handoff.py` renders `final-consensus.html` deterministically from a `handoff-data.json`. The skill runs fine without them — they're for wiring a board into CI and other tooling. See `scripts/README.md`.
+Optional helpers in `scripts/` (Python 3 stdlib, no install): `board_verdict.py` validates `verdict.json` and gates CI on the verdict (`--gate`; exit `1` block / `3` abstain when the board is torn or a citation is refuted); `verify_evidence.py` resolves a verdict's typed evidence and stamps each `verified`/`unverified`/`refuted`; `render_verdict.py` renders `final-consensus.md` from the verdict; `format_output.py` renders it as a TL;DR, PR comment, Slack message, or JSON; `render_handoff.py` renders `final-consensus.html` deterministically from a `handoff-data.json`. The skill runs fine without them — they're for wiring a board into CI and other tooling. See `scripts/README.md`.
 
 ## When To Stop
 

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -1,14 +1,18 @@
 # Verdict Schema — `verdict.json`
 
-Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readable summary so the board's conclusion can drive tooling — most usefully a **CI / launch gate** ("block the merge when the board says block"). It is a *view* of `final-consensus.md`; the two must agree.
+Alongside the prose handoff, a run emits `verdict.json`: the **canonical, machine-readable
+source of truth** for the board's conclusion. The Markdown (`final-consensus.md`) and HTML
+render *from* it — `scripts/render_verdict.py` renders the Markdown directly; the HTML renders
+via `scripts/render_handoff.py`. It drives tooling — most usefully a **CI / launch gate**
+("block the merge when the board says block"; "ask a human when the board is torn").
 
-## Schema (`advisory-board/verdict@1`)
+## Schema (`advisory-board/verdict@2`)
 
 ```json
 {
-  "schema": "advisory-board/verdict@1",
+  "schema": "advisory-board/verdict@2",
   "title": "Payments API idempotency keys",
-  "date": "2026-06-24",
+  "date": "2026-06-25",
   "verdict": "block",
   "confidence": "high",
   "unanimous": true,
@@ -23,11 +27,23 @@ Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readab
     }
   ],
   "blockers": [
-    { "title": "Atomic dedup", "body": "SET NX claim with an in-progress sentinel ..." }
+    {
+      "title": "Atomic dedup",
+      "body": "Without an atomic SET NX claim two concurrent same-key requests double-charge.",
+      "evidence": [
+        { "kind": "code", "path": "src/charges.py", "line": 42, "status": "verified" },
+        { "kind": "code", "path": "src/charges.py", "symbol": "charge_idempotent", "status": "verified" },
+        { "kind": "source", "url": "https://internal/plan", "quote": "store the key-to-response mapping in Redis", "status": "verified" }
+      ]
+    }
   ],
   "dissent": [
-    { "who": "Codex", "body": "..." }
+    { "who": "Codex", "body": "The rollout aggressiveness is debatable; the correctness blockers are not." }
   ],
+  "concerns": [
+    { "title": "TTL vs retry window", "body": "...", "evidence": [ { "kind": "judgment", "detail": "no client data" } ] }
+  ],
+  "caveats": ["Reviewed the plan, not the code — re-check against the actual handler."],
   "open_questions": ["..."],
   "next_actions": ["..."]
 }
@@ -35,36 +51,95 @@ Alongside the prose handoff, a run emits `verdict.json`: a small, machine-readab
 
 ### Fields
 
-- `verdict` — `ship` | `caution` | `block`. The board's final position, and the canonical gate axis.
-- `decision` (optional) — the native call when the decision isn't software-shipping (e.g. `invest` / `hold` / `wind-down`, or `go` / `no-go`). Map it onto `verdict` (invest→ship, hold→caution, wind-down/no-go→block); tooling reads `verdict`, while humans and `scripts/format_output.py` show `decision`.
-- `confidence` — `low` | `medium` | `high`.
+- `verdict` — `ship` | `caution` | `block`. The board's substantive position, and the canonical
+  gate axis. (`abstain` is **not** a `verdict` value — it is a *gate outcome* computed at gate
+  time from observed agreement; see below. It can't be self-asserted, by design.)
+- `decision` (optional) — the native call when the decision isn't software-shipping (e.g.
+  `invest` / `hold` / `wind-down`). Map it onto `verdict`; tooling reads `verdict`.
+- `confidence` — `low` | `medium` | `high`. A self-reported number; informational. **The gate
+  never reads it** — a gameable confidence must not move a gate.
 - `unanimous` — did every seat land on `verdict` in the final round.
-- `board[]` — one entry per seat; `round_verdicts` is per-round, `dropped` flags a seat that didn't finish (see `references/run-metadata-template.md`).
-- `blockers[]` / `dissent[]` / `open_questions[]` / `next_actions[]` — the same content the handoff shows.
+- `board[]` — one entry per seat; `round_verdicts` is per-round, `dropped` flags a seat that
+  didn't finish (see `references/run-metadata-template.md`).
+- `blockers[]` / `dissent[]` / `concerns[]` — verdict-moving claims; each may carry `evidence[]`.
+- `caveats[]` — the couldn't-verify bucket (strings, or `{claim, impact}`); rendered first-class.
+- `open_questions[]` / `next_actions[]` — the same content the handoff shows.
 
-Required: `schema`, `verdict`, `confidence`, `board`, `rounds`. The rest are recommended.
+### Typed `evidence[]` (new in @2)
+
+Each verdict-moving claim may cite structured, resolvable evidence. A claim citing no
+external referent stays a *concern*, not a *blocker* (a synthesis judgment, not a validator
+rule). Each item has a `kind`:
+
+- `code` — `path` plus either `line` (positive int) or `symbol` (string).
+- `source` — `url` plus a verbatim `quote`.
+- `command` — a `command` string (re-execution is deferred to v1.x).
+- `judgment` — no external referent, by design; carries optional `detail`.
+
+`scripts/verify_evidence.py` **resolves** a verdict's citations and stamps each with a
+`status`: `verified` (the cited line exists / the quoted text is in the captured packet),
+`unverified` (couldn't check — no source/packet, a missing file, or a deferred `command`), or
+`refuted` (we have the material and the line/quote is **not** there — a fabrication signal).
+`code` resolves against the source tree; `source` quotes resolve against the **captured
+packet, never a live URL fetch** (that would breach quarantine in gate mode). **Honesty
+(§9):** a `verified` stamp proves *the receipt resolves*, not that the inference is sound — it
+catches fabrication, not faulty reasoning.
 
 ## What `board_verdict.py` enforces
 
-Validation is strict so a malformed verdict can't quietly pass a gate. Beyond the required fields, `scripts/board_verdict.py` checks:
+Validation is strict so a malformed verdict can't quietly pass a gate. `scripts/board_verdict.py`
+accepts both `advisory-board/verdict@1` (the original; evidence-optional) and `@2` (which makes
+typed evidence first-class). Evidence is validated identically under either schema id — an `@1`
+file *may* carry `evidence[]`, and a malformed item is rejected regardless of version. It checks:
 
-- `schema` is exactly `advisory-board/verdict@1`.
-- `verdict` ∈ {ship, caution, block}; `confidence` ∈ {low, medium, high}; `rounds` is a positive integer.
-- each `board[]` seat has `seat`, `model`, and a non-empty `round_verdicts` (every entry ∈ {ship, caution, block}); `lens` and `dropped` are type-checked when present.
-- at least **two** seats actually ran — a seat with `dropped: true` doesn't count, because a one-voice board isn't a board.
-- if `unanimous` is present, it matches the seats' final-round verdicts (claiming unanimity the votes don't support is rejected).
+- `schema` ∈ {`advisory-board/verdict@1`, `advisory-board/verdict@2`}.
+- `verdict` ∈ {ship, caution, block}; `confidence` ∈ {low, medium, high}; `rounds` a positive int.
+- each `board[]` seat has `seat`, `model`, a non-empty `round_verdicts` (every entry a valid
+  verdict); `lens`/`dropped` type-checked when present.
+- at least **two** seats actually ran (a `dropped` seat doesn't count — a one-voice board isn't a board).
+- if `unanimous` is present, it matches the seats' final-round verdicts.
+- every `evidence[]` item (on blockers/dissent/concerns or at the top level) is well-formed for
+  its `kind`, and any `status` ∈ {verified, unverified, refuted}.
 
 A schema violation exits `2`, distinct from a clean file that simply fails the gate (`1`).
 
 ## Using it as a gate
-
-`scripts/board_verdict.py` validates the file and, with `--gate`, exits non-zero when the verdict meets a threshold:
 
 ```
 python3 scripts/board_verdict.py verdict.json --gate                    # fail on block
 python3 scripts/board_verdict.py verdict.json --gate --fail-on caution  # fail on caution or block
 ```
 
-Exit codes: `0` pass · `1` gate fail · `2` usage/schema error. Drop it into CI to hold a merge or launch until the board clears it.
+Exit codes: **`0`** pass · **`1`** gate fail · **`2`** usage/schema error · **`3`** abstain.
 
-See `references/output-formats.md` for turning the same file into a PR comment, Slack message, or TL;DR.
+**`abstain` ("human required").** A stochastic gate is safe when the board is decisive and
+dangerous exactly when it is torn. `--gate` returns the neutral exit `3` — neither pass nor
+fail — when:
+
+- the seats that ran **straddle the `--fail-on` threshold** (some would trip the gate, some
+  wouldn't) **and no single verdict holds a strict majority**; or
+- the **declared `verdict` clears the gate while a majority of seats trip it** — the verdict
+  contradicts the board it summarizes (an injected or fabricated "ship" over a block-leaning
+  board is exactly this case); or
+- **any citation is `refuted`** (a fabricated receipt in the decision document).
+
+Synthesis *escalation* is honored: a declared verdict that **trips** the gate fails it even if
+the seats lean the other way (blocking on a minority-but-correct concern is a legitimate, safe
+call) — only **de-escalation** below the observed board is distrusted. The decision reads
+**observed cross-seat agreement** (the `round_verdicts`), never the self-reported `confidence`.
+In CI, treat `3` as "don't auto-merge — a human must decide," distinct from a clean `block` (`1`).
+
+## The chain
+
+Synthesis stays a reasoning task (§11): the conductor produces clean per-round packets and hands
+them to the orchestrating agent (or one neutral seat) to fill `verdict.json` — it does **not**
+generate the verdict in code. Then the deterministic chain runs:
+
+```
+run_board.py verify    verdict.json --source <src-tree> --run <run-dir>   # stamp evidence
+run_board.py consensus verdict.json --run <run-dir> -o final-consensus.md # md (+ --html) from the verdict
+run_board.py validate  verdict.json --gate                                # ship / block / ABSTAIN
+```
+
+See `references/output-formats.md` for turning the same file into a PR comment, Slack message,
+or TL;DR (`scripts/format_output.py`).

--- a/skills/advisory-board/scripts/README.md
+++ b/skills/advisory-board/scripts/README.md
@@ -4,8 +4,10 @@
 
 | Script | Does | Reference |
 | ------ | ---- | --------- |
-| `run_board.py` | The **conductor** (M1–M4): deterministic seat-adapter registry, `--dry-run`, toolchain currency (`toolchain` — check/update stale CLIs, propose fallback model ids), executable preflight (GO/NO-GO), a hash-bound egress/quarantine gate before any provider call, the **round-1 fan-out** (real spawn, §13 failure protocol, per-seat `round-1/` artifacts), and **round 2** (cross-reading `board-packet-round-2.md`, debate fan-out, `run-metadata.tsv`). Calls the scripts below; never reimplements them. Implemented as the [`_conductor/`](#package-layout) package — `run_board.py` is a thin façade (re-exports the API + the CLI entry). | `design/run-board-conductor.md` |
-| `board_verdict.py` | Validate `verdict.json`; gate CI on the verdict (`--gate`). | `references/verdict-schema.md` |
+| `run_board.py` | The **conductor** (M1–M5): deterministic seat-adapter registry, `--dry-run`, toolchain currency (`toolchain` — check/update stale CLIs, propose fallback model ids), executable preflight (GO/NO-GO), a hash-bound egress/quarantine gate before any provider call, the **round-1 fan-out** (real spawn, §13 failure protocol, per-seat `round-1/` artifacts), **round 2** (cross-reading `board-packet-round-2.md`, debate fan-out, `run-metadata.tsv`), and the **canonical-verdict chain** (`verify` → `consensus` → `validate`). Calls the scripts below; never reimplements them. Implemented as the [`_conductor/`](#package-layout) package — `run_board.py` is a thin façade (re-exports the API + the CLI entry). | `design/run-board-conductor.md` |
+| `board_verdict.py` | Validate `verdict.json` (`@1`/`@2`); gate CI on the verdict (`--gate`) — pass `0` / fail `1` / schema `2` / **abstain `3`** when the board is torn, the declared verdict contradicts the observed board, or a citation is refuted. | `references/verdict-schema.md` |
+| `verify_evidence.py` | Resolve a verdict's typed `evidence[]` and stamp each `verified`/`unverified`/`refuted` — `code` `path:line`/`symbol` against the source, `source` quotes against the **captured packet** (never a live fetch). | `references/verdict-schema.md` |
+| `render_verdict.py` | Render `final-consensus.md` **from** the canonical `verdict.json` (evidence trail + couldn't-verify bucket); `--handoff-data`/`--html` derive the HTML via `render_handoff.py`. | `references/verdict-schema.md` |
 | `format_output.py` | Render `verdict.json` as a TL;DR, PR comment, Slack message, or normalized JSON. | `references/output-formats.md` |
 | `render_handoff.py` | Render `final-consensus.html` from a `handoff-data.json` — deterministic, fails on any leftover placeholder. | `references/handoff-template.html` |
 
@@ -52,14 +54,16 @@ python3 scripts/run_board.py preflight --source plan.md
 
 # full run: preflight + egress gate + round 1 + round 2 (cross-reading debate)
 # -> round-{1,2}/<seat>.md + .raw, board-packet-round-2.md, run-metadata.tsv
-# (stops at the last round's boundary; synthesis -> verdict.json is M5)
+# (stops at the last round's boundary; synthesis -> verdict.json is the agent's job, §11)
 python3 scripts/run_board.py run --source plan.md --sensitivity public --rounds 2 --cross-reading summaries
 
-# validate and summarize
-python3 scripts/board_verdict.py path/to/verdict.json
-
-# gate a merge: non-zero exit when the board says "block"
-python3 scripts/board_verdict.py path/to/verdict.json --gate
+# --- the canonical-verdict chain (after the agent fills verdict.json) ---
+# 1. resolve + stamp each typed citation verified/unverified/refuted
+python3 scripts/run_board.py verify <out>/verdict.json --source ./src --run <out>
+# 2. render final-consensus.md FROM the verdict (+ --html for the HTML)
+python3 scripts/run_board.py consensus <out>/verdict.json --run <out> -o <out>/final-consensus.md
+# 3. gate: 0 pass / 1 block / 2 schema / 3 ABSTAIN (board torn or a citation refuted)
+python3 scripts/run_board.py validate <out>/verdict.json --gate
 
 # turn the verdict into a PR comment
 python3 scripts/format_output.py path/to/verdict.json --format pr
@@ -70,4 +74,4 @@ python3 scripts/render_handoff.py path/to/handoff-data.json -o final-consensus.h
 
 > Paths above are relative to the **skill directory** — `skills/advisory-board/` in this repo, or the installed skill root (e.g. `~/.codex/skills/advisory-board/`) — the same convention as every `references/…` path in the skill. Run the scripts from there, or prefix them with that directory; `scripts/board_verdict.py` won't resolve from the repo root.
 
-`board_verdict.py` and `format_output.py` read the `verdict.json` a *completed* run emits next to `final-consensus.md` (produced once the conductor reaches synthesis — M5). `run_board.py` currently stops at the **last round's boundary**: it spawns the board for round 1 and (by default) a cross-reading round 2, capturing each seat's review under `round-1/` and `round-2/`, but does not yet synthesize a `verdict.json` (M5). See the repo-root `examples/payments-idempotency-review/verdict.json` for a filled-in sample, and `references/verdict-schema.md` for the schema.
+`board_verdict.py`, `verify_evidence.py`, `render_verdict.py`, and `format_output.py` all read the canonical `verdict.json`. `run_board.py run` stops at the **last round's boundary** and prints the synthesis chain: the agent (or one neutral seat) reads `round-N/*.md` and writes `verdict.json` (synthesis stays a reasoning task — §11; the conductor does **not** generate the verdict in code), then `verify` → `consensus` → `validate` run deterministically. See the repo-root `examples/payments-idempotency-review/verdict.json` for a filled-in sample (still `@1`; regenerated via the conductor in M6), and `references/verdict-schema.md` for the `@2` schema with typed evidence and the `abstain` gate.

--- a/skills/advisory-board/scripts/_conductor/cli.py
+++ b/skills/advisory-board/scripts/_conductor/cli.py
@@ -67,6 +67,8 @@ __all__ = [
     "_maybe_update_tools",
     "cmd_run",
     "cmd_render",
+    "cmd_consensus",
+    "cmd_verify",
     "cmd_validate",
     "_delegate",
     "add_run_options",
@@ -262,17 +264,33 @@ def cmd_run(args) -> int:
 
     last = rounds_done[-1]
     usable_last = [r for r in last if r.usable]
-    # M4 boundary: rounds are captured. The canonical verdict + resolved evidence
-    # (M5) is the next milestone — v1 hands the clean per-round artifacts to the
-    # synthesizer rather than flattening them in code (§11).
+    # Rounds are captured. Synthesis stays a REASONING task (§11): the conductor
+    # produces clean packets and hands the latest round's reviews to the orchestrating
+    # agent (or one neutral seat) to fill verdict.json — it does NOT generate the
+    # verdict in code. Once verdict.json exists, the deterministic M5 chain runs:
+    last_dir = f"{config.out_dir}/round-{last[0].round_no}"
     print(f"\nRounds complete ({len(rounds_done)} round(s)): {len(usable_last)} usable reviews in "
-          f"{config.out_dir}/round-{last[0].round_no}/. Next (M5, not yet automated): synthesize "
-          "the latest round into verdict.json, then `validate` it.")
+          f"{last_dir}/.")
+    print("\nNext — synthesize, then run the deterministic M5 chain:")
+    print(f"  1. Read {last_dir}/*.md and write {config.out_dir}/verdict.json "
+          "(advisory-board/verdict@2; cite typed evidence on each blocker).")
+    print(f"  2. run_board.py verify {config.out_dir}/verdict.json --source <src> --run {config.out_dir}")
+    print(f"  3. run_board.py consensus {config.out_dir}/verdict.json --run {config.out_dir} "
+          f"-o {config.out_dir}/final-consensus.md")
+    print(f"  4. run_board.py validate {config.out_dir}/verdict.json --gate")
     return EXIT_OK
 
 
 def cmd_render(args) -> int:
     return _delegate("render_handoff.py", args.passthrough)
+
+
+def cmd_consensus(args) -> int:
+    return _delegate("render_verdict.py", args.passthrough)
+
+
+def cmd_verify(args) -> int:
+    return _delegate("verify_evidence.py", args.passthrough)
 
 
 def cmd_validate(args) -> int:
@@ -317,9 +335,10 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="run_board.py",
-        description="The Advisory Board conductor (M1-M4: registry, dry-run, preflight, "
+        description="The Advisory Board conductor: registry, dry-run, preflight, "
                     "egress/quarantine gate, round-1 + round-2 fan-out with failure "
-                    "protocol and cross-reading packets).",
+                    "protocol and cross-reading packets, and the canonical-verdict chain "
+                    "(verify evidence -> consensus -> validate/gate).",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -359,11 +378,19 @@ def build_parser() -> argparse.ArgumentParser:
                         help="skip the confirmation prompt (for unattended runs)")
     p_tool.set_defaults(func=cmd_toolchain)
 
-    p_render = sub.add_parser("render", help="delegate to render_handoff.py")
+    p_render = sub.add_parser("render", help="delegate to render_handoff.py (HTML from handoff-data.json)")
     p_render.add_argument("passthrough", nargs=argparse.REMAINDER)
     p_render.set_defaults(func=cmd_render)
 
-    p_validate = sub.add_parser("validate", help="delegate to board_verdict.py")
+    p_verify = sub.add_parser("verify", help="delegate to verify_evidence.py (resolve + stamp evidence)")
+    p_verify.add_argument("passthrough", nargs=argparse.REMAINDER)
+    p_verify.set_defaults(func=cmd_verify)
+
+    p_consensus = sub.add_parser("consensus", help="delegate to render_verdict.py (final-consensus.md from verdict.json)")
+    p_consensus.add_argument("passthrough", nargs=argparse.REMAINDER)
+    p_consensus.set_defaults(func=cmd_consensus)
+
+    p_validate = sub.add_parser("validate", help="delegate to board_verdict.py (schema check + --gate)")
     p_validate.add_argument("passthrough", nargs=argparse.REMAINDER)
     p_validate.set_defaults(func=cmd_validate)
 

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -7,7 +7,17 @@ Examples:
   board_verdict.py verdict.json --gate --fail-on caution   exit 1 if "caution" or "block"
   board_verdict.py verdict.json --json                     echo normalized JSON
 
-Exit codes: 0 ok / gate pass, 1 gate fail, 2 usage or schema error.
+Exit codes:
+  0  ok / gate pass
+  1  gate fail (the board's verdict meets the fail threshold)
+  2  usage or schema error
+  3  gate abstain - the board is too split, the declared verdict contradicts the
+     observed board, or a citation was refuted; a human must decide. Neutral, not a fail.
+
+Schema: accepts advisory-board/verdict@1 and @2. @2 adds typed `evidence[]` on
+blockers/dissent/concerns (kinds code|source|command|judgment) and an optional
+per-citation `status` (verified|unverified|refuted) stamped by verify_evidence.py.
+
 Standard library only; no third-party dependencies.
 """
 from __future__ import annotations
@@ -15,17 +25,28 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 
 SEVERITY = {"ship": 0, "caution": 1, "block": 2}
 CONFIDENCE = {"low", "medium", "high"}
-SCHEMA = "advisory-board/verdict@1"
+SCHEMAS = {"advisory-board/verdict@1", "advisory-board/verdict@2"}
+CURRENT_SCHEMA = "advisory-board/verdict@2"
 REQUIRED = ("schema", "verdict", "confidence", "board", "rounds")
 SEAT_REQUIRED = ("seat", "model", "round_verdicts")
+EVIDENCE_KINDS = {"code", "source", "command", "judgment"}
+EVIDENCE_STATUS = {"verified", "unverified", "refuted"}
+# Top-level keys whose items may each carry an `evidence[]` list.
+EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
+
+EXIT_OK = 0
+EXIT_GATE_FAIL = 1
+EXIT_SCHEMA = 2
+EXIT_ABSTAIN = 3
 
 
 def die(message: str) -> None:
     print(f"error: {message}", file=sys.stderr)
-    raise SystemExit(2)
+    raise SystemExit(EXIT_SCHEMA)
 
 
 def load(path: str) -> dict:
@@ -42,14 +63,61 @@ def load(path: str) -> dict:
     return data
 
 
+def _validate_evidence_list(items, where: str) -> None:
+    """Structural check for a typed evidence[] list (schema @2)."""
+    if not isinstance(items, list):
+        die(f"{where}.evidence must be a list")
+    for index, ev in enumerate(items):
+        loc = f"{where}.evidence[{index}]"
+        if not isinstance(ev, dict):
+            die(f"{loc} must be an object")
+        kind = ev.get("kind")
+        if kind not in EVIDENCE_KINDS:
+            die(f"{loc}: kind must be one of {', '.join(sorted(EVIDENCE_KINDS))}; got {kind!r}")
+        if "status" in ev and ev["status"] not in EVIDENCE_STATUS:
+            die(f"{loc}: status must be one of {', '.join(sorted(EVIDENCE_STATUS))}; got {ev['status']!r}")
+        if kind == "code":
+            if not isinstance(ev.get("path"), str) or not ev["path"].strip():
+                die(f"{loc}: code evidence needs a non-empty 'path'")
+            has_line, has_symbol = "line" in ev, "symbol" in ev
+            if not (has_line or has_symbol):
+                die(f"{loc}: code evidence needs 'line' or 'symbol'")
+            if has_line:
+                line = ev["line"]
+                if isinstance(line, bool) or not isinstance(line, int) or line < 1:
+                    die(f"{loc}: code 'line' must be a positive integer; got {line!r}")
+            if has_symbol and (not isinstance(ev["symbol"], str) or not ev["symbol"].strip()):
+                die(f"{loc}: code 'symbol' must be a non-empty string")
+        elif kind == "source":
+            if not isinstance(ev.get("url"), str) or not ev["url"].strip():
+                die(f"{loc}: source evidence needs a non-empty 'url'")
+            if not isinstance(ev.get("quote"), str) or not ev["quote"].strip():
+                die(f"{loc}: source evidence needs a non-empty 'quote'")
+        elif kind == "command":
+            if not isinstance(ev.get("command"), str) or not ev["command"].strip():
+                die(f"{loc}: command evidence needs a non-empty 'command'")
+        # kind == "judgment": no external referent required, by design.
+
+
+def iter_evidence_containers(data: dict):
+    """Yield (label, obj) for every object that may carry an evidence[] list."""
+    for key in EVIDENCE_CONTAINERS:
+        items = data.get(key) or []
+        if isinstance(items, list):
+            for index, item in enumerate(items):
+                if isinstance(item, dict):
+                    yield f"{key}[{index}]", item
+    yield "verdict", data  # the top level may carry a bare evidence[]
+
+
 def validate(data: dict) -> None:
     """Strict schema check: a malformed verdict must not quietly pass a gate."""
     missing = [key for key in REQUIRED if key not in data]
     if missing:
         die(f"missing required field(s): {', '.join(missing)}")
 
-    if data["schema"] != SCHEMA:
-        die(f"schema must be {SCHEMA!r}; got {data['schema']!r}")
+    if data["schema"] not in SCHEMAS:
+        die(f"schema must be one of {', '.join(sorted(SCHEMAS))}; got {data['schema']!r}")
     if data["verdict"] not in SEVERITY:
         die(f"verdict must be one of {', '.join(SEVERITY)}; got {data['verdict']!r}")
     if data["confidence"] not in CONFIDENCE:
@@ -89,6 +157,10 @@ def validate(data: dict) -> None:
     if len(ran) < 2:
         die(f"a board needs >= 2 seats that ran; found {len(ran)} (dropped seats don't count)")
 
+    for key in EVIDENCE_CONTAINERS:
+        if key in data and not isinstance(data[key], list):
+            die(f"{key} must be a list when present; got {type(data[key]).__name__}")
+
     if "unanimous" in data:
         if not isinstance(data["unanimous"], bool):
             die(f"unanimous must be true or false; got {data['unanimous']!r}")
@@ -101,6 +173,93 @@ def validate(data: dict) -> None:
                 f"{data['verdict']!r}"
             )
 
+    for label, obj in iter_evidence_containers(data):
+        if "evidence" in obj:
+            _validate_evidence_list(obj["evidence"], label)
+
+
+# --------------------------------------------------------------------------- #
+# Gate logic
+# --------------------------------------------------------------------------- #
+
+
+def refuted_citations(data: dict) -> list:
+    """Locations of any `refuted` (fabricated-receipt) citation, anywhere in the verdict.
+
+    A refuted citation is a detected fabrication in the decision document — on a
+    blocker, a dissent, a concern, or the top level. The gate cannot tell a 'harmless'
+    fabrication from a load-bearing one, so it routes ALL of them to a human.
+    """
+    hits = []
+    for label, obj in iter_evidence_containers(data):
+        if any(isinstance(ev, dict) and ev.get("status") == "refuted"
+               for ev in (obj.get("evidence") or [])):
+            name = obj.get("title") or obj.get("who")
+            hits.append(f"{label}" + (f" ({name})" if name else ""))
+    return hits
+
+
+def gate_outcome(data: dict, fail_on: str):
+    """Decide the gate from OBSERVED cross-seat agreement, returning (outcome, reason).
+
+    outcome is 'pass' | 'fail' | 'abstain'. abstain ("human required") fires when:
+      1. any citation is refuted (a fabricated receipt in the decision basis); or
+      2. the seats that ran are genuinely torn at the threshold (some trip it, some
+         clear it, with no strict majority) — the regime where a stochastic gate is
+         dangerous; or
+      3. the declared `verdict` field *clears* the gate while a majority of seats
+         *trip* it — the verdict contradicts the board it summarizes (an injected or
+         fabricated 'ship' over a block-leaning board is exactly this case).
+
+    Synthesis ESCALATION is honored: a declared verdict that trips the gate fails it,
+    even if the seats lean the other way (blocking on a minority-but-correct concern is
+    a legitimate, safe call). Only DE-escalation below the observed board is distrusted.
+    The decision reads each seat's final-round verdict, never the gameable `confidence`.
+    """
+    refuted = refuted_citations(data)
+    if refuted:
+        return "abstain", "a citation was refuted (fabricated receipt): " + "; ".join(refuted)
+
+    ran = [seat for seat in data["board"] if not seat.get("dropped")]
+    finals = [seat["round_verdicts"][-1] for seat in ran]
+    threshold = SEVERITY[fail_on]
+    trip = [v for v in finals if SEVERITY[v] >= threshold]
+    clear = [v for v in finals if SEVERITY[v] < threshold]
+    top_count = Counter(finals).most_common(1)[0][1] if finals else 0
+    has_majority = top_count * 2 > len(finals)
+    if trip and clear and not has_majority:
+        return "abstain", (
+            f"board is split across the '{fail_on}' line with no majority "
+            f"(final-round verdicts: {finals}) - human review required"
+        )
+
+    declared_fails = SEVERITY[data["verdict"]] >= threshold
+    observed_majority_trips = len(trip) * 2 > len(finals)
+    if not declared_fails and observed_majority_trips:
+        return "abstain", (
+            f"declared verdict '{data['verdict']}' clears the '{fail_on}' gate but a "
+            f"majority of seats trip it (final-round verdicts: {finals}) - the verdict "
+            "contradicts the board; human review required"
+        )
+
+    if declared_fails:
+        return "fail", f"verdict '{data['verdict']}' meets threshold '{fail_on}'"
+    return "pass", f"verdict '{data['verdict']}' is below threshold '{fail_on}'"
+
+
+# --------------------------------------------------------------------------- #
+# Summary
+# --------------------------------------------------------------------------- #
+
+
+def _evidence_tally(data: dict) -> Counter:
+    tally = Counter()
+    for _, obj in iter_evidence_containers(data):
+        for ev in (obj.get("evidence") or []):
+            if isinstance(ev, dict):
+                tally[ev.get("status", "unchecked")] += 1
+    return tally
+
 
 def summarize(data: dict) -> str:
     board = data["board"]
@@ -110,24 +269,27 @@ def summarize(data: dict) -> str:
     if dropped:
         names = ", ".join(s.get("seat", "?") for s in dropped)
         seats_line += f", {len(dropped)} dropped ({names})"
-    return "\n".join(
-        [
-            f"title      : {data.get('title', '(untitled)')}",
-            f"verdict    : {data['verdict']}"
-            + (f" ({data['decision']})" if data.get("decision") else "")
-            + f"  ({data['confidence']} confidence)",
-            f"unanimous  : {data.get('unanimous', 'n/a')}",
-            f"rounds     : {data['rounds']}",
-            f"seats      : {seats_line}",
-            f"blockers   : {len(data.get('blockers', []))}",
-        ]
-    )
+    lines = [
+        f"title      : {data.get('title', '(untitled)')}",
+        f"verdict    : {data['verdict']}"
+        + (f" ({data['decision']})" if data.get("decision") else "")
+        + f"  ({data['confidence']} confidence)",
+        f"unanimous  : {data.get('unanimous', 'n/a')}",
+        f"rounds     : {data['rounds']}",
+        f"seats      : {seats_line}",
+        f"blockers   : {len(data.get('blockers', []))}",
+    ]
+    tally = _evidence_tally(data)
+    if tally:
+        parts = [f"{tally[k]} {k}" for k in ("verified", "unverified", "refuted", "unchecked") if tally.get(k)]
+        lines.append(f"evidence   : {', '.join(parts)}")
+    return "\n".join(lines)
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="Validate / gate an advisory-board verdict.json.")
     parser.add_argument("path", nargs="?", default="verdict.json", help="path to verdict.json (default: verdict.json)")
-    parser.add_argument("--gate", action="store_true", help="exit 1 when the verdict meets the fail threshold")
+    parser.add_argument("--gate", action="store_true", help="exit 1 when the verdict meets the fail threshold (3 to abstain)")
     parser.add_argument(
         "--fail-on", choices=("caution", "block"), default="block", help="threshold for --gate (default: block)"
     )
@@ -139,19 +301,20 @@ def main(argv=None) -> int:
     if args.as_json:
         json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
         print()
-        return 0
+        return EXIT_OK
 
     print(summarize(data))
 
     if args.gate:
-        if SEVERITY[data["verdict"]] >= SEVERITY[args.fail_on]:
-            print(
-                f"gate: FAIL - verdict '{data['verdict']}' meets threshold '{args.fail_on}'",
-                file=sys.stderr,
-            )
-            return 1
-        print(f"gate: pass - verdict '{data['verdict']}' is below threshold '{args.fail_on}'")
-    return 0
+        outcome, reason = gate_outcome(data, args.fail_on)
+        if outcome == "abstain":
+            print(f"gate: ABSTAIN - {reason}", file=sys.stderr)
+            return EXIT_ABSTAIN
+        if outcome == "fail":
+            print(f"gate: FAIL - {reason}", file=sys.stderr)
+            return EXIT_GATE_FAIL
+        print(f"gate: pass - {reason}")
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Render the human-facing consensus FROM the canonical verdict.json.
+
+The verdict.json is the source of truth (design section 9); the Markdown and HTML
+are *views* of it. This renders:
+
+  * final-consensus.md   - always; the decision, the blockers with their resolved
+                           evidence, the preserved dissent, the couldn't-verify
+                           bucket, the open questions, and the next actions.
+  * handoff-data.json    - with --handoff-data; a derived input for render_handoff.py
+                           so the HTML, too, renders FROM the verdict. Per-round prose
+                           is pulled from a run dir's round-N/<seat>.md when --run is
+                           given, else replaced with a pointer - never invented. The
+                           narrative the JSON references stays in the artifacts; we do
+                           not flatten it into the schema (section 9: don't over-flatten).
+  * final-consensus.html - with --html; same mapping, rendered through render_handoff.py.
+
+Usage:
+  render_verdict.py verdict.json                              -> final-consensus.md
+  render_verdict.py verdict.json -o consensus.md
+  render_verdict.py verdict.json --check                      print to stdout, write nothing
+  render_verdict.py verdict.json --handoff-data handoff-data.json [--run RUNDIR]
+  render_verdict.py verdict.json --html final-consensus.html [--run RUNDIR]
+
+Exit codes: 0 ok, 2 usage / data error.
+Standard library only; no third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import html
+import json
+import os
+import re
+import sys
+
+LABEL = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP YET"}
+STATUS_WORD = {"verified": "verified", "unverified": "unverified", "refuted": "REFUTED"}
+EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        die(f"{path}: not found")
+    except json.JSONDecodeError as exc:
+        die(f"{path}: invalid JSON ({exc})")
+    if not isinstance(data, dict):
+        die(f"{path}: top level must be a JSON object")
+    if "verdict" not in data:
+        die(f"{path}: missing required field 'verdict'")
+    return data
+
+
+# --------------------------------------------------------------------------- #
+# Markdown
+# --------------------------------------------------------------------------- #
+
+
+def _seats_line(data: dict) -> str:
+    parts = []
+    for seat in data.get("board", []):
+        name = seat.get("seat", "?")
+        lens = seat.get("lens")
+        model = seat.get("model")
+        tag = "/".join(x for x in (lens, model) if x)
+        parts.append(f"{name} ({tag})" if tag else name)
+    return " · ".join(parts)
+
+
+def _stance(data: dict) -> str:
+    if "unanimous" in data:
+        return "unanimous" if data.get("unanimous") else "split board"
+    ran = [s for s in data.get("board", []) if not s.get("dropped")]
+    finals = {s["round_verdicts"][-1] for s in ran if s.get("round_verdicts")}
+    return "unanimous" if finals == {data.get("verdict")} else "split board"
+
+
+def _evidence_label(ev: dict) -> str:
+    kind = ev.get("kind")
+    if kind == "code":
+        loc = f"{ev.get('path', '?')}:{ev['line']}" if "line" in ev else f"{ev.get('path', '?')}::{ev.get('symbol', '?')}"
+        return f"`{loc}` (code)"
+    if kind == "source":
+        quote = ev.get("quote", "")
+        snippet = quote if len(quote) <= 60 else quote[:57] + "..."
+        return f"{ev.get('url', '?')} — “{snippet}” (source)"
+    if kind == "command":
+        return f"`{ev.get('command', '?')}` (command)"
+    return f"judgment{(' — ' + ev['detail']) if ev.get('detail') else ''}"
+
+
+def _evidence_trail(ev: dict) -> str:
+    status = ev.get("status")
+    badge = f" — {STATUS_WORD.get(status, status)}" if status else " — unchecked"
+    if ev.get("kind") == "judgment":
+        badge = ""  # judgment has no external referent to resolve
+    return _evidence_label(ev) + badge
+
+
+def _iter_evidence(data: dict):
+    for key in EVIDENCE_CONTAINERS:
+        for item in (data.get(key) or []):
+            if isinstance(item, dict):
+                for ev in (item.get("evidence") or []):
+                    if isinstance(ev, dict):
+                        yield ev
+    for ev in (data.get("evidence") or []):
+        if isinstance(ev, dict):
+            yield ev
+
+
+def render_markdown(data: dict) -> str:
+    out = ["# Advisory Board — Final Consensus"]
+    if data.get("title"):
+        out.append(data["title"])
+    seats = _seats_line(data)
+    rounds = data.get("rounds", "?")
+    out.append(f"Board: {seats}. Rounds: {rounds}.")
+    out.append("")
+
+    label = data.get("decision") or LABEL.get(data.get("verdict"), str(data.get("verdict")))
+    out.append(f"## Verdict: {label} — {_stance(data)} ({data.get('confidence', '?')} confidence)")
+    if data.get("verdict_note"):
+        out.append(data["verdict_note"])
+    out.append("")
+
+    blockers = data.get("blockers", [])
+    if blockers:
+        out.append("## Consensus blockers (must fix before ship)")
+        for index, blocker in enumerate(blockers, 1):
+            title = blocker.get("title", "blocker")
+            body = blocker.get("body", "")
+            out.append(f"{index}. {title}" + (f" — {body}" if body else ""))
+            for ev in (blocker.get("evidence") or []):
+                if isinstance(ev, dict):
+                    out.append(f"   - evidence: {_evidence_trail(ev)}")
+        out.append("")
+
+    dissent = data.get("dissent", [])
+    if dissent:
+        out.append("## Hard dissent (preserved)")
+        for entry in dissent:
+            who = entry.get("who", "-")
+            out.append(f"- {who}: {entry.get('body', '')}")
+        out.append("")
+
+    couldnt = _couldnt_verify_lines(data)
+    if couldnt:
+        out.append("## What the board couldn't verify")
+        out += [f"- {line}" for line in couldnt]
+        out.append("")
+
+    questions = data.get("open_questions", [])
+    if questions:
+        out.append("## Open questions")
+        out += [f"- {q}" for q in questions]
+        out.append("")
+
+    actions = data.get("next_actions", [])
+    if actions:
+        out.append("## Next actions")
+        out += [f"- {a}" for a in actions]
+        out.append("")
+
+    if any(True for _ in _iter_evidence(data)):
+        out.append("---")
+        out.append("_Evidence status is a resolution check — it confirms the cited line exists "
+                   "or the quote is present in the captured material. It does not prove the "
+                   "inference drawn from it is sound (design §9)._")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def _couldnt_verify_lines(data: dict) -> list:
+    """The honesty bucket: authored caveats plus any unverified/refuted citation."""
+    lines = []
+    for caveat in (data.get("caveats") or []):
+        if isinstance(caveat, str):
+            lines.append(caveat)
+        elif isinstance(caveat, dict):
+            claim = caveat.get("claim", "")
+            impact = caveat.get("impact", "")
+            lines.append(claim + (f" — {impact}" if impact else ""))
+    for ev in _iter_evidence(data):
+        if ev.get("status") in ("unverified", "refuted"):
+            verb = "could not be resolved" if ev["status"] == "unverified" else "was REFUTED (not found)"
+            lines.append(f"{_evidence_label(ev)} {verb}.")
+    return lines
+
+
+# --------------------------------------------------------------------------- #
+# handoff-data.json (so render_handoff.py can produce the HTML from the verdict)
+# --------------------------------------------------------------------------- #
+
+_VERDICT_CLASS = {"ship": "ship", "caution": "caution", "block": "block"}
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+_ZW = "​"  # zero-width space
+
+
+def _nb(text: str) -> str:
+    """Neutralize render_handoff's `{{TOKEN}}` sentinel so literal braces in user content
+    (a plan quoting a template, a Jinja/env snippet) can't survive into the HTML and trip
+    its leftover-token guard (which dies — aborting --html). Inserting a zero-width space
+    after each `{` breaks every brace adjacency; the visible text is unchanged. Works in
+    both pass-through (RAW) and renderer-escaped (non-RAW) slots — the ZWSP survives
+    html.escape, so the same string is safe either way."""
+    return str(text).replace("{", "{" + _ZW)
+
+
+def _raw(text: str) -> str:
+    """For a render_handoff RAW (pass-through HTML) slot: HTML-escape, then neutralize braces."""
+    return _nb(html.escape(text))
+
+
+def _plain(text: str) -> str:
+    """For a render_handoff non-RAW slot (the renderer html-escapes it): neutralize braces only."""
+    return _nb(text)
+
+
+def _md_to_html(text: str) -> str:
+    """Minimal, honest md->HTML: escape, turn `code` into <code>, paragraph-wrap on
+    blank lines. We deliberately do NOT reconstruct rich structure the JSON never
+    held - the full prose lives in the round-N/<seat>.md artifacts this points at."""
+    blocks = re.split(r"\n\s*\n", text.strip())
+    paras = []
+    for block in blocks:
+        escaped = _raw(block.strip())
+        escaped = _BACKTICK.sub(lambda m: "<code>" + m.group(1) + "</code>", escaped)
+        escaped = escaped.replace("\n", "<br>\n")
+        if escaped:
+            paras.append(f"<p>{escaped}</p>")
+    return "\n".join(paras)
+
+
+def _round_review(run_dir, seat_name: str, round_no: int, verdict: str) -> str:
+    if run_dir:
+        for candidate in glob.glob(os.path.join(run_dir, f"round-{round_no}", "*.md")):
+            if os.path.splitext(os.path.basename(candidate))[0].lower() == seat_name.lower():
+                try:
+                    with open(candidate, encoding="utf-8", errors="replace") as handle:
+                        return _md_to_html(handle.read())
+                except OSError:
+                    break
+    pointer = _nb(f"round-{round_no}/{html.escape(seat_name.lower())}.md")
+    return f"<p>Round {round_no} verdict: <strong>{_nb(html.escape(verdict))}</strong>. Full review in <code>{pointer}</code>.</p>"
+
+
+def build_handoff_data(data: dict, run_dir=None) -> dict:
+    verdict = data.get("verdict", "")
+    label = data.get("decision") or LABEL.get(verdict, str(verdict))
+    hd = {
+        # non-RAW slots (the renderer escapes them) -> _plain; RAW slots -> _raw.
+        "title": _plain(data.get("title", "Advisory Board review")),
+        "subtitle": "Rendered from the canonical verdict.json.",
+        "date": _plain(data.get("date", "")),
+        "board": _raw(" · ".join(s.get("seat", "?") for s in data.get("board", []))),
+        "rounds": str(data.get("rounds", "")),
+        "verdict": _plain(f"{label} — {_stance(data)}"),
+        "verdict_class": _VERDICT_CLASS.get(verdict, ""),
+        "verdict_note": _raw(data["verdict_note"]) if data.get("verdict_note") else "",
+        "plan": _raw(data.get("title", "")),
+        "metadata": "Rendered from <code>verdict.json</code> by <code>scripts/render_verdict.py</code>.",
+        "dissent_flag": "Dissent on the record" if data.get("dissent") else "",
+        "seats": [],
+        "blockers": [{"blocker_title": _plain(b.get("title", "blocker")),
+                      "blocker_body": _raw(b.get("body", ""))} for b in data.get("blockers", [])],
+        "dissents": [{"dissent_who": _plain(d.get("who", "-")),
+                      "dissent_body": _raw(d.get("body", ""))} for d in data.get("dissent", [])],
+        "caveats": [{"caveat_claim": _raw(line), "caveat_impact": ""}
+                    for line in _couldnt_verify_lines(data)],
+        "questions": [{"question": _raw(q)} for q in data.get("open_questions", [])],
+        "actions": [{"action": _raw(a)} for a in data.get("next_actions", [])],
+    }
+    for seat in data.get("board", []):
+        name = seat.get("seat", "?")
+        rounds = []
+        for round_no, rv in enumerate(seat.get("round_verdicts", []), 1):
+            rounds.append({
+                "round_label": f"Round {round_no}",
+                "round_verdict": _plain(LABEL.get(rv, rv)),
+                "round_verdict_class": _VERDICT_CLASS.get(rv, ""),
+                "round_confidence": "",
+                "round_review": _round_review(run_dir, name, round_no, LABEL.get(rv, rv)),
+            })
+        lens = seat.get("lens", "") or ""
+        hd["seats"].append({
+            "seat_name": _plain(name),
+            "seat_lens": _plain(lens.capitalize() + (" lens" if lens else "")),
+            "seat_model": _plain(seat.get("model", "")),
+            "seat_status": "dropped" if seat.get("dropped") else "",
+            "seat_status_class": "dropped" if seat.get("dropped") else "",
+            "seat_highlight": "",
+            "rounds": rounds,
+        })
+    return hd
+
+
+def _render_html(hd: dict) -> str:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import render_handoff  # sibling script
+    with open(render_handoff.default_template(), encoding="utf-8") as handle:
+        template = handle.read()
+    return render_handoff.render(hd, template)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Render final-consensus.md / handoff-data.json / HTML from verdict.json.")
+    parser.add_argument("path", help="path to verdict.json")
+    parser.add_argument("-o", "--out", default="final-consensus.md", help="Markdown output path (default: final-consensus.md)")
+    parser.add_argument("--check", action="store_true", help="print Markdown to stdout; write nothing")
+    parser.add_argument("--handoff-data", dest="handoff_data", help="also write a derived handoff-data.json here")
+    parser.add_argument("--html", help="also write final-consensus.html here (via render_handoff.py)")
+    parser.add_argument("--run", dest="run_dir", help="a run dir; pulls per-round prose from its round-N/<seat>.md")
+    args = parser.parse_args(argv)
+
+    data = load(args.path)
+    markdown = render_markdown(data)
+
+    if args.check:
+        sys.stdout.write(markdown)
+    else:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+        print(f"wrote {args.out} ({len(markdown)} bytes)")
+
+    if args.handoff_data or args.html:
+        hd = build_handoff_data(data, run_dir=args.run_dir)
+        if args.handoff_data:
+            with open(args.handoff_data, "w", encoding="utf-8") as handle:
+                json.dump(hd, handle, indent=2, ensure_ascii=False)
+                handle.write("\n")
+            print(f"wrote {args.handoff_data}")
+        if args.html:
+            out_html = _render_html(hd)
+            with open(args.html, "w", encoding="utf-8") as handle:
+                handle.write(out_html)
+            print(f"wrote {args.html} ({len(out_html)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/advisory-board/scripts/run_board.py
+++ b/skills/advisory-board/scripts/run_board.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""run_board.py — the Advisory Board conductor (M1 + M2 + M3 + M4).
+"""run_board.py — the Advisory Board conductor (M1 + M2 + M3 + M4 + M5).
 
 The skill's controls used to be prose addressed to the very agent that wants to
 run the board. This conductor turns the load-bearing mechanics into code: a
@@ -29,18 +29,28 @@ This file implements milestones M1, M2 and M3 of design/run-board-conductor.md:
       its own packet hash but reuses the run's approval (the run-card disclosed the
       multi-round plan). Round 3 / `auto` stay v1.x.
 
-What is deliberately NOT here yet (later milestones): the canonical verdict +
-resolved evidence (M5). `run` stops at the last round's boundary and hands the
-clean per-seat reviews to the synthesizer (§11) rather than flattening them in
-code.
+  M5  Canonical verdict + resolved evidence. `run` still stops at the last round's
+      boundary and hands the clean per-seat reviews to the synthesizer (§11) — the
+      conductor does NOT generate the verdict in code. Once verdict.json exists
+      (schema advisory-board/verdict@2, with typed evidence[] on blockers), the
+      deterministic chain runs as subcommands: `verify` resolves and stamps each
+      citation (verify_evidence.py — code path:line/symbol against the source,
+      source quotes against the captured packet, never a live fetch), `consensus`
+      renders final-consensus.md FROM the verdict (render_verdict.py), and
+      `validate --gate` decides ship/block/ABSTAIN (board_verdict.py). `abstain`
+      ("human required", exit 3) fires when the board is torn across the gate line
+      with no majority, or a blocker rests on a refuted citation — driven by
+      OBSERVED cross-seat agreement, never self-reported confidence.
 
 Subcommands:
   init        resolve config and emit run-recipe.yaml + the run-card (no spawn)
   toolchain   check each seat CLI vs its latest release; --update upgrades stale ones
   preflight   probe each seat (version / smoke ping) and print a GO/NO-GO table
   run         resolve -> preflight -> egress gate -> round-1 -> round-2 -> artifacts
-  render      delegate to render_handoff.py (final-consensus.html from data)
-  validate    delegate to board_verdict.py (validate / gate verdict.json)
+  verify      delegate to verify_evidence.py (resolve + stamp a verdict's evidence)
+  consensus   delegate to render_verdict.py (final-consensus.md from verdict.json)
+  render      delegate to render_handoff.py (final-consensus.html from handoff-data.json)
+  validate    delegate to board_verdict.py (validate / gate verdict.json; abstain = exit 3)
 
 Toolchain currency (the `toolchain` subcommand, also `run --update-tools`) keeps a
 stale CLI from 404-ing a freshly-renamed frontier model id: it reads installed-vs-

--- a/skills/advisory-board/scripts/verify_evidence.py
+++ b/skills/advisory-board/scripts/verify_evidence.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Resolve a verdict.json's typed evidence against the reviewed material and stamp
+each citation verified | unverified | refuted.
+
+WHAT THIS PROVES (design section 9 - read it before trusting a green stamp): that
+the *receipt resolves* - the cited line exists, the quoted text is present in the
+captured packet. It does NOT prove the inference drawn from that receipt is sound.
+It catches fabrication (a hallucinated path:line, a quote that was never in the
+source), not faulty reasoning. The scary failure is a hallucinated citation driving
+a false gate; this is the cheapest partial defense against it.
+
+Resolution respects quarantine:
+  * `source` quotes are checked against the CAPTURED PACKET, never by re-fetching
+    the URL (a live fetch would reintroduce the network in gate mode).
+  * `command` re-execution is deferred to v1.x -> those citations stamp `unverified`.
+  * `judgment` evidence has no external referent and is left unstamped, by design.
+
+How each kind resolves:
+  code  path:line   -> verified  if the file has that line;
+                       refuted   if the file exists but the line is out of range;
+                       unverified if the file isn't under --source, or no --source.
+  code  path:symbol -> verified  if the symbol token appears in the cited file;
+                       refuted   if the file exists but the token does not;
+                       unverified if the file isn't found / no --source.
+  source url+quote  -> verified  if the (whitespace-normalized) quote is in the packet;
+                       refuted   if a packet was given and the quote is absent;
+                       unverified if no packet was given.
+
+A missing file is `unverified`, not `refuted`: --source may be an incomplete tree,
+and we refuse to cry fabrication on a file we simply weren't handed. A file we DO
+have with a bad line/symbol is `refuted` - that is a positive contradiction.
+
+Usage:
+  verify_evidence.py verdict.json --source SRC --packet PKT      stamp in place
+  verify_evidence.py verdict.json --run RUNDIR                   derive the packet from a run dir
+  verify_evidence.py verdict.json --source SRC -o stamped.json   write elsewhere
+  verify_evidence.py verdict.json --source SRC --check           report only; write nothing
+
+Exit codes: 0 ok, 2 usage / bad JSON. Gating on the stamps is board_verdict.py's job.
+Standard library only; no third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
+_WS = re.compile(r"\s+")
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _norm(text: str) -> str:
+    return _WS.sub(" ", text).strip()
+
+
+def iter_evidence_containers(data: dict):
+    """Yield every object that may carry an evidence[] list (blockers/dissent/concerns + top level)."""
+    for key in EVIDENCE_CONTAINERS:
+        items = data.get(key) or []
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict):
+                    yield item
+    yield data
+
+
+def resolve_file(source_root, rel: str):
+    """Return the path to the cited file, or None if it can't be SAFELY resolved.
+
+    --source may be a single file (single-file review) or a directory root. We refuse
+    to resolve an absolute path or one that escapes the root with '..' (a hallucinated
+    citation must not read arbitrary files off disk and earn a green stamp), and a
+    single-file source matches only a bare-filename citation OF THAT FILE (a different
+    directory that merely shares the basename must not resolve to it).
+    """
+    if source_root is None or not rel:
+        return None
+    rel = rel.replace("\\", "/")
+    if os.path.isabs(rel) or any(part == ".." for part in rel.split("/")):
+        return None
+    if os.path.isfile(source_root):
+        return source_root if rel == os.path.basename(source_root) else None
+    candidate = os.path.join(source_root, rel)
+    return candidate if os.path.isfile(candidate) else None
+
+
+def _read_lines(path: str):
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read().splitlines()
+
+
+def resolve_code(ev: dict, source_root) -> str:
+    target = resolve_file(source_root, ev.get("path", ""))
+    if target is None:
+        return "unverified"  # no --source, or the file isn't in the tree we were handed
+    try:
+        lines = _read_lines(target)
+    except OSError:
+        return "unverified"
+    if "line" in ev:
+        line = ev["line"]
+        if isinstance(line, bool) or not isinstance(line, int) or line < 1:
+            return "unverified"  # malformed line locator - can't resolve, don't crash
+        return "verified" if line <= len(lines) else "refuted"
+    symbol = ev.get("symbol", "")
+    if symbol and re.search(r"\b" + re.escape(symbol) + r"\b", "\n".join(lines)):
+        return "verified"
+    return "refuted"
+
+
+def resolve_source(ev: dict, packet_text) -> str:
+    if packet_text is None:
+        return "unverified"  # no captured packet to check against; we never live-fetch
+    quote = _norm(ev.get("quote", ""))
+    if not quote:
+        return "unverified"
+    return "verified" if quote in _norm(packet_text) else "refuted"
+
+
+def load_packet_text(packet, run_dir):
+    """Concatenate the captured-packet text. The packet is what was EGRESSED - the
+    `prompts/*.prompt` blobs under a run dir - never a re-fetch of any cited URL."""
+    paths = []
+    if run_dir:
+        prompts = os.path.join(run_dir, "prompts")
+        if os.path.isdir(prompts):
+            paths += sorted(glob.glob(os.path.join(prompts, "*.prompt")))
+        elif os.path.isdir(run_dir):
+            paths += sorted(glob.glob(os.path.join(run_dir, "*.prompt")))
+    if packet:
+        if os.path.isdir(packet):
+            for pattern in ("*.prompt", "*.md", "*.txt"):
+                paths += sorted(glob.glob(os.path.join(packet, pattern)))
+        elif os.path.isfile(packet):
+            paths.append(packet)
+        else:
+            die(f"--packet: {packet} not found")
+    seen, uniq = set(), []  # --packet and --run can name the same prompts dir
+    for path in paths:
+        key = os.path.abspath(path)
+        if key not in seen:
+            seen.add(key)
+            uniq.append(path)
+    paths = uniq
+    if not paths:
+        return None
+    chunks = []
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                chunks.append(handle.read())
+        except OSError:
+            pass
+    return "\n".join(chunks) if chunks else None
+
+
+def stamp(data: dict, source_root, packet_text) -> dict:
+    """Resolve every code/source/command citation and write its `status`. Mutates data."""
+    counts = {"verified": 0, "unverified": 0, "refuted": 0, "skipped": 0}
+    for obj in iter_evidence_containers(data):
+        for ev in (obj.get("evidence") or []):
+            if not isinstance(ev, dict):
+                continue
+            kind = ev.get("kind")
+            if kind == "code":
+                status = resolve_code(ev, source_root)
+            elif kind == "source":
+                status = resolve_source(ev, packet_text)
+            elif kind == "command":
+                status = "unverified"  # re-execution deferred to v1.x
+            else:  # judgment / unknown: no external referent to resolve
+                counts["skipped"] += 1
+                continue
+            ev["status"] = status
+            counts[status] += 1
+    return counts
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve and stamp a verdict.json's typed evidence.")
+    parser.add_argument("path", help="path to verdict.json")
+    parser.add_argument("--source", help="source tree (dir) or file for `code` path:line / symbol resolution")
+    parser.add_argument("--packet", help="captured packet (file or dir) for `source` quote resolution")
+    parser.add_argument("--run", dest="run_dir", help="a run dir; derives --packet from its prompts/")
+    parser.add_argument("-o", "--out", help="write stamped JSON here (default: in place)")
+    parser.add_argument("--check", action="store_true", help="report only; write nothing")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        die(f"{args.path}: not found")
+    except json.JSONDecodeError as exc:
+        die(f"{args.path}: invalid JSON ({exc})")
+    if not isinstance(data, dict):
+        die(f"{args.path}: top level must be a JSON object")
+
+    packet_text = load_packet_text(args.packet, args.run_dir)
+    counts = stamp(data, args.source, packet_text)
+
+    total = sum(counts.values()) - counts["skipped"]
+    print(
+        f"resolved {total} citation(s): "
+        f"{counts['verified']} verified, {counts['unverified']} unverified, "
+        f"{counts['refuted']} refuted"
+        + (f" ({counts['skipped']} judgment/skipped)" if counts["skipped"] else "")
+    )
+    if not args.source and any(
+        ev.get("kind") == "code"
+        for obj in iter_evidence_containers(data)
+        for ev in (obj.get("evidence") or [])
+        if isinstance(ev, dict)
+    ):
+        print("note: no --source given - `code` citations stamped unverified (could not resolve).",
+              file=sys.stderr)
+    if packet_text is None and any(
+        ev.get("kind") == "source"
+        for obj in iter_evidence_containers(data)
+        for ev in (obj.get("evidence") or [])
+        if isinstance(ev, dict)
+    ):
+        print("note: no --packet/--run given - `source` quotes stamped unverified (no captured packet).",
+              file=sys.stderr)
+    if counts["refuted"]:
+        print(f"WARNING: {counts['refuted']} citation(s) REFUTED - a cited line/quote was not "
+              "found in the material. Inspect before trusting the verdict.", file=sys.stderr)
+
+    if args.check:
+        print("(--check: no file written)")
+        return 0
+
+    out_path = args.out or args.path
+    with open(out_path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -1,10 +1,11 @@
 # Conductor tests
 
-Tests for `scripts/run_board.py` (the M1–M4 conductor; implemented as the
-`scripts/_conductor/` package behind a thin `run_board` façade). Python 3
-standard library only; they run the whole pipeline — including the real round-1
-and round-2 fan-outs — against **mock CLIs** on `PATH`, so no provider tokens are
-spent and nothing leaves the machine.
+Tests for `scripts/run_board.py` (the M1–M5 conductor; implemented as the
+`scripts/_conductor/` package behind a thin `run_board` façade) and the sibling
+scripts it calls (`board_verdict.py`, `verify_evidence.py`, `render_verdict.py`).
+Python 3 standard library only; they run the whole pipeline — including the real
+round-1 and round-2 fan-outs — against **mock CLIs** on `PATH`, so no provider
+tokens are spent and nothing leaves the machine.
 
 ## Run
 
@@ -28,6 +29,12 @@ needed beyond a Python 3 interpreter.
 | `mocks/{claude,codex,gemini,agy,ollama}` | banner-accurate CLI stubs; behavior switched by `MOCK_<SEAT>_MODE` (`go`/`nogo_version`/`nogo_smoke`/`empty`/`degraded`/`timeout`/`model_not_found`/`stub`; gemini also `model_proposal`) and argv captured to `MOCK_ARGV_LOG`. The smoke ping returns `ready`; a round-1 prompt returns a full multi-section review (with a `model:` banner on stderr) so a single test exercises preflight **and** the fan-out — `stub` returns a short plan-style reply (the §13 shape-check failure). `claude`/`codex`/`agy` also mock `update` (force failure with `MOCK_<SEAT>_UPDATE_FAIL=1`); `agy` also mocks `models`. (`agy` is the Antigravity seat — `MOCK_AGY_VERSION` sets its reported version. `ollama` is the local seat — prompt on stdin, no `model_not_found`/`update` arms; `MOCK_OLLAMA_VERSION` sets its reported version, default `0.5.0`) |
 | `mocks/{npm,brew}` | package-manager stubs for the toolchain check/update: latest version is env-controlled (`MOCK_NPM_CLAUDE`/`MOCK_NPM_CODEX`, `MOCK_BREW_GEMINI`/`MOCK_BREW_OLLAMA` formulae, `MOCK_BREW_CASK` for the antigravity cask; default `9.9.9` → stale); `brew upgrade` fails with `MOCK_BREW_UPGRADE_FAIL=1` |
 | `fixtures/sample-plan.md` | a small, stable source for deterministic runs |
+| `fixtures/{verdict-m5.json, src/charges.py, packet.txt}` | M5 evidence-resolution fixtures — a `@2` verdict exercising every kind/status, a 15-line source file (`charge_idempotent`), and a captured packet a `source` quote resolves against |
+
+The M5 canonical-verdict layer (`TestSchemaV2Validation`, `TestGateAbstain`,
+`TestEvidenceResolution`, `TestRenderVerdict`, `TestM5ChainDelegation`) tests the
+schema `@2` validation, the abstain gate, evidence resolution/stamping, and the
+`verify` → `consensus` → `validate` chain (see "the M5 invariants" below).
 
 ## The safety properties the suite locks
 
@@ -86,3 +93,31 @@ The M4 round-2 layer adds:
 - **`--rounds`/`--cross-reading` honored** — `--rounds 1` skips round 2; `none`
   skips the board packet; `--rounds 3`/`auto` caps at round 2 with a v1.x note;
   `<2` usable round-1 reviews skips round 2 but still records what was captured.
+
+The M5 canonical-verdict layer adds:
+
+- **The schema `@2` validates strictly** (`TestSchemaV2Validation`) — `@1` files
+  still pass; a bad evidence kind/status, a `code` citation missing `path` or
+  `line`/`symbol`, or a `source` citation missing its `quote` is rejected with the
+  schema exit code; a `judgment` citation needs no referent.
+- **Evidence resolution respects quarantine** (`TestEvidenceResolution`) — `code`
+  `path:line`/`symbol` resolves against the source (in-range → verified, out-of-range
+  / absent-symbol → refuted, missing-file / no-source → unverified); `source` quotes
+  resolve against the **captured packet only** (present → verified, absent → refuted,
+  no-packet → unverified — it never reaches the URL); `command` is unverified
+  (deferred), `judgment` is left unstamped.
+- **The gate abstains in the torn regime** (`TestGateAbstain`, `TestGateReconcileVerdictVsBoard`,
+  `TestGateRefutedAnywhere`) — `--gate` returns exit `3` ("human required") when the seats that
+  ran straddle the `--fail-on` line with no strict majority, when the declared `verdict` clears
+  the gate while a majority of seats trip it (a verdict that contradicts its board — the
+  injected-"ship" case), or when any citation is refuted. Synthesis *escalation* (a declared
+  verdict that trips the gate) still fails decisively; the decision reads observed
+  `round_verdicts`, never the gameable `confidence`.
+- **md + HTML render FROM the verdict** (`TestRenderVerdict`) — `final-consensus.md`
+  carries the decision, the evidence trail with stamps, and the couldn't-verify
+  bucket; the derived `handoff-data.json` round-trips cleanly through
+  `render_handoff.py`; per-round prose is pulled from `round-N/<seat>.md` when a run
+  dir is given, never invented.
+- **The chain wires through the conductor** (`TestM5ChainDelegation`) — `verify` /
+  `consensus` / `validate` delegate to the sibling scripts, the abstain exit
+  propagates, and `run` prints the synthesis-then-chain guidance.

--- a/skills/advisory-board/tests/fixtures/packet.txt
+++ b/skills/advisory-board/tests/fixtures/packet.txt
@@ -1,0 +1,5 @@
+MATERIAL UNDER REVIEW (captured packet — what was egressed; quotes resolve against this).
+
+The plan stores the key-to-response mapping in Redis with a 24h TTL. It does not
+take an atomic SET NX claim on receipt, so two concurrent same-key requests both
+miss the cache and double-charge.

--- a/skills/advisory-board/tests/fixtures/src/charges.py
+++ b/skills/advisory-board/tests/fixtures/src/charges.py
@@ -1,0 +1,15 @@
+# A tiny stand-in source file for evidence-resolution tests.
+# Deterministic: 15 lines, one named symbol `charge_idempotent`.
+import redis
+
+STORE = redis.Redis()
+
+
+def charge_idempotent(key, request):
+    """Claim the key atomically, then charge."""
+    claimed = STORE.set(key, "in-progress", nx=True)
+    if not claimed:
+        return STORE.get(key)
+    result = do_charge(request)
+    STORE.set(key, result)
+    return result

--- a/skills/advisory-board/tests/fixtures/verdict-m5.json
+++ b/skills/advisory-board/tests/fixtures/verdict-m5.json
@@ -1,0 +1,44 @@
+{
+  "schema": "advisory-board/verdict@2",
+  "title": "Payments API idempotency keys",
+  "date": "2026-06-25",
+  "verdict": "block",
+  "confidence": "high",
+  "unanimous": true,
+  "rounds": 2,
+  "board": [
+    { "seat": "Claude", "model": "claude-opus-4-8", "lens": "architecture", "round_verdicts": ["block", "block"], "dropped": false },
+    { "seat": "Codex", "model": "gpt-5.5", "lens": "implementation/testing", "round_verdicts": ["caution", "block"], "dropped": false },
+    { "seat": "Gemini", "model": "gemini-3.5-flash", "lens": "product/ops", "round_verdicts": ["block", "block"], "dropped": false }
+  ],
+  "blockers": [
+    {
+      "title": "Atomic dedup",
+      "body": "Without an atomic SET NX claim two concurrent same-key requests both miss the cache and double-charge.",
+      "evidence": [
+        { "kind": "code", "path": "charges.py", "line": 10, "detail": "the SET NX claim" },
+        { "kind": "code", "path": "charges.py", "symbol": "charge_idempotent" },
+        { "kind": "source", "url": "https://internal/plan", "quote": "atomic SET NX claim on receipt" }
+      ]
+    },
+    {
+      "title": "Phantom blocker (fabricated)",
+      "body": "Cites a line that does not exist and a quote never in the packet.",
+      "evidence": [
+        { "kind": "code", "path": "charges.py", "line": 999 },
+        { "kind": "code", "path": "missing.py", "line": 3 },
+        { "kind": "source", "url": "https://internal/plan", "quote": "this sentence was never in the source material" }
+      ]
+    }
+  ],
+  "dissent": [
+    { "who": "Codex", "body": "Rollout aggressiveness is debatable; the correctness blockers are not.",
+      "evidence": [ { "kind": "command", "command": "pytest -q tests/test_idempotency.py" } ] }
+  ],
+  "concerns": [
+    { "title": "TTL vs retry window", "body": "A legitimate retry after expiry may double-charge.",
+      "evidence": [ { "kind": "judgment", "detail": "no client-behavior data was available to the board" } ] }
+  ],
+  "open_questions": ["24h TTL vs client retry/settlement windows."],
+  "next_actions": ["Spec the atomic state machine.", "Decide Redis failure policy."]
+}

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -17,6 +17,7 @@ The suite asserts the safety-critical properties M2 must guarantee:
 """
 import contextlib
 import io
+import json
 import os
 import sys
 import tempfile
@@ -31,6 +32,13 @@ REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", "..", ".."))
 
 sys.path.insert(0, SCRIPTS)
 import run_board as rb  # noqa: E402
+import board_verdict as bv  # noqa: E402  (M5: schema @2 + abstain gate)
+import verify_evidence as ve  # noqa: E402  (M5: evidence resolution)
+import render_verdict as rv  # noqa: E402  (M5: consensus render)
+
+SRC_FIXTURE = os.path.join(FIXTURES, "src")
+PACKET_FIXTURE = os.path.join(FIXTURES, "packet.txt")
+VERDICT_M5 = os.path.join(FIXTURES, "verdict-m5.json")
 
 
 def run_cli(argv, *, stdin=None):
@@ -1656,6 +1664,446 @@ class TestRound2RunLevel(EnvMixin):
         self.assertFalse(os.path.exists(os.path.join(out, "round-2")))
         # a one-voice run still records what round 1 captured
         self.assertTrue(os.path.exists(os.path.join(out, "run-metadata.tsv")))
+
+
+# --------------------------------------------------------------------------- #
+# M5 — canonical verdict + resolved evidence
+# --------------------------------------------------------------------------- #
+
+
+def run_bv(argv):
+    """Invoke board_verdict.main(argv), capturing (exit_code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            code = bv.main(argv)
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue(), err.getvalue()
+
+
+def _seats(*finals):
+    return [{"seat": f"S{i}", "model": "m", "round_verdicts": ["caution", f]}
+            for i, f in enumerate(finals)]
+
+
+def _verdict(overall, *finals, **extra):
+    data = {"schema": "advisory-board/verdict@2", "verdict": overall,
+            "confidence": "high", "rounds": 2, "board": _seats(*finals)}
+    data.update(extra)
+    return data
+
+
+class TestSchemaV2Validation(unittest.TestCase):
+    EXAMPLE = os.path.join(REPO_ROOT, "examples", "payments-idempotency-review", "verdict.json")
+
+    def _assert_rejects(self, data, needle=None):
+        with self.assertRaises(SystemExit) as ctx:
+            bv.validate(data)
+        self.assertEqual(ctx.exception.code, bv.EXIT_SCHEMA)
+
+    def test_v1_example_still_valid(self):
+        if not os.path.exists(self.EXAMPLE):
+            self.skipTest("example verdict.json not present")
+        with open(self.EXAMPLE) as fh:
+            bv.validate(json.load(fh))  # @1 with no evidence must still pass
+
+    def test_v2_fixture_valid(self):
+        with open(VERDICT_M5) as fh:
+            bv.validate(json.load(fh))
+
+    def test_unknown_schema_rejected(self):
+        self._assert_rejects(_verdict("ship", "ship", "ship", schema="advisory-board/verdict@9"))
+
+    def test_evidence_free_blocker_allowed(self):
+        # A blocker with no evidence is structurally valid (degrading to a concern is
+        # a synthesis judgment, not a validator rejection).
+        bv.validate(_verdict("block", "block", "block",
+                             blockers=[{"title": "x", "body": "y"}]))
+
+    def test_bad_evidence_kind_rejected(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "telepathy"}]}]))
+
+    def test_code_evidence_needs_path(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "code", "line": 1}]}]))
+
+    def test_code_evidence_needs_line_or_symbol(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "code", "path": "a.py"}]}]))
+
+    def test_code_line_must_be_positive_int(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "code", "path": "a.py", "line": 0}]}]))
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "code", "path": "a.py", "line": True}]}]))
+
+    def test_source_evidence_needs_quote(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "source", "url": "http://x"}]}]))
+
+    def test_bad_status_rejected(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [
+                {"kind": "code", "path": "a.py", "line": 1, "status": "probably"}]}]))
+
+    def test_judgment_needs_no_referent(self):
+        bv.validate(_verdict("block", "block", "block",
+            blockers=[{"title": "x", "evidence": [{"kind": "judgment", "detail": "experience"}]}]))
+
+    def test_top_level_evidence_validated(self):
+        self._assert_rejects(_verdict("block", "block", "block",
+            evidence=[{"kind": "code", "line": 1}]))  # missing path
+
+
+class TestGateAbstain(unittest.TestCase):
+    def test_unanimous_block_fails(self):
+        self.assertEqual(bv.gate_outcome(_verdict("block", "block", "block"), "block")[0], "fail")
+
+    def test_majority_block_fails(self):
+        self.assertEqual(bv.gate_outcome(_verdict("block", "block", "block", "ship"), "block")[0], "fail")
+
+    def test_torn_no_majority_abstains(self):
+        self.assertEqual(bv.gate_outcome(_verdict("block", "ship", "caution", "block"), "block")[0], "abstain")
+
+    def test_two_seat_split_abstains(self):
+        self.assertEqual(bv.gate_outcome(_verdict("block", "block", "caution"), "block")[0], "abstain")
+
+    def test_agreement_below_threshold_passes(self):
+        # ship + caution, fail_on=block: nobody trips the line -> not torn -> pass.
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "ship", "caution"), "block")[0], "pass")
+
+    def test_fail_on_caution_majority_passes(self):
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "ship", "ship", "caution"), "caution")[0], "pass")
+
+    def test_fail_on_caution_split_abstains(self):
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "ship", "caution"), "caution")[0], "abstain")
+
+    def test_refuted_blocker_abstains(self):
+        data = _verdict("block", "block", "block", blockers=[
+            {"title": "real", "evidence": [{"kind": "code", "path": "a.py", "line": 1, "status": "verified"}]},
+            {"title": "fake", "evidence": [{"kind": "source", "url": "u", "quote": "q", "status": "refuted"}]}])
+        outcome, reason = bv.gate_outcome(data, "block")
+        self.assertEqual(outcome, "abstain")
+        self.assertIn("fake", reason)
+
+    def test_abstain_uses_agreement_not_confidence(self):
+        # low self-reported confidence but a unanimous, decisive board -> NOT abstain.
+        self.assertEqual(bv.gate_outcome(_verdict("block", "block", "block", confidence="low"), "block")[0], "fail")
+
+    def test_main_exit_codes(self):
+        with tempfile.TemporaryDirectory() as d:
+            torn = os.path.join(d, "torn.json")
+            with open(torn, "w") as fh:
+                json.dump(_verdict("block", "ship", "caution", "block"), fh)
+            self.assertEqual(run_bv([torn, "--gate"])[0], bv.EXIT_ABSTAIN)
+
+            clear = os.path.join(d, "clear.json")
+            with open(clear, "w") as fh:
+                json.dump(_verdict("ship", "ship", "ship"), fh)
+            self.assertEqual(run_bv([clear, "--gate"])[0], bv.EXIT_OK)
+
+            block = os.path.join(d, "block.json")
+            with open(block, "w") as fh:
+                json.dump(_verdict("block", "block", "block"), fh)
+            self.assertEqual(run_bv([block, "--gate"])[0], bv.EXIT_GATE_FAIL)
+
+
+class TestEvidenceResolution(unittest.TestCase):
+    def code(self, **kw):
+        return dict(kind="code", **kw)
+
+    def test_code_line_in_range_verified(self):
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=10), SRC_FIXTURE), "verified")
+
+    def test_code_line_out_of_range_refuted(self):
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=999), SRC_FIXTURE), "refuted")
+
+    def test_code_symbol_present_verified(self):
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", symbol="charge_idempotent"), SRC_FIXTURE), "verified")
+
+    def test_code_symbol_absent_refuted(self):
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", symbol="nonexistent_fn"), SRC_FIXTURE), "refuted")
+
+    def test_code_missing_file_unverified(self):
+        # An absent file is unverified, not refuted: --source may be incomplete.
+        self.assertEqual(ve.resolve_code(self.code(path="ghost.py", line=1), SRC_FIXTURE), "unverified")
+
+    def test_code_no_source_unverified(self):
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=10), None), "unverified")
+
+    def test_code_single_file_source(self):
+        single = os.path.join(SRC_FIXTURE, "charges.py")
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=10), single), "verified")
+
+    def test_source_quote_present_verified(self):
+        text = open(PACKET_FIXTURE).read()
+        self.assertEqual(ve.resolve_source({"quote": "atomic SET NX claim on receipt"}, text), "verified")
+
+    def test_source_quote_absent_refuted(self):
+        text = open(PACKET_FIXTURE).read()
+        self.assertEqual(ve.resolve_source({"quote": "never appeared anywhere"}, text), "refuted")
+
+    def test_source_no_packet_unverified(self):
+        # Structural guarantee of quarantine: with no captured packet there is nothing
+        # to check against, and we NEVER reach out to the URL -> unverified.
+        self.assertEqual(ve.resolve_source({"quote": "anything", "url": "http://x"}, None), "unverified")
+
+    def test_source_quote_whitespace_normalized(self):
+        self.assertEqual(ve.resolve_source({"quote": "atomic   SET\nNX   claim"},
+                                           "... an atomic SET NX claim here ..."), "verified")
+
+    def test_stamp_full_fixture(self):
+        with open(VERDICT_M5) as fh:
+            data = json.load(fh)
+        counts = ve.stamp(data, SRC_FIXTURE, open(PACKET_FIXTURE).read())
+        self.assertEqual((counts["verified"], counts["unverified"], counts["refuted"], counts["skipped"]),
+                         (3, 2, 2, 1))
+        # command stamped unverified (deferred); judgment left unstamped.
+        cmd = data["dissent"][0]["evidence"][0]
+        self.assertEqual(cmd["status"], "unverified")
+        judgment = data["concerns"][0]["evidence"][0]
+        self.assertNotIn("status", judgment)
+
+    def test_main_writes_in_place_and_check_does_not(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "v.json")
+            with open(VERDICT_M5) as fh:
+                src = fh.read()
+            with open(path, "w") as fh:
+                fh.write(src)
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                ve.main([path, "--source", SRC_FIXTURE, "--packet", PACKET_FIXTURE, "--check"])
+            self.assertEqual(open(path).read(), src)            # --check writes nothing
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                ve.main([path, "--source", SRC_FIXTURE, "--packet", PACKET_FIXTURE])
+            stamped = json.load(open(path))
+            self.assertEqual(stamped["blockers"][0]["evidence"][0]["status"], "verified")
+
+    def test_packet_from_run_dir_prompts(self):
+        with tempfile.TemporaryDirectory() as d:
+            prompts = os.path.join(d, "prompts")
+            os.makedirs(prompts)
+            with open(os.path.join(prompts, "claude-round-1.prompt"), "w") as fh:
+                fh.write("MATERIAL: take an atomic SET NX claim on receipt please")
+            text = ve.load_packet_text(None, d)
+            self.assertIn("atomic SET NX", text)
+
+
+class TestRenderVerdict(unittest.TestCase):
+    def setUp(self):
+        with open(VERDICT_M5) as fh:
+            self.data = json.load(fh)
+        ve.stamp(self.data, SRC_FIXTURE, open(PACKET_FIXTURE).read())
+
+    def test_markdown_has_decision_and_evidence(self):
+        md = rv.render_markdown(self.data)
+        self.assertIn("## Verdict: DO NOT SHIP YET", md)
+        self.assertIn("`charges.py:10` (code) — verified", md)
+        self.assertIn("REFUTED", md)
+        self.assertIn("## What the board couldn't verify", md)
+        self.assertIn("## Hard dissent", md)
+        self.assertIn("§9", md)  # the honesty footer
+
+    def test_markdown_no_evidence_omits_footer(self):
+        plain = _verdict("block", "block", "block", title="t",
+                         blockers=[{"title": "b", "body": "x"}])
+        md = rv.render_markdown(plain)
+        self.assertNotIn("§9", md)
+        self.assertNotIn("couldn't verify", md)
+
+    def test_handoff_data_round_trips_through_render_handoff(self):
+        sys.path.insert(0, SCRIPTS)
+        import render_handoff as rh
+        hd = rv.build_handoff_data(self.data)
+        template = open(rh.default_template()).read()
+        html_out = rh.render(hd, template)         # dies on any leftover token / stray comment
+        self.assertIn("DO NOT SHIP YET", html_out)
+        self.assertIn("Atomic dedup", html_out)
+
+    def test_run_dir_prose_pulled_into_round_review(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "round-1"))
+            with open(os.path.join(d, "round-1", "claude.md"), "w") as fh:
+                fh.write("Independent take: needs an atomic `SET NX`.")
+            hd = rv.build_handoff_data(self.data, run_dir=d)
+            claude = next(s for s in hd["seats"] if s["seat_name"] == "Claude")
+            self.assertIn("atomic", claude["rounds"][0]["round_review"])
+            self.assertIn("<code>SET NX</code>", claude["rounds"][0]["round_review"])
+            # round 2 had no file -> a pointer, never invented prose
+            self.assertIn("round-2/claude.md", claude["rounds"][1]["round_review"])
+
+
+class TestM5ChainDelegation(EnvMixin):
+    def _stage(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        path = os.path.join(d, "verdict.json")
+        with open(VERDICT_M5) as fh:
+            open(path, "w").write(fh.read())
+        return path
+
+    def test_verify_delegates_and_stamps(self):
+        path = self._stage()
+        code, out, _ = run_cli(["verify", path, "--source", SRC_FIXTURE, "--packet", PACKET_FIXTURE])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.load(open(path))["blockers"][0]["evidence"][0]["status"], "verified")
+
+    def test_consensus_delegates(self):
+        # _delegate shells out, so the child's stdout bypasses the in-process redirect;
+        # assert on the written file (and the exit code) the way TestDelegation does.
+        path = self._stage()
+        md = os.path.join(os.path.dirname(path), "final-consensus.md")
+        code, _, _ = run_cli(["consensus", path, "-o", md])
+        self.assertEqual(code, 0)
+        self.assertIn("Final Consensus", open(md).read())
+
+    def test_validate_gate_abstains_on_refuted(self):
+        path = self._stage()
+        run_cli(["verify", path, "--source", SRC_FIXTURE, "--packet", PACKET_FIXTURE])
+        code, _, _ = run_cli(["validate", path, "--gate"])
+        self.assertEqual(code, bv.EXIT_ABSTAIN)
+
+    def test_run_prints_synthesis_chain_guidance(self):
+        out_dir = os.path.join(tempfile.mkdtemp(), "run")
+        self.addCleanup(lambda: __import__("shutil").rmtree(os.path.dirname(out_dir), ignore_errors=True))
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out_dir, "--yes"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("verdict.json", text)
+        self.assertIn("verify", text)
+        self.assertIn("consensus", text)
+        self.assertIn("validate", text)
+
+
+# --------------------------------------------------------------------------- #
+# M5 — adversarial-review regression tests (findings fixed before merge)
+# --------------------------------------------------------------------------- #
+
+
+class TestGateReconcileVerdictVsBoard(unittest.TestCase):
+    """The gate must not let a self-reported `verdict` that contradicts the observed
+    board clear it (the injected/fabricated 'ship' worst case), while still honoring a
+    synthesizer's legitimate ESCALATION to block."""
+
+    def test_unanimous_block_but_verdict_ship_abstains(self):
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "block", "block", "block"), "block")[0], "abstain")
+
+    def test_majority_block_but_verdict_ship_abstains(self):
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "block", "block", "ship"), "block")[0], "abstain")
+
+    def test_minority_block_verdict_block_escalation_fails(self):
+        # synthesizer escalates to block on a minority-but-correct concern -> respected.
+        self.assertEqual(bv.gate_outcome(_verdict("block", "block", "ship", "ship"), "block")[0], "fail")
+
+    def test_all_ship_verdict_ship_passes(self):
+        self.assertEqual(bv.gate_outcome(_verdict("ship", "ship", "ship"), "block")[0], "pass")
+
+    def test_all_ship_verdict_block_escalation_fails(self):
+        self.assertEqual(bv.gate_outcome(_verdict("block", "ship", "ship"), "block")[0], "fail")
+
+
+class TestGateRefutedAnywhere(unittest.TestCase):
+    """A refuted (fabricated) citation routes to a human regardless of which container
+    it sits in - not only blockers."""
+
+    def _abstains_with(self, **extra):
+        data = _verdict("block", "block", "block", **extra)
+        outcome, reason = bv.gate_outcome(data, "block")
+        self.assertEqual(outcome, "abstain")
+        return reason
+
+    def test_refuted_on_concern_abstains(self):
+        self._abstains_with(concerns=[{"title": "c", "evidence": [
+            {"kind": "code", "path": "a.py", "line": 1, "status": "refuted"}]}])
+
+    def test_refuted_on_dissent_abstains(self):
+        self._abstains_with(dissent=[{"who": "Codex", "evidence": [
+            {"kind": "source", "url": "u", "quote": "q", "status": "refuted"}]}])
+
+    def test_refuted_on_top_level_evidence_abstains(self):
+        self._abstains_with(evidence=[{"kind": "code", "path": "a.py", "line": 1, "status": "refuted"}])
+
+
+class TestContainerTypeRejected(unittest.TestCase):
+    """A non-list blockers/dissent/concerns once slipped past evidence validation and the
+    refuted-citation gate; it must now be a hard schema error."""
+
+    def _rejects(self, **extra):
+        with self.assertRaises(SystemExit) as ctx:
+            bv.validate(_verdict("block", "block", "block", **extra))
+        self.assertEqual(ctx.exception.code, bv.EXIT_SCHEMA)
+
+    def test_dict_blockers_rejected(self):
+        self._rejects(blockers={"title": "x", "evidence": [{"kind": "NONSENSE"}]})
+
+    def test_string_dissent_rejected(self):
+        self._rejects(dissent="Codex disagrees")
+
+
+class TestEvidencePathSafety(unittest.TestCase):
+    """verify_evidence must not read arbitrary files off disk or false-verify on a
+    basename collision, and must not crash on a malformed line locator."""
+
+    def code(self, **kw):
+        return dict(kind="code", **kw)
+
+    def test_absolute_path_not_resolved(self):
+        self.assertEqual(ve.resolve_code(self.code(path="/etc/passwd", line=1), SRC_FIXTURE), "unverified")
+
+    def test_parent_traversal_not_resolved(self):
+        self.assertEqual(ve.resolve_code(self.code(path="../../charges.py", line=1), SRC_FIXTURE), "unverified")
+
+    def test_non_int_line_does_not_crash(self):
+        for bad in ("1", 1.0, True, None):
+            self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=bad), SRC_FIXTURE), "unverified")
+
+    def test_single_file_basename_collision_not_verified(self):
+        single = os.path.join(SRC_FIXTURE, "charges.py")
+        self.assertEqual(ve.resolve_code(self.code(path="elsewhere/charges.py", line=1), single), "unverified")
+        self.assertEqual(ve.resolve_code(self.code(path="charges.py", line=1), single), "verified")
+
+
+class TestRenderBraceSafe(unittest.TestCase):
+    """A literal {{TOKEN}} in user content must not survive into the derived handoff-data
+    and abort render_handoff's --html step (it dies on any leftover placeholder)."""
+
+    def setUp(self):
+        sys.path.insert(0, SCRIPTS)
+        import render_handoff as rh
+        self.rh = rh
+        self.template = open(rh.default_template()).read()
+
+    def _renders(self, data):
+        data.setdefault("verdict", "block")
+        hd = rv.build_handoff_data(data)
+        return self.rh.render(hd, self.template)  # raises SystemExit on a leftover {{TOKEN}}
+
+    def test_token_in_title(self):
+        self._renders({"title": "Quoting the {{CLAUDE_OUTPUT_OVERRIDE}} sentinel"})
+
+    def test_token_in_blocker_and_triple_braces(self):
+        self._renders({"title": "t", "blockers": [{"title": "b {{X}}", "body": "see {{{Y}}} and {{Z}}"}]})
+
+    def test_token_in_seat_fields(self):
+        self._renders({"title": "t", "board": [
+            {"seat": "S{{A}}", "model": "m{{B}}", "lens": "x{{C}}", "round_verdicts": ["block", "block"]}]})
+
+
+class TestEvidenceToolingHygiene(unittest.TestCase):
+    def test_verify_evidence_imports_no_network(self):
+        # The quarantine guarantee is structural: source quotes resolve against the
+        # captured packet, never a live fetch. Assert the module pulls in no network lib.
+        src = open(os.path.join(SCRIPTS, "verify_evidence.py")).read()
+        for banned in ("urllib", "socket", "http.client", "requests", "urlopen"):
+            self.assertNotIn(banned, src, f"verify_evidence.py must not reference {banned}")
+
+    def test_evidence_containers_agree_across_scripts(self):
+        # Three independent stdlib scripts each define EVIDENCE_CONTAINERS; a silent
+        # divergence would let one tool miss evidence the others stamp/validate.
+        self.assertEqual(tuple(bv.EVIDENCE_CONTAINERS), tuple(ve.EVIDENCE_CONTAINERS))
+        self.assertEqual(tuple(bv.EVIDENCE_CONTAINERS), tuple(rv.EVIDENCE_CONTAINERS))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## M5 — canonical verdict + resolved evidence

`verdict.json` becomes the **source of truth** for the board's decision; `final-consensus.md` (and the HTML) render *from* it. Synthesis stays a reasoning task (§11) — the conductor produces clean per-round packets and the agent fills `verdict.json`; it does **not** generate the verdict in code. The deterministic chain then runs as subcommands.

### What's new
- **Schema `advisory-board/verdict@2`** (`references/verdict-schema.md` + `board_verdict.py`, still accepts `@1`): blockers/dissent/concerns may carry typed `evidence[]` (kinds `code`/`source`/`command`/`judgment`) with an optional `status` (`verified`/`unverified`/`refuted`).
- **`scripts/verify_evidence.py`** (new): resolves `code` `path:line`/`symbol` against `--source` and `source` quotes against the **captured packet** (`--packet`/`--run`) — **never a live URL fetch** (respects quarantine). `command` deferred → `unverified`; `judgment` unstamped. Stamps each citation in place. Honesty (§9): proves *the receipt resolves*, not that the inference is sound.
- **`scripts/render_verdict.py`** (new): `final-consensus.md` from the verdict (evidence trail + couldn't-verify bucket); `--handoff-data`/`--html` derive the HTML via the existing `render_handoff.py`. Per-round prose is pulled from `round-N/<seat>.md` when a run dir is given, never invented.
- **`board_verdict.py --gate`**: new neutral exit **`3` = abstain** ("human required"), driven by **observed cross-seat agreement** (`round_verdicts`), never the gameable `confidence`. Abstains when the board straddles the threshold with no majority, when the **declared verdict clears the gate while a majority of seats trip it** (the injected-"ship" case), or when **any citation is refuted**. Synthesis *escalation* still fails decisively.
- **`cli.py`**: `verify` + `consensus` subcommands; `run` prints the synthesis→verify→consensus→validate chain.

### Adversarial review (before merge)
Ran 5 parallel finders + skeptic verification (per the project's review-before-commit gate). Confirmed findings fixed and locked by regression tests:
- **HIGH** — the gate's non-torn branch trusted the self-reported `verdict`; a unanimous-`block` board with `verdict:"ship"` gated to PASS → now abstains (escalation still honored).
- **HIGH** — `verify_evidence` absolute-path read / single-file basename collision (false `verified`) and a non-int `line` crash → unsafe paths and malformed locators now resolve to `unverified`.
- **HIGH** — a literal `{{TOKEN}}` in user content killed `render_handoff` on `--html` → braces neutralized in the derived handoff-data.
- **MEDIUM** — `refuted` checked only on blockers → broadened to any container; a dict-shaped `blockers`/`dissent`/`concerns` bypassed evidence validation → now a hard schema error.

### Verification
- **164 → 227 tests** green (`python3 -m unittest discover -s tests -t tests`).
- Live preflight **3/3 GO**; CLI `--help`/`run --dry-run` byte-identical; clean mock run produces the full artifact tree.
- Standard library only; no new dependencies.

The shipped `examples/payments-idempotency-review/verdict.json` stays `@1` (untouched) — M6 regenerates it via the conductor as the proof-of-life run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)