### PR TITLE
Add release workflow: skill-scoped tags + GitHub releases on tag push

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Keep text files LF so tooling (e.g. the release workflow's changelog parser)
+# never sees stray carriage returns, regardless of contributor platform.
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.gif binary
+*.pdf binary

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+# Categorizes GitHub's auto-generated release notes (the fallback path in
+# .github/workflows/release.yml, used when a version has no CHANGELOG section).
+changelog:
+  categories:
+    - title: Added
+      labels: [feature, enhancement, added]
+    - title: Fixed
+      labels: [bug, fix, fixed]
+    - title: Changed
+      labels: [changed, refactor, docs]
+    - title: Other
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: release
+
+# Publish a GitHub release whenever a skill-scoped version tag is pushed.
+#
+# Tag format:  <skill>/vX.Y.Z   e.g.  advisory-board/v0.5.0
+# Release body: that skill's CHANGELOG.md section for the version
+#               (skills/<skill>/CHANGELOG.md, heading "## [vX.Y.Z]"),
+#               falling back to GitHub's auto-generated notes if the
+#               section is missing. See RELEASING.md.
+
+on:
+  push:
+    tags:
+      - "*/v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Derive + VALIDATE skill/version from the tag. GITHUB_REF_NAME is an env
+      # var (safe); downstream steps read these via env, never via ${{ }} inside a
+      # run block, so a crafted tag name can't inject into the shell.
+      - name: Resolve tag, skill, and version
+        id: meta
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tag="$REF_NAME"
+          skill="${tag%/*}"        # advisory-board/v0.5.0 -> advisory-board
+          version="${tag##*/}"     # advisory-board/v0.5.0 -> v0.5.0
+          if ! printf '%s' "$skill" | grep -Eq '^[a-z0-9][a-z0-9._-]*$'; then
+            echo "::error::tag '$tag' has an unexpected skill segment '$skill'" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::tag '$tag' is not <skill>/vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          {
+            echo "tag=$tag"
+            echo "skill=$skill"
+            echo "version=$version"
+            echo "changelog=skills/$skill/CHANGELOG.md"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from the changelog
+        id: notes
+        env:
+          CHANGELOG: ${{ steps.meta.outputs.changelog }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          : > notes.md
+          if [ -f "$CHANGELOG" ]; then
+            awk -v ver="$VERSION" '
+              { sub(/\r$/, "") }                                # tolerate CRLF
+              index($0, "## [" ver "]") == 1 { capture = 1; next }
+              capture && /^## \[/            { exit }
+              capture                        { print }
+            ' "$CHANGELOG" > notes.md
+          fi
+          if grep -q '[^[:space:]]' notes.md; then
+            echo "have_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_notes=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no '## [$VERSION]' section in $CHANGELOG — using auto-generated notes"
+          fi
+
+      - name: Publish release (from changelog)
+        if: steps.notes.outputs.have_notes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          SKILL: ${{ steps.meta.outputs.skill }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --title "$SKILL $VERSION" \
+            --notes-file notes.md \
+            --verify-tag
+
+      - name: Publish release (auto-generated fallback)
+        if: steps.notes.outputs.have_notes == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          SKILL: ${{ steps.meta.outputs.skill }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --title "$SKILL $VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,11 @@ skills/<skill-name>/
 ## Validation
 
 When a skill is Codex-compatible, validate it with the local skill validator before publishing changes.
+
+## Releases
+
+Skills are published as GitHub releases cut from **skill-scoped semver tags** (`<skill>/vX.Y.Z`,
+e.g. `advisory-board/v0.5.0`). Pushing a version tag triggers the `release` workflow, which
+publishes the release from that skill's `CHANGELOG.md`. Cut a release when a **milestone PR merges
+to `main`** — not on every PR. Keep the skill's `CHANGELOG.md` current as you work. See
+[`RELEASING.md`](./RELEASING.md) for the scheme, cadence, and exact commands.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ For Codex-compatible runtimes, copy or sync a skill directory into your local sk
 
 GitHub Pages-ready documentation lives in [`docs/`](./docs/) — the Advisory Board page covers what the workflow does and how it is meant to be used.
 
+## Releases
+
+Each skill is versioned independently and published as a GitHub release from a skill-scoped tag
+(`<skill>/vX.Y.Z`). Per-skill changes are tracked in that skill's `CHANGELOG.md` (e.g.
+[`skills/advisory-board/CHANGELOG.md`](./skills/advisory-board/CHANGELOG.md)); see
+[`RELEASING.md`](./RELEASING.md) for how releases are cut.
+
 ## License
 
 Released under the [MIT License](./LICENSE.md) — free to use, copy, modify, and adapt with attribution.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing
+
+This repo ships its skills as **GitHub releases** cut from **skill-scoped, annotated git tags**.
+Pushing a version tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
+which publishes the release automatically — you never run `gh release create` by hand.
+
+## Conventions
+
+- **Tag format:** `<skill>/vMAJOR.MINOR.PATCH` — e.g. `advisory-board/v0.5.0`. Skill-scoped so each
+  skill in the repo versions independently and tags never collide.
+- **Scheme (semver), pre-1.0:** the **minor** tracks the conductor milestone — M5 → `v0.5.0`,
+  M6 → `v0.6.0` — and **`v1.0.0` is reserved for an explicit "production-ready" call**, not an
+  automatic milestone bump. Use the **patch** for follow-up fixes within a released milestone
+  (`v0.5.1`). This is a separate axis from the verdict-JSON schema version (`advisory-board/verdict@N`).
+- **Cadence:** cut a release **when a milestone PR merges to `main`** — not on every PR. Infra-only,
+  CI-only, and docs-only PRs do **not** get a tag or release (no tag → the workflow never fires).
+- **Notes source:** each skill keeps a [`CHANGELOG.md`](skills/advisory-board/CHANGELOG.md)
+  (Keep a Changelog). The release body is that skill's `## [vX.Y.Z]` section; if it's missing the
+  workflow falls back to GitHub's auto-generated notes.
+
+## Per-PR habit
+
+A milestone PR carries its own changelog entry so the release is ready the moment it merges:
+
+1. Add your changes under `## [Unreleased]` in `skills/<skill>/CHANGELOG.md` as you work.
+2. As part of the release commit, rename `## [Unreleased]` → `## [vX.Y.Z] - YYYY-MM-DD — <milestone>`
+   and add a fresh empty `## [Unreleased]` above it.
+
+## Cutting a release
+
+After the milestone PR has **merged to `main`**:
+
+```bash
+git fetch origin
+git checkout main && git pull            # or: branch from origin/main
+
+# 1. Make sure skills/<skill>/CHANGELOG.md has a "## [vX.Y.Z] - DATE" section on main
+#    (this normally lands with the milestone PR). If not, add it via a small PR first.
+
+# 2. Annotated, skill-scoped tag on the current tip of main (which now includes the
+#    milestone's code AND its changelog section):
+git tag -a advisory-board/v0.5.0 -m "advisory-board v0.5.0 — M5: canonical verdict + resolved evidence"
+
+# 3. Push the tag — this is what triggers the release workflow:
+git push origin advisory-board/v0.5.0
+```
+
+The `release` workflow then publishes a GitHub release titled `advisory-board v0.5.0` with the
+changelog section as its body. Confirm it on the repo's **Releases** page (or `gh release view
+advisory-board/v0.5.0`).
+
+> **Commit gate:** the skills repo blocks a bare `git commit` (see the project's review-before-commit
+> hook). A changelog/release commit is trivial — use `SKIP_REVIEW=1 git commit …`. Tagging and
+> pushing a tag are not commits and are not gated.
+
+## Fixing a release
+
+```bash
+gh release delete advisory-board/v0.5.0 --yes        # remove the release
+git push origin --delete advisory-board/v0.5.0       # remove the remote tag
+git tag -d advisory-board/v0.5.0                      # remove the local tag
+# re-tag the corrected commit and push again
+```
+
+## Mechanism
+
+[`.github/workflows/release.yml`](.github/workflows/release.yml) runs on any pushed tag matching
+`*/v*.*.*`. It splits the tag into `<skill>` and `vX.Y.Z`, reads `skills/<skill>/CHANGELOG.md` for
+the matching section, and calls `gh release create` with `contents: write` permission (the only
+scope it needs). [`.github/release.yml`](.github/release.yml) categorizes the auto-generated
+fallback notes by PR label.

--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog — advisory-board
+
+All notable changes to the `advisory-board` skill are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Releases are
+cut as **skill-scoped semver tags** `advisory-board/vX.Y.Z` (see [`RELEASING.md`](../../RELEASING.md)).
+Pre-1.0 the minor tracks the conductor milestone (M5 → `v0.5.0`, M6 → `v0.6.0`); `v1.0.0` is
+reserved for an explicit production-ready call. The verdict-JSON schema is versioned separately
+(`advisory-board/verdict@N`) and is not the same axis as the release version.
+
+## [Unreleased]
+
+## [v0.5.0] - 2026-06-25 — M5: canonical verdict + resolved evidence
+
+`verdict.json` becomes the source of truth for the board's decision; the Markdown and HTML
+render from it. Synthesis stays a reasoning task (design §11) — the conductor produces clean
+per-round packets and the agent fills `verdict.json`; it does not generate the verdict in code.
+
+### Added
+- **Schema `advisory-board/verdict@2`** — typed `evidence[]` (kinds `code`/`source`/`command`/`judgment`)
+  with an optional `status` (`verified`/`unverified`/`refuted`) on blockers, dissent, and concerns.
+  `board_verdict.py` validates both `@1` and `@2`.
+- **`scripts/verify_evidence.py`** — resolves `code` `path:line`/`symbol` against `--source` and
+  `source` quotes against the captured packet (`--packet`/`--run`), never a live URL fetch
+  (respects quarantine); stamps each citation. `command` is deferred (`unverified`); `judgment`
+  is left unstamped. Path-safe (rejects absolute/`..` paths and basename collisions).
+- **`scripts/render_verdict.py`** — renders `final-consensus.md` from the canonical `verdict.json`
+  (evidence trail + couldn't-verify bucket); `--handoff-data`/`--html` derive the HTML via the
+  existing `render_handoff.py`. Per-round prose is pulled from `round-N/<seat>.md`, never invented.
+- **`board_verdict.py --gate` abstain** — a neutral exit `3` ("human required"), driven by observed
+  cross-seat agreement (`round_verdicts`), never the gameable `confidence`. Fires when the board is
+  torn across the threshold with no majority, when the declared verdict clears the gate while a
+  majority of seats trip it (the injected-"ship" case), or when any citation is refuted.
+- **`run_board.py` subcommands `verify` and `consensus`**; `run` now prints the
+  synthesis → verify → consensus → validate chain at the end of a run.
+
+### Changed
+- `references/verdict-schema.md`, `scripts/README.md`, `tests/README.md`, and the `SKILL.md`
+  helper list updated for the verdict chain and the `@2` schema.
+
+### Notes
+- The shipped `examples/payments-idempotency-review/verdict.json` stays `@1` (regenerated via the
+  conductor in M6).
+- Verification: 227 standard-library tests; live preflight 3/3 GO; CLI byte-identical. Shipped in
+  [#11](https://github.com/timharris707/skills/pull/11), reviewed by a 5-agent adversarial pass.


### PR DESCRIPTION
## What

Establish a release process for the repo (it had **0 tags / 0 releases / no CI**). Pushing a **skill-scoped semver tag** now publishes a GitHub release automatically.

This is the workflow change requested: *"start using GitHub releases and tags every time we push updates to the skill."*

## Convention (see [`RELEASING.md`](RELEASING.md))

- **Tag format:** `<skill>/vMAJOR.MINOR.PATCH` (e.g. `advisory-board/v0.5.0`) — skill-scoped so each skill in the monorepo versions independently.
- **Scheme:** pre-1.0 the **minor tracks the conductor milestone** (M5 → `v0.5.0`, M6 → `v0.6.0`); **`v1.0.0` is reserved for an explicit production-ready call**. Separate axis from the verdict-JSON schema version (`verdict@N`).
- **Cadence:** cut a release on a **milestone PR merge to `main`** — not on every PR. Infra/docs/CI-only PRs get no tag and no release.

## Mechanism

- **`.github/workflows/release.yml`** — fires on a pushed tag matching `*/v*.*.*`, derives + validates `skill` and `version`, and publishes via `gh release create`. The body comes from `skills/<skill>/CHANGELOG.md`'s `## [vX.Y.Z]` section, falling back to GitHub's auto-generated notes if missing. Derived values pass via `env:` (no `${{ }}` expression injection into `run:` blocks); the changelog parser tolerates CRLF.
- **`.github/release.yml`** — categorizes the fallback auto-notes by label.
- **`.gitattributes`** — normalizes text to LF so the parser never sees stray carriage returns.

## Docs

- **`skills/advisory-board/CHANGELOG.md`** — Keep a Changelog; seeded with the `v0.5.0` (M5) section so that release is ready the moment [#11](https://github.com/timharris707/skills/pull/11) merges.
- **`CONTRIBUTING.md`** / **`README.md`** — short Releases sections pointing at `RELEASING.md`.

## Review

Reviewed by a 3-dimension adversarial workflow (Actions correctness · shell+security · docs consistency) with skeptic verification — **1 confirmed nit** (CRLF carried into the release body → fixed via the awk CR-strip + `.gitattributes`), **9 findings dismissed**. The tag→skill/version parsing, glob matching, semver/skill validation, and changelog extraction were verified locally against valid and malformed/injection-y tags and LF/CRLF changelogs.

## Cutting the first release (after merge)

This PR and the M5 PR (#11) both need to be on `main`; then:

```bash
git checkout main && git pull
git tag -a advisory-board/v0.5.0 -m "advisory-board v0.5.0 — M5: canonical verdict + resolved evidence"
git push origin advisory-board/v0.5.0   # triggers the release workflow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)