### PR TITLE
Refine the v1.x plan after an adversarial content review

### DIFF
--- a/design/run-board-v1x.html
+++ b/design/run-board-v1x.html
@@ -422,20 +422,20 @@ footer.colophon code { background: var(--surface-2); }
           
           <span class="chip"><b>Owner</b> Tim</span>
           
-          <span class="chip"><b>Baseline</b> advisory-board/v1.0.0 · 229 tests green</span>
+          <span class="chip"><b>Baseline</b> advisory-board/v1.0.0 + plan view · 268 tests green</span>
           
         </div>
       </div>
       <div class="gauge">
-        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 15%">
+        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 9%">
           <circle class="ring-track" cx="60" cy="60" r="52" fill="none" stroke-width="11"/>
           <circle class="ring-arc" cx="60" cy="60" r="52" fill="none" stroke-width="11"
                   stroke-linecap="round" transform="rotate(-90 60 60)"
-                  stroke-dasharray="326.7" stroke-dashoffset="277.7"/>
-          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">15%</text>
+                  stroke-dasharray="326.7" stroke-dashoffset="297.3"/>
+          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">9%</text>
           <text class="ring-sub" x="60" y="76" text-anchor="middle" dominant-baseline="middle">complete</text>
         </svg>
-        <div class="gauge-count"><b>3</b> / 20 tasks done</div>
+        <div class="gauge-count"><b>2</b> / 22 tasks done</div>
       </div>
     </div>
 
@@ -478,8 +478,8 @@ footer.colophon code { background: var(--surface-2); }
           <div class="ms-meta">
             <span class="badge wip"><span class="dot"></span>In progress</span>
             <span class="ms-progress">
-              <span class="ms-bar"><span style="width:38%"></span></span>
-              3/8
+              <span class="ms-bar"><span style="width:22%"></span></span>
+              2/9
             </span>
           </div>
         </div>
@@ -498,11 +498,13 @@ footer.colophon code { background: var(--surface-2); }
         </div>
         <ul class="checklist">
           
-          <li class="done"><span class="tick">✓</span><span class="task-text">Specify the per-seat <em>movement</em> metric (verdict shift + new-citation delta between rounds)</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">DECISION: the round template emits one literal <code>VERDICT: ship|caution|block</code> line per seat — the model reasons, the conductor only reads the token (this changes the egressed prompt, so <code>prompt_template_sha</code> and the prompt version bump)</span></li>
           
-          <li class="done"><span class="tick">✓</span><span class="task-text">Decide the stop predicate: stop when board-wide movement &lt; threshold, or <code>--max-rounds</code> reached</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">DECISION: movement = verdict-token shift + new-citation delta between a seat&#x27;s round N-1 and N; board-wide movement <code>&lt; threshold</code> (or <code>--max-rounds</code>) stops</span></li>
           
-          <li class="done"><span class="tick">✓</span><span class="task-text">Write the metric as a pure function over <code>round-N/*.md</code></span></li>
+          <li class="todo"><span class="tick"></span><span class="task-text">Add the <code>VERDICT:</code> line to the ROUND1/ROUND2 templates and bump the prompt version</span></li>
+          
+          <li class="todo"><span class="tick"></span><span class="task-text">Implement the metric as a pure function over the parsed token + citation set (no prose inference)</span></li>
           
           <li class="wip"><span class="tick">●</span><span class="task-text">Decide sane defaults for the threshold and the ceiling</span></li>
           
@@ -510,7 +512,7 @@ footer.colophon code { background: var(--surface-2); }
         
         <div class="testing">
           <p class="t-label">Testing strategy</p>
-          <div class="t-body"><p>unit tests for the metric on hand-built two-round fixtures (moved / unchanged / mixed); a property test that movement is zero when round N == round N-1.</p></div>
+          <div class="t-body"><p>unit tests on hand-built two-round fixtures (moved / unchanged / mixed); a property test that movement is zero when round N == round N-1; an adversarial fixture where a seat rephrases its prose but the <code>VERDICT</code> token is unchanged (must read as <em>no move</em>).</p></div>
         </div>
         
         
@@ -529,7 +531,7 @@ footer.colophon code { background: var(--surface-2); }
         </div>
         <ul class="checklist">
           
-          <li class="todo"><span class="tick"></span><span class="task-text">Add <code>auto</code> to the <code>--rounds</code> arg and the recipe schema</span></li>
+          <li class="todo"><span class="tick"></span><span class="task-text">Replace the clamp-to-2 deferral note (<code>auto</code>/<code>3</code> already parse — <code>cli.py</code>/<code>config.py</code>/<code>recipe.py</code>) with the real round loop</span></li>
           
           <li class="todo"><span class="tick"></span><span class="task-text">Loop rounds in <code>rounds.py</code> until the stop predicate fires</span></li>
           
@@ -547,7 +549,7 @@ footer.colophon code { background: var(--surface-2); }
         
         <div class="gate">
           <span class="g-label">Validation gate</span>
-          <code>PATH=&quot;$PWD/tests/mocks:$PATH&quot; python3 scripts/run_board.py run --recipe tests/fixtures/auto.json --check</code>
+          <code>PATH=&quot;$PWD/tests/mocks:$PATH&quot; python3 scripts/run_board.py run --source tests/fixtures/sample-plan.md --rounds auto --out &quot;$(mktemp -d)&quot; --yes</code>
         </div>
         
       </div>
@@ -599,7 +601,7 @@ footer.colophon code { background: var(--surface-2); }
         
         <div class="gate">
           <span class="g-label">Validation gate</span>
-          <code>python3 scripts/run_board.py verify /tmp/v.json --run examples/payments-idempotency-review --check</code>
+          <code>python3 scripts/run_board.py verify /tmp/v.json --run ../../examples/payments-idempotency-review --check</code>
         </div>
         
       </div>
@@ -697,14 +699,14 @@ footer.colophon code { background: var(--surface-2); }
             <span class="badge todo"><span class="dot"></span>To do</span>
             <span class="ms-progress">
               <span class="ms-bar"><span style="width:0%"></span></span>
-              0/3
+              0/4
             </span>
           </div>
         </div>
       </div>
 
       
-      <div class="ms-desc"><p>Round 2 hands each seat a digest of the others&#x27; round-1 reviews via <code>prompts._digest</code>. It is currently a flat concatenation. A structured digest — grouped by claim, with agreements and conflicts surfaced — gives round 2 (and the <code>auto</code> stop-rule) a sharper signal to debate against.</p></div>
+      <div class="ms-desc"><p>Round 2 hands each seat a round-2 packet of the others&#x27; round-1 reviews, assembled by <code>prompts.build_round2_packet</code>. Under <code>cross_reading=summaries</code> each review is head-truncated to a char budget by <code>prompts._digest</code>; under <code>full</code> the reviews are concatenated verbatim. A structured digest — grouped by claim, with agreements and conflicts surfaced — would replace this, giving round 2 (and the <code>auto</code> stop-rule) a sharper signal to debate against.</p></div>
       
 
       
@@ -715,6 +717,8 @@ footer.colophon code { background: var(--surface-2); }
           <span class="phase-state">To do</span>
         </div>
         <ul class="checklist">
+          
+          <li class="todo"><span class="tick"></span><span class="task-text">Decide scope: does the structured digest replace the <code>summaries</code> path only, or <code>full</code> too</span></li>
           
           <li class="todo"><span class="tick"></span><span class="task-text">Extract per-seat claims and cluster the overlapping ones</span></li>
           
@@ -793,6 +797,11 @@ footer.colophon code { background: var(--surface-2); }
         <div class="entry-body">mitigated by the allowlist plus the existing egress/quarantine gate; anything off-list stays <code>unverified</code>, never silently trusted.</div>
       </li>
       
+      <li>
+        <div class="entry-head"><span class="entry-tag">R4</span><span class="entry-title">The convergence signal must not make the conductor reason over prose</span></div>
+        <div class="entry-body">the round artifacts are free-form, so M1 has each seat emit a machine-parseable <code>VERDICT:</code> token and the conductor only diffs tokens + citations (§11 / principle 1). A seat that moves its mind without changing the token is the residual risk; the adversarial-rephrasing fixture in M1 Phase 1 covers it.</div>
+      </li>
+      
     </ol>
   </section>
   
@@ -801,14 +810,14 @@ footer.colophon code { background: var(--surface-2); }
   
   <section class="block">
     <div class="section-head"><h2 class="section-title">Dependency order</h2><span class="rule"></span></div>
-    <figure class="diagram"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Milestone dependency order: the smarter digest (M4) feeds the auto stop-rule (M1), which feeds the neutral synthesizer (M2); command re-execution (M3) is independent and can ship any time." font-family="'Poppins',-apple-system,sans-serif">
+    <figure class="diagram"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Milestone dependency order: the smarter digest (M4) sharpens the debate signal the auto stop-rule (M1) measures (a soft dependency, shown dashed); M1 then feeds the neutral synthesizer (M2); command re-execution (M3) is independent and can ship any time." font-family="'Poppins',-apple-system,sans-serif">
   <title>Milestone dependency order</title>
   <defs>
     <marker id="arr" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#b0aea5"/>
     </marker>
   </defs>
-  <line x1="222" y1="76" x2="258" y2="76" stroke="#b0aea5" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="222" y1="76" x2="258" y2="76" stroke="#b0aea5" stroke-width="2" stroke-dasharray="4 3" marker-end="url(#arr)"/>
   <line x1="462" y1="76" x2="498" y2="76" stroke="#b0aea5" stroke-width="2" marker-end="url(#arr)"/>
 
   <g>
@@ -842,7 +851,7 @@ footer.colophon code { background: var(--surface-2); }
 
   <!-- ===================== COLOPHON ===================== -->
   <footer class="colophon">
-    Rendered from <code>run-board-v1x.md</code> &middot; 4 milestones &middot; 3/20 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
+    Rendered from <code>run-board-v1x.md</code> &middot; 4 milestones &middot; 2/22 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
   </footer>
 
 </div>

--- a/design/run-board-v1x.md
+++ b/design/run-board-v1x.md
@@ -4,7 +4,7 @@
 - **Updated:** 2026-06-25
 - **Source:** design/run-board-conductor.md §15 + the 2026-06-25 handoff (scope)
 - **Owner:** Tim
-- **Baseline:** advisory-board/v1.0.0 · 229 tests green
+- **Baseline:** advisory-board/v1.0.0 + plan view · 268 tests green
 
 ## Overview
 v1.0.0 shipped the full board: **preflight → egress gate → round-1 fan-out → round-2 cross-reading → canonical verdict chain**. The v1.x line sharpens four edges that the M6 proof-of-life run exposed: the board always runs a fixed number of rounds, the verdict is still an agent hand-off rather than one command, `command`-evidence is captured but never re-executed, and the cross-reading digest is coarse.
@@ -18,21 +18,23 @@ status: wip
 Today the board runs a fixed two rounds. A third round only helps when seats are still *moving* — when round 2 changed minds. `--rounds auto` keeps going while a measurable convergence signal says the debate is live, and stops the moment it goes quiet (or hits a hard ceiling), so we never pay for a round that just restates round 2.
 
 ### Phase 1 — Define the convergence signal
-- [x] Specify the per-seat *movement* metric (verdict shift + new-citation delta between rounds)
-- [x] Decide the stop predicate: stop when board-wide movement < threshold, or `--max-rounds` reached
-- [x] Write the metric as a pure function over `round-N/*.md`
+The round artifacts (`round-N/<seat>.md`) are the seat's free-form prose, so the conductor must **not** infer a verdict from them — that would be reasoning (§11 / principle 1). The seat emits a machine-parseable token the conductor can diff.
+- [x] DECISION: the round template emits one literal `VERDICT: ship|caution|block` line per seat — the model reasons, the conductor only reads the token (this changes the egressed prompt, so `prompt_template_sha` and the prompt version bump)
+- [x] DECISION: movement = verdict-token shift + new-citation delta between a seat's round N-1 and N; board-wide movement `< threshold` (or `--max-rounds`) stops
+- [ ] Add the `VERDICT:` line to the ROUND1/ROUND2 templates and bump the prompt version
+- [ ] Implement the metric as a pure function over the parsed token + citation set (no prose inference)
 - [wip] Decide sane defaults for the threshold and the ceiling
-Testing: unit tests for the metric on hand-built two-round fixtures (moved / unchanged / mixed); a property test that movement is zero when round N == round N-1.
+Testing: unit tests on hand-built two-round fixtures (moved / unchanged / mixed); a property test that movement is zero when round N == round N-1; an adversarial fixture where a seat rephrases its prose but the `VERDICT` token is unchanged (must read as *no move*).
 Gate: `python3 -m unittest discover -s tests -t tests`
 
 ### Phase 2 — Wire `--rounds auto` through the conductor
 status: todo
-- [ ] Add `auto` to the `--rounds` arg and the recipe schema
+- [ ] Replace the clamp-to-2 deferral note (`auto`/`3` already parse — `cli.py`/`config.py`/`recipe.py`) with the real round loop
 - [ ] Loop rounds in `rounds.py` until the stop predicate fires
 - [ ] Record the per-round movement + stop reason in provenance
 - [ ] A mock run that converges in 2 and one that needs 3, both deterministic
 Testing: end-to-end mock-CLI runs asserting the stop reason and round count; provenance has the movement trace.
-Gate: `PATH="$PWD/tests/mocks:$PATH" python3 scripts/run_board.py run --recipe tests/fixtures/auto.json --check`
+Gate: `PATH="$PWD/tests/mocks:$PATH" python3 scripts/run_board.py run --source tests/fixtures/sample-plan.md --rounds auto --out "$(mktemp -d)" --yes`
 
 ## Milestone: Neutral synthesizer seat
 status: todo
@@ -44,7 +46,7 @@ status: todo
 - [ ] Spawn it as a no-lens seat that reads `round-N/*.md` only
 - [ ] Validate its output against the `verdict@2` schema before accepting
 Testing: feed the committed example's rounds to the synthesizer mock; assert schema-valid `verdict@2` and that evidence ids resolve.
-Gate: `python3 scripts/run_board.py verify /tmp/v.json --run examples/payments-idempotency-review --check`
+Gate: `python3 scripts/run_board.py verify /tmp/v.json --run ../../examples/payments-idempotency-review --check`
 
 ### Phase 2 — Make it optional + auditable
 status: todo
@@ -68,10 +70,11 @@ Gate: `python3 -m unittest discover -s tests -t tests`
 
 ## Milestone: Smarter cross-reading digest
 status: todo
-Round 2 hands each seat a digest of the others' round-1 reviews via `prompts._digest`. It is currently a flat concatenation. A structured digest — grouped by claim, with agreements and conflicts surfaced — gives round 2 (and the `auto` stop-rule) a sharper signal to debate against.
+Round 2 hands each seat a round-2 packet of the others' round-1 reviews, assembled by `prompts.build_round2_packet`. Under `cross_reading=summaries` each review is head-truncated to a char budget by `prompts._digest`; under `full` the reviews are concatenated verbatim. A structured digest — grouped by claim, with agreements and conflicts surfaced — would replace this, giving round 2 (and the `auto` stop-rule) a sharper signal to debate against.
 
 ### Phase 1 — Structure the digest
 status: todo
+- [ ] Decide scope: does the structured digest replace the `summaries` path only, or `full` too
 - [ ] Extract per-seat claims and cluster the overlapping ones
 - [ ] Render agreements vs. conflicts, not a raw dump
 - [ ] Keep it within the token budget the seats already assume
@@ -88,17 +91,18 @@ Gate: `python3 -m unittest discover -s tests -t tests`
 - **R1** Auto-rounds runaway — a board that never converges burns tokens; the `--max-rounds` ceiling and a flagged-large-run prompt are the backstop.
 - **R2** Synthesizer smuggles in new opinion — mitigated by schema validation, the no-lens briefing, and keeping the human gate on the final call.
 - **R3** Command re-execution side effects — mitigated by the allowlist plus the existing egress/quarantine gate; anything off-list stays `unverified`, never silently trusted.
+- **R4** The convergence signal must not make the conductor reason over prose — the round artifacts are free-form, so M1 has each seat emit a machine-parseable `VERDICT:` token and the conductor only diffs tokens + citations (§11 / principle 1). A seat that moves its mind without changing the token is the residual risk; the adversarial-rephrasing fixture in M1 Phase 1 covers it.
 
 ## Dependency order
 ```svg
-<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Milestone dependency order: the smarter digest (M4) feeds the auto stop-rule (M1), which feeds the neutral synthesizer (M2); command re-execution (M3) is independent and can ship any time." font-family="'Poppins',-apple-system,sans-serif">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Milestone dependency order: the smarter digest (M4) sharpens the debate signal the auto stop-rule (M1) measures (a soft dependency, shown dashed); M1 then feeds the neutral synthesizer (M2); command re-execution (M3) is independent and can ship any time." font-family="'Poppins',-apple-system,sans-serif">
   <title>Milestone dependency order</title>
   <defs>
     <marker id="arr" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#b0aea5"/>
     </marker>
   </defs>
-  <line x1="222" y1="76" x2="258" y2="76" stroke="#b0aea5" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="222" y1="76" x2="258" y2="76" stroke="#b0aea5" stroke-width="2" stroke-dasharray="4 3" marker-end="url(#arr)"/>
   <line x1="462" y1="76" x2="498" y2="76" stroke="#b0aea5" stroke-width="2" marker-end="url(#arr)"/>
 
   <g>


### PR DESCRIPTION
Follows the planning directive: the v1.x plan **content** gets its own adversarial review **before any implementation**. A five-lens review (each lens grounded in the real `_conductor/` code + spec, not vibes) of `design/run-board-v1x.md` surfaced 14 confirmed findings; this applies the correctness fixes.

### What changed
- **M1 Phase 1 (the substantive one).** The movement metric was specified as "a pure function over `round-N/*.md`" — but those artifacts are the seat's **free-form prose**, so recovering a verdict would force the *conductor* to reason over prose, violating §11 / principle 1 ("models reason; the conductor plumbs"). Re-scoped: each seat emits a machine-parseable `VERDICT: ship|caution|block` line (the model reasons; the conductor only diffs the token + citation set). Added the `prompt_template_sha`/version bump, an adversarial-rephrasing test (prose changes, token doesn't → reads as *no move*), and **risk R4**.
- **M1 Phase 2.** The validation-gate command cited flags that don't exist (`run` has no `--recipe` or `--check`; recipe is YAML; a real run needs `--yes` to clear the egress gate). Rewritten to a real mock-run shape. Also reworded "add `auto` to `--rounds`" — that already shipped in v1.0.0 (it clamps to 2 today; the real work is the loop).
- **M2 Phase 1.** Fixed the gate's example path for the advisory-board cwd (`../../examples/…`). *The review also confirmed M2's neutral-synthesizer seat does **not** violate §11* — a spawned reasoning seat is exactly what §11/§15 contemplate.
- **M4.** Corrected the digest description: `build_round2_packet` assembles the round-2 packet; `_digest` is head-truncation under `cross_reading=summaries` only (not a flat concat). Added a mode-scope task.
- **Dependency diagram.** Softened the M4→M1 "feeds" arrow to a dashed **soft** dependency (M4 sharpens the signal M1 measures; it isn't a data feed).

### Honesty
Re-rendered the view → it now reads **9% (2/22 tasks)**, reflecting reality: only the two design decisions are settled; no v1.x code is written. The drift guard keeps the HTML in sync with the markdown.

268 tests OK. No code touched — this is the plan doc + its rendered view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)