### PR TITLE
advisory-board: plain-language, lens-aware verdict label (v1.6.0)

### DIFF
--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -8,6 +8,37 @@ Pre-1.0 the minor tracks the conductor milestone (M5 → `v0.5.0`, M6 → `v0.6.
 reserved for an explicit production-ready call. The verdict-JSON schema is versioned separately
 (`advisory-board/verdict@N`) and is not the same axis as the release version.
 
+## [v1.6.0] - 2026-06-26 — Plain-language, lens-aware verdict label
+
+The machine token `verdict: ship|caution|block` stays byte-identical (the gate
+axis is untouched), but the **human-facing label** is now lens-aware. A
+`software-architecture` board keeps the familiar `SHIP` / `SHIP WITH CHANGES` /
+`DO NOT SHIP YET`; every other lens preset (product, research, legal, business,
+writing — and any unknown one) renders plain language — `Go ahead` / `Proceed
+with care` / `Stop and rethink` — plus a one-line "what this means" note, so a
+non-developer reader isn't handed shipping jargon. An explicit `decision` field
+still wins verbatim.
+
+### Added
+- **`lens_preset` in `verdict.json`** — the conductor writes the run's board-level
+  lens preset name into the canonical verdict so the renderers (which read it
+  standalone) can pick the right label family. Type-checked (optional string) by
+  `board_verdict.py`; documented in `references/verdict-schema.md`. A wholly
+  absent field defaults to the software family (backward compatible: every
+  pre-feature verdict.json was a software-lens run).
+- **Shared `scripts/_verdict_labels.py`** — one `human_label(token, lens_preset,
+  decision)` source of truth so the three renderers stop diverging (they each
+  carried their own, already-drifted, label map).
+
+### Changed
+- `render_verdict.py` (Markdown headline, handoff `verdict`/`verdict_note`,
+  per-round pills) and `format_output.py` (`verdict_line`) now resolve labels
+  through `_verdict_labels.human_label`. The handoff banner color
+  (`verdict_class`) stays keyed on the **raw** token, not the label. Plain labels
+  keep their natural case (no shouted "STOP AND RETHINK").
+- The M2 synthesizer prompt gains a light `decision` optional-field nudge
+  (template version `synthesizer@1` → `@2`).
+
 ## [v1.5.0] - 2026-06-26 — Repo-grounded review (`--repo`)
 
 Optional `--repo PATH` augments `--source`: the source file frames the question

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -16,6 +16,7 @@ via `scripts/render_handoff.py`. It drives tooling — most usefully a **CI / la
   "verdict": "block",
   "confidence": "high",
   "unanimous": true,
+  "lens_preset": "software-architecture",
   "rounds": 2,
   "board": [
     {
@@ -55,7 +56,15 @@ via `scripts/render_handoff.py`. It drives tooling — most usefully a **CI / la
   gate axis. (`abstain` is **not** a `verdict` value — it is a *gate outcome* computed at gate
   time from observed agreement; see below. It can't be self-asserted, by design.)
 - `decision` (optional) — the native call when the decision isn't software-shipping (e.g.
-  `invest` / `hold` / `wind-down`). Map it onto `verdict`; tooling reads `verdict`.
+  `invest` / `hold` / `wind-down`). Map it onto `verdict`; tooling reads `verdict`. When set,
+  it's the human label verbatim — it wins over the lens-derived label below.
+- `lens_preset` (optional) — the board-level lens preset name the run used (e.g.
+  `software-architecture`, `business-decision`, `research-paper`). The conductor writes it; it
+  picks the **human-facing** verdict label only — the machine `verdict` token is untouched. A
+  `software-architecture` board (and an old file with no `lens_preset`) keeps the legacy
+  `SHIP` / `SHIP WITH CHANGES` / `DO NOT SHIP YET` labels; every other preset (and any unknown
+  one) renders plain language — `Go ahead` / `Proceed with care` / `Stop and rethink` — plus a
+  one-line "what this means" note. An explicit `decision` overrides all of this.
 - `confidence` — `low` | `medium` | `high`. A self-reported number; informational. **The gate
   never reads it** — a gameable confidence must not move a gate.
 - `unanimous` — did every seat land on `verdict` in the final round.
@@ -102,6 +111,7 @@ file *may* carry `evidence[]`, and a malformed item is rejected regardless of ve
 - `verdict` ∈ {ship, caution, block}; `confidence` ∈ {low, medium, high}; `rounds` a positive int.
 - each `board[]` seat has `seat`, `model`, a non-empty `round_verdicts` (every entry a valid
   verdict); `lens`/`dropped` type-checked when present.
+- `lens_preset` is a string when present (it selects the human label; it never moves a gate).
 - at least **two** seats actually ran (a `dropped` seat doesn't count — a one-voice board isn't a board).
 - if `unanimous` is present, it matches the seats' final-round verdicts.
 - every `evidence[]` item (on blockers/dissent/concerns or at the top level) is well-formed for

--- a/skills/advisory-board/scripts/_conductor/synthesizer.py
+++ b/skills/advisory-board/scripts/_conductor/synthesizer.py
@@ -134,6 +134,11 @@ Required content fields:
   medium = a clear majority, low = torn or a single voice carrying the call.
 
 Optional content fields (include each only when the reviews support it):
+- `decision` (string): the board's call in its OWN domain language, for when "ship"
+  reads oddly — e.g. `invest` / `hold` / `wind-down` for a business decision, `accept`
+  / `revise` / `reject` for a paper. It becomes the human-facing label verbatim; the
+  machine `verdict` stays the gate axis. Set it only when the board's domain has a
+  natural word the reviews used; a software-shipping board needs none.
 - `blockers` (array of objects): a deduplicated list of the load-bearing objections
   the board raised in the final round. Each object: `title` (short), `body`
   (the seat-grounded reasoning), `evidence` (array — see below).
@@ -175,8 +180,9 @@ Reply with the ```json``` fence and nothing else.
 
 # Bump when the template shape (or its escape semantics) changes. The sha covers
 # the exact bytes, so any edit changes the recorded sha even without a bump. @1 is
-# the v1.3.0 first-cut of the M2 synthesizer prompt.
-SYNTHESIZER_TEMPLATE_VERSION = "advisory-board/synthesizer@1"
+# the v1.3.0 first-cut of the M2 synthesizer prompt; @2 adds the optional `decision`
+# field guidance (the plain-language / lens-aware verdict label, v1.6.0).
+SYNTHESIZER_TEMPLATE_VERSION = "advisory-board/synthesizer@2"
 
 
 def synthesizer_template_sha() -> str:
@@ -260,6 +266,10 @@ def build_skeleton(config: RunConfig, rounds_done: list) -> dict:
         "schema": "advisory-board/verdict@2",
         "title": config.title,
         "date": config.date,
+        # The board-level lens preset name, so the renderers (which read verdict.json
+        # standalone) can pick a lens-aware human label without re-deriving it. The
+        # machine `verdict` token is unaffected — this only colors the human label.
+        "lens_preset": config.lens,
         "rounds": rounds_run,
         "board": board,
     }
@@ -432,6 +442,12 @@ def merge_synthesizer_content(skeleton: dict, content: dict) -> dict:
                          f"{type(content).__name__}")
     safe = {k: v for k, v in content.items() if k not in PROTECTED_SKELETON_KEYS}
     merged = {**skeleton, **safe}
+    # `lens_preset` is conductor-authoritative (it names the run's board preset). It's
+    # not in PROTECTED_SKELETON_KEYS — keeping that set, and the prompt's enumeration
+    # of it, byte-stable — so re-pin it from the skeleton here, the same way we never
+    # trust a model-asserted `unanimous`.
+    if "lens_preset" in skeleton:
+        merged["lens_preset"] = skeleton["lens_preset"]
     final_tokens = {seat["round_verdicts"][-1] for seat in skeleton.get("board", [])
                     if seat.get("round_verdicts") and not seat.get("dropped")}
     if "verdict" in merged and final_tokens:

--- a/skills/advisory-board/scripts/_verdict_labels.py
+++ b/skills/advisory-board/scripts/_verdict_labels.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Lens-aware human label for a `verdict.json` token.
+
+The machine token `verdict` (`ship` | `caution` | `block`) is the canonical gate
+axis and stays byte-identical everywhere — downstream parsing depends on it. But
+the *human-facing* label rendered to a reader should fit the board's lens. A
+software-architecture board ships code, so "SHIP / SHIP WITH CHANGES / DO NOT SHIP
+YET" reads naturally. A product, research, legal, business, or writing board does
+not "ship" anything — that jargon confused a non-developer reader — so for every
+non-software preset (and any unknown one) we render plain language plus a one-line
+"what this means" note.
+
+The three renderers (`render_verdict.py` Markdown + handoff data, `format_output.py`
+share formats) all consumed their own copy of the legacy software map; they now call
+:func:`human_label` here so the families live in one place and can't drift apart.
+
+Precedence (unchanged): an explicit `decision` field — the board's native call when
+the decision isn't software-shipping (`invest` / `hold` / `wind-down`) — always wins
+over the token map; we return it verbatim with no note.
+
+Standard library only; no third-party dependencies.
+"""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+# The legacy software-shipping labels. Used only for the `software-architecture`
+# preset (the historical default), so existing software boards read unchanged.
+SOFTWARE_LABELS = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP YET"}
+
+# Plain language for every other lens (and any unknown preset). No shipping metaphor.
+PLAIN_LABELS = {"ship": "Go ahead", "caution": "Proceed with care", "block": "Stop and rethink"}
+
+# A one-line "what this means" note for each plain verdict — the bit a non-developer
+# reader actually wanted. Software boards keep their familiar label and get no note.
+PLAIN_NOTES = {
+    "ship": "The board sees no blocking concerns — proceed with confidence.",
+    "caution": "Workable, but address the flagged concerns before you go ahead.",
+    "block": "The board found serious problems — don't proceed as-is.",
+}
+
+# The one preset that keeps the software-shipping labels. Absent/unknown presets fall
+# through to PLAIN — EXCEPT a wholly missing field, which defaults to software for
+# backward compatibility (every pre-feature verdict.json was a software-lens run and
+# carried no `lens_preset`; see `human_label`).
+SOFTWARE_PRESET = "software-architecture"
+
+
+def is_software_lens(lens_preset: Optional[str]) -> bool:
+    """True when the board-level preset is the software-architecture family.
+
+    A wholly absent preset (``None`` — an old verdict.json written before this field
+    existed) defaults to software: those runs were all software-lens, and defaulting
+    to plain would silently relabel them. An explicit-but-unknown string is treated
+    as plain (it isn't the one special case)."""
+    if lens_preset is None:
+        return True
+    return lens_preset == SOFTWARE_PRESET
+
+
+def human_label(token: str, lens_preset: Optional[str] = None,
+                decision: Optional[str] = None) -> Tuple[str, Optional[str]]:
+    """Resolve a verdict token to a (label, note) pair for human display.
+
+    * an explicit ``decision`` wins verbatim, with no note (it's already the board's
+      own words for the call);
+    * else a software-lens board gets the legacy SHIP/… label and no note;
+    * else (every other preset, and any unknown one) the plain label plus its
+      one-line "what this means" note.
+
+    ``note`` is ``None`` whenever there's nothing to add (a decision, or a software
+    label); callers render it only when present."""
+    if decision:
+        return decision, None
+    if is_software_lens(lens_preset):
+        return SOFTWARE_LABELS.get(token, str(token)), None
+    return PLAIN_LABELS.get(token, str(token)), PLAIN_NOTES.get(token)

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -173,6 +173,11 @@ def validate(data: dict) -> None:
     if len(ran) < 2:
         die(f"a board needs >= 2 seats that ran; found {len(ran)} (dropped seats don't count)")
 
+    # Optional board-level lens preset (e.g. "software-architecture", "business-decision").
+    # Used only to pick a lens-aware human label; the machine `verdict` is unaffected.
+    if "lens_preset" in data and not isinstance(data["lens_preset"], str):
+        die(f"lens_preset must be a string when present; got {type(data['lens_preset']).__name__}")
+
     for key in EVIDENCE_CONTAINERS:
         if key in data and not isinstance(data[key], list):
             die(f"{key} must be a list when present; got {type(data[key]).__name__}")

--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 
-LABEL = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP"}
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _verdict_labels import human_label, is_software_lens  # noqa: E402  lens-aware label
 
 
 def die(message: str) -> None:
@@ -36,8 +38,14 @@ def load(path: str) -> dict:
 
 def verdict_line(data: dict) -> str:
     stance = "unanimous" if data.get("unanimous") else "split board"
-    label = data.get("decision") or LABEL.get(data.get("verdict"), str(data.get("verdict")))
-    return f"{label.upper()} ({data.get('confidence', '?')} confidence, {stance})"
+    lens_preset = data.get("lens_preset")
+    label, _ = human_label(data.get("verdict"), lens_preset, data.get("decision"))
+    # Software labels (and a native decision) read as upper-case tokens, as they
+    # always have; plain-language labels keep their natural case so "Stop and rethink"
+    # doesn't become a shouted "STOP AND RETHINK".
+    if data.get("decision") or is_software_lens(lens_preset):
+        label = label.upper()
+    return f"{label} ({data.get('confidence', '?')} confidence, {stance})"
 
 
 def as_tldr(data: dict) -> str:

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -37,8 +37,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _render_engine import die  # noqa: E402  shared with the other renderers
+from _verdict_labels import human_label  # noqa: E402  lens-aware label, shared with format_output
 
-LABEL = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP YET"}
 STATUS_WORD = {"verified": "verified", "unverified": "unverified", "refuted": "REFUTED"}
 EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
 
@@ -125,10 +125,13 @@ def render_markdown(data: dict) -> str:
     out.append(f"Board: {seats}. Rounds: {rounds}.")
     out.append("")
 
-    label = data.get("decision") or LABEL.get(data.get("verdict"), str(data.get("verdict")))
+    label, note = human_label(data.get("verdict"), data.get("lens_preset"), data.get("decision"))
     out.append(f"## Verdict: {label} — {_stance(data)} ({data.get('confidence', '?')} confidence)")
-    if data.get("verdict_note"):
-        out.append(data["verdict_note"])
+    # An explicit verdict_note (authored in the verdict.json) wins; else the plain
+    # "what this means" line a non-software lens supplies.
+    note = data.get("verdict_note") or note
+    if note:
+        out.append(note)
     out.append("")
 
     blockers = data.get("blockers", [])
@@ -265,7 +268,11 @@ def _round_review(run_dir, seat_name: str, round_no: int, verdict: str) -> str:
 
 def build_handoff_data(data: dict, run_dir=None) -> dict:
     verdict = data.get("verdict", "")
-    label = data.get("decision") or LABEL.get(verdict, str(verdict))
+    lens_preset = data.get("lens_preset")
+    label, note = human_label(verdict, lens_preset, data.get("decision"))
+    # An explicit verdict_note (authored) wins; else the plain lens note. The banner
+    # color (verdict_class) stays keyed on the raw token, never the lens label.
+    verdict_note = data.get("verdict_note") or note
     hd = {
         # non-RAW slots (the renderer escapes them) -> _plain; RAW slots -> _raw.
         "title": _plain(data.get("title", "Advisory Board review")),
@@ -275,7 +282,7 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         "rounds": str(data.get("rounds", "")),
         "verdict": _plain(f"{label} — {_stance(data)}"),
         "verdict_class": _VERDICT_CLASS.get(verdict, ""),
-        "verdict_note": _raw(data["verdict_note"]) if data.get("verdict_note") else "",
+        "verdict_note": _raw(verdict_note) if verdict_note else "",
         "plan": _raw(data.get("title", "")),
         "metadata": "Rendered from <code>verdict.json</code> by <code>scripts/render_verdict.py</code>.",
         "dissent_flag": "Dissent on the record" if data.get("dissent") else "",
@@ -293,12 +300,16 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         name = seat.get("seat", "?")
         rounds = []
         for round_no, rv in enumerate(seat.get("round_verdicts", []), 1):
+            # Per-round pills follow the board-level lens family (the note is for the
+            # headline only; a pill is just the short label). No `decision` here — a
+            # round_verdict is always a raw ship/caution/block token.
+            rv_label, _ = human_label(rv, lens_preset)
             rounds.append({
                 "round_label": f"Round {round_no}",
-                "round_verdict": _plain(LABEL.get(rv, rv)),
+                "round_verdict": _plain(rv_label),
                 "round_verdict_class": _VERDICT_CLASS.get(rv, ""),
                 "round_confidence": "",
-                "round_review": _round_review(run_dir, name, round_no, LABEL.get(rv, rv)),
+                "round_review": _round_review(run_dir, name, round_no, rv_label),
             })
         lens = seat.get("lens", "") or ""
         hd["seats"].append({

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -35,6 +35,8 @@ import run_board as rb  # noqa: E402
 import board_verdict as bv  # noqa: E402  (M5: schema @2 + abstain gate)
 import verify_evidence as ve  # noqa: E402  (M5: evidence resolution)
 import render_verdict as rv  # noqa: E402  (M5: consensus render)
+import format_output as fo  # noqa: E402  (share formats; lens-aware verdict label)
+import _verdict_labels as vl  # noqa: E402  (lens-aware human label module)
 from _conductor import grounding as grd  # noqa: E402  (repo-grounding: scope/snapshot/manifest)
 from _conductor.config import resolve_config as resolve_config  # noqa: E402
 
@@ -3154,6 +3156,10 @@ class TestRenderVerdict(unittest.TestCase):
     def setUp(self):
         with open(VERDICT_M5) as fh:
             self.data = json.load(fh)
+        # This fixture is a software-architecture board; make that explicit so these
+        # tests are a deliberate regression guard for the legacy SHIP/… labels (the
+        # plain-language family is exercised in TestVerdictLabels below).
+        self.data["lens_preset"] = "software-architecture"
         ve.stamp(self.data, SRC_FIXTURE, open(PACKET_FIXTURE).read())
 
     def test_markdown_has_decision_and_evidence(self):
@@ -3198,6 +3204,124 @@ class TestRenderVerdict(unittest.TestCase):
             # end-to-end: render_handoff converts it to real HTML exactly once
             html_out = rh.render(hd, open(rh.default_template()).read())
             self.assertIn("<code>SET NX</code>", html_out)
+
+
+class TestVerdictLabels(unittest.TestCase):
+    """The plain-language, lens-aware verdict label (v1.6.0)."""
+
+    # --- the shared label module ------------------------------------------- #
+
+    def test_software_lens_keeps_legacy_labels(self):
+        for token, label in (("ship", "SHIP"), ("caution", "SHIP WITH CHANGES"),
+                             ("block", "DO NOT SHIP YET")):
+            got, note = vl.human_label(token, "software-architecture")
+            self.assertEqual(got, label)
+            self.assertIsNone(note)  # software labels carry no "what this means" note
+
+    def test_absent_preset_defaults_to_software(self):
+        # An old verdict.json with no lens_preset must read unchanged (backward compat).
+        self.assertEqual(vl.human_label("block", None), ("DO NOT SHIP YET", None))
+
+    def test_non_software_lens_is_plain_with_note(self):
+        cases = {
+            "ship": ("Go ahead", vl.PLAIN_NOTES["ship"]),
+            "caution": ("Proceed with care", vl.PLAIN_NOTES["caution"]),
+            "block": ("Stop and rethink", vl.PLAIN_NOTES["block"]),
+        }
+        for token, (label, note) in cases.items():
+            self.assertEqual(vl.human_label(token, "business-decision"), (label, note))
+
+    def test_unknown_preset_falls_to_plain(self):
+        self.assertEqual(vl.human_label("ship", "totally-made-up"),
+                         ("Go ahead", vl.PLAIN_NOTES["ship"]))
+
+    def test_explicit_decision_overrides_lens_label(self):
+        # A native `decision` wins verbatim under any lens, with no note.
+        self.assertEqual(vl.human_label("block", "business-decision", decision="wind-down"),
+                         ("wind-down", None))
+        self.assertEqual(vl.human_label("ship", "software-architecture", decision="invest"),
+                         ("invest", None))
+
+    # --- render_verdict.py: Markdown + HTML handoff ------------------------ #
+
+    def _plain_verdict(self):
+        return _verdict("block", "block", "block", title="Q3 expansion",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "Unit economics", "body": "Margin is negative."}])
+
+    def test_markdown_plain_label_and_note(self):
+        md = rv.render_markdown(self._plain_verdict())
+        self.assertIn("## Verdict: Stop and rethink", md)
+        self.assertIn(vl.PLAIN_NOTES["block"], md)
+        self.assertNotIn("DO NOT SHIP", md)  # no software jargon on a non-software lens
+
+    def test_markdown_explicit_decision_wins_over_lens(self):
+        data = _verdict("block", "block", "block", title="t",
+                        lens_preset="business-decision", decision="wind-down")
+        md = rv.render_markdown(data)
+        self.assertIn("## Verdict: wind-down", md)
+        self.assertNotIn("Stop and rethink", md)
+
+    def test_handoff_plain_label_note_and_class(self):
+        hd = rv.build_handoff_data(self._plain_verdict())
+        self.assertIn("Stop and rethink", hd["verdict"])
+        # verdict_note is a RAW (HTML-escaped) slot, so match the escaped form.
+        self.assertIn("The board found serious problems", hd["verdict_note"])
+        # The banner color stays keyed on the RAW token, not the lens label.
+        self.assertEqual(hd["verdict_class"], "block")
+
+    def test_handoff_html_round_trips_plain_label(self):
+        import render_handoff as rh
+        hd = rv.build_handoff_data(self._plain_verdict())
+        with open(rh.default_template()) as fh:
+            template = fh.read()
+        html_out = rh.render(hd, template)  # dies on any leftover token
+        self.assertIn("Stop and rethink", html_out)
+        self.assertIn("verdict block", html_out)  # raw-token color class survives
+
+    def test_handoff_round_pills_follow_lens(self):
+        hd = rv.build_handoff_data(_verdict("caution", "caution", "ship",
+                                            lens_preset="research-paper"))
+        pills = [r["round_verdict"] for s in hd["seats"] for r in s["rounds"]]
+        self.assertIn("Proceed with care", pills)
+        self.assertIn("Go ahead", pills)
+
+    def test_authored_verdict_note_wins_over_lens_note(self):
+        data = self._plain_verdict()
+        data["verdict_note"] = "Authored override note."
+        md = rv.render_markdown(data)
+        self.assertIn("Authored override note.", md)
+        self.assertNotIn(vl.PLAIN_NOTES["block"], md)
+
+    # --- format_output.py: verdict_line ------------------------------------ #
+
+    def test_format_output_software_uppercases(self):
+        data = _verdict("block", "block", "block", lens_preset="software-architecture")
+        self.assertIn("DO NOT SHIP YET", fo.verdict_line(data))
+
+    def test_format_output_plain_keeps_natural_case(self):
+        data = _verdict("block", "block", "block", lens_preset="business-decision")
+        line = fo.verdict_line(data)
+        self.assertIn("Stop and rethink", line)
+        self.assertNotIn("STOP AND RETHINK", line)  # plain labels aren't shouted
+
+    def test_format_output_decision_overrides(self):
+        data = _verdict("block", "block", "block", lens_preset="business-decision",
+                        decision="wind-down")
+        self.assertIn("WIND-DOWN", fo.verdict_line(data))  # a decision still upper-cases
+
+    # --- the machine contract is untouched --------------------------------- #
+
+    def test_lens_preset_validates_and_gate_ignores_it(self):
+        data = _verdict("block", "block", "block", lens_preset="business-decision")
+        bv.validate(data)  # a string lens_preset is accepted
+        # The gate reads the raw token, never the human label.
+        outcome, _ = bv.gate_outcome(data, "block")
+        self.assertEqual(outcome, "fail")
+
+    def test_lens_preset_must_be_string(self):
+        with self.assertRaises(SystemExit):
+            bv.validate(_verdict("ship", "ship", "ship", lens_preset=42))
 
 
 class TestM5ChainDelegation(EnvMixin):
@@ -3468,6 +3592,24 @@ class TestSynthesizerPureFunctions(unittest.TestCase):
         merged = rb.merge_synthesizer_content(skel, {"verdict": "ship", "confidence": "high"})
         self.assertTrue(merged["unanimous"])
 
+    def test_merge_repins_lens_preset_blocks_smuggle(self):
+        # `lens_preset` is conductor-authoritative (it names the run's board preset
+        # and selects the human-facing label family), but it is deliberately NOT in
+        # PROTECTED_SKELETON_KEYS — so under `{**skeleton, **safe}` a model-asserted
+        # value in `content` would survive without the explicit re-pin. The merge
+        # must keep the skeleton's value, not the smuggled one.
+        skel = {"schema": "advisory-board/verdict@2", "title": "T", "date": "D",
+                "rounds": 2, "lens_preset": "business-decision", "board": [
+                    {"seat": "Claude", "model": "m", "round_verdicts": ["ship", "ship"],
+                     "dropped": False}]}
+        content = {"lens_preset": "software-architecture",
+                   "verdict": "ship", "confidence": "high"}
+        merged = rb.merge_synthesizer_content(skel, content)
+        self.assertEqual(merged["lens_preset"], "business-decision")
+        # The non-protected fields the synthesizer legitimately set still flow through.
+        self.assertEqual(merged["verdict"], "ship")
+        self.assertEqual(merged["confidence"], "high")
+
     def test_choose_synthesizer_seat_defaults_to_claude(self):
         config = rb.resolve_config(_args(source=SAMPLE, out=tempfile.mkdtemp(prefix="b-")))
         # rounds_done can be empty for this branch — choose only looks at the board
@@ -3517,7 +3659,7 @@ class TestSynthesizerPromptShape(unittest.TestCase):
         # Sha is stable.
         self.assertEqual(rb.synthesizer_template_sha(),
                          rb.synthesizer_template_sha())
-        self.assertEqual(rb.SYNTHESIZER_TEMPLATE_VERSION, "advisory-board/synthesizer@1")
+        self.assertEqual(rb.SYNTHESIZER_TEMPLATE_VERSION, "advisory-board/synthesizer@2")
 
     def test_build_skeleton_per_seat_verdicts_come_from_parse(self):
         config = rb.resolve_config(_args(source=SAMPLE, out=tempfile.mkdtemp(prefix="b-")))
@@ -3536,6 +3678,25 @@ class TestSynthesizerPromptShape(unittest.TestCase):
         self.assertEqual(names, ["Claude", "Codex", "Gemini"])
         verds = [s["round_verdicts"] for s in skel["board"]]
         self.assertEqual(verds, [["block", "block"], ["caution", "block"], ["block", "block"]])
+
+    def test_build_skeleton_writes_lens_preset_from_config(self):
+        # The skeleton must carry the run's board-level lens preset name so the
+        # standalone renderers can pick a lens-aware human label without re-deriving
+        # it. It comes straight from config.lens — assert a NON-default preset lands.
+        config = rb.resolve_config(_args(source=SAMPLE, out=tempfile.mkdtemp(prefix="b-"),
+                                         lens="business-decision"))
+        self.assertEqual(config.lens, "business-decision")
+        rounds = [
+            [_sr("claude", 1, "ok\nVERDICT: ship"),
+             _sr("codex",  1, "ok\nVERDICT: ship"),
+             _sr("gemini", 1, "ok\nVERDICT: ship")],
+            [_sr("claude", 2, "ok\nVERDICT: ship"),
+             _sr("codex",  2, "ok\nVERDICT: ship"),
+             _sr("gemini", 2, "ok\nVERDICT: ship")],
+        ]
+        skel = rb.build_skeleton(config, rounds)
+        self.assertEqual(skel["lens_preset"], "business-decision")
+        self.assertEqual(skel["lens_preset"], config.lens)
 
 
 class TestSynthesizerConfig(EnvMixin):


### PR DESCRIPTION
## What

Renders the board verdict in **plain, lens-aware language** for non-developer audiences, while keeping the machine token (`VERDICT: ship|caution|block`) byte-identical.

- New shared module `scripts/_verdict_labels.py` → `human_label(token, lens_preset, decision) -> (label, note)`; all three renderers (`render_verdict.py`, `format_output.py`, the HTML handoff) now route through it instead of three drifted hard-coded maps.
- `software-architecture` lens keeps the legacy labels ("SHIP / SHIP WITH CHANGES / DO NOT SHIP YET"); every other lens (and unknown/general) renders plain language ("Go ahead / Proceed with care / Stop and rethink") plus a one-line "what this means" note.
- Threads the board-level `lens_preset` into `verdict.json` (written by the conductor, re-pinned so a synthesizer reply can't smuggle/override it, type-checked in `board_verdict.py`), documented in `references/verdict-schema.md`.
- Explicit `decision` field still wins over the lens label (preserves the invest/hold/wind-down path).

## Contract preservation

The per-seat `VERDICT:` token and `prompts.py` `VERDICT_LINE_INSTRUCTION` are unchanged (no `prompt_template_sha` churn). `verdict_class` (HTML banner color) still keys on the raw token. Synthesizer template bumped `@1`→`@2` only for the optional-`decision` prompt nudge.

## Tests + review

- 579 tests OK (18 net new, incl. `TestVerdictLabels` + two conductor-side `lens_preset` regression tests covering the smuggle-guard).
- Independent adversarial review (4 finders → skeptic verify) found one real gap — a missing regression test for the smuggling defense — which this PR closes.

First half of the v1.6.0 build-out (GitHub-grounding feature lands separately; tag `advisory-board/v1.6.0` after both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)