### PR TITLE
advisory-board: fix model-not-found false positive on self-referential reviews

### DIFF
--- a/skills/advisory-board/scripts/_conductor/preflight.py
+++ b/skills/advisory-board/scripts/_conductor/preflight.py
@@ -65,7 +65,10 @@ def preflight_seat(seat: SeatConfig, *, network_on: bool, workdir: Optional[str]
     # "degraded-but-ran". This is a stale-CLI / renamed-id symptom, not auth — so
     # probe the seat's fallbacks for a resolvable id to PROPOSE (never auto-apply).
     proposal = None
-    if model_not_found(smoke):
+    # include_stdout: this is the smoke-ping path answering a fixed SMOKE_PROMPT, so
+    # stdout cannot be poisoned by material under review — and claude emits its
+    # genuine "model may not exist" notice to stdout here (grounded 2026-06-25).
+    if model_not_found(smoke, include_stdout=True):
         proposal = propose_model(seat, network_on=network_on, workdir=workdir,
                                   smoke_timeout=smoke_timeout)
         detail = f"version ok; model '{seat.model}' did not resolve ({FAILURE_MODEL})"

--- a/skills/advisory-board/scripts/_conductor/registry.py
+++ b/skills/advisory-board/scripts/_conductor/registry.py
@@ -369,8 +369,20 @@ _MODEL_NOT_FOUND_SIGNALS = (
 )
 
 
-def model_not_found(result: "SpawnResult") -> bool:
-    blob = (result.stdout + "\n" + result.stderr).lower()
+def model_not_found(result: "SpawnResult", *, include_stdout: bool = False) -> bool:
+    # Scan stderr ONLY by default — mirroring auth_failed(): never read the review
+    # on stdout, which may legitimately quote a model-not-found string when the
+    # material under review is this very skill's source (e.g. a seat reviewing the
+    # board's own code echoing the literal "ModelNotFound"). A genuine stale/renamed
+    # id surfaces on stderr (codex/gemini emit it there). The ONE exception is the
+    # smoke-ping path (preflight / propose_model): claude prints its "model may not
+    # exist" notice to stdout with exit 1 there, and that path answers a fixed
+    # SMOKE_PROMPT, so its stdout cannot be poisoned by material under review —
+    # those callers opt in with include_stdout=True.
+    blob = result.stderr
+    if include_stdout:
+        blob = result.stdout + "\n" + blob
+    blob = blob.lower()
     return any(sig in blob for sig in _MODEL_NOT_FOUND_SIGNALS)
 
 

--- a/skills/advisory-board/scripts/_conductor/toolchain.py
+++ b/skills/advisory-board/scripts/_conductor/toolchain.py
@@ -226,6 +226,8 @@ def propose_model(seat: SeatConfig, *, network_on: bool, workdir: Optional[str],
                                   workdir=workdir, network=network_on)
         smoke = spawn(adapter, argv, prompt=SMOKE_PROMPT, timeout=smoke_timeout, cwd=workdir)
         status, _ = classify(smoke, adapter)
-        if status in ("ran", "degraded") and not model_not_found(smoke):
+        # include_stdout: smoke-ping path (fixed SMOKE_PROMPT) where claude emits its
+        # genuine model-not-found notice to stdout — same rationale as preflight_seat.
+        if status in ("ran", "degraded") and not model_not_found(smoke, include_stdout=True):
             return candidate
     return None

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -990,12 +990,26 @@ class TestModelNotFoundDetector(unittest.TestCase):
         return rb.SpawnResult(1, out, err, 0.0, False)
 
     def test_detects_each_providers_grounded_signature(self):
+        # stderr-emitters (codex/gemini) are caught by the stderr-only default.
         self.assertTrue(rb.model_not_found(self._r(err="ModelNotFoundError: Requested entity was not found.")))
-        self.assertTrue(rb.model_not_found(self._r(out="It may not exist or you may not have access to it.")))
         self.assertTrue(rb.model_not_found(self._r(err='"message":"The model is not supported when using Codex"')))
+        # claude prints its notice to stdout — only the smoke-ping callers opt into
+        # scanning stdout (include_stdout=True); see preflight_seat / propose_model.
+        self.assertTrue(rb.model_not_found(
+            self._r(out="It may not exist or you may not have access to it."),
+            include_stdout=True))
+
+    def test_stdout_signal_ignored_by_default(self):
+        # A model-not-found string on stdout must NOT trip the detector by default —
+        # it may be the review legitimately quoting the board's own source. Only an
+        # explicit include_stdout=True (the smoke-ping path) scans stdout.
+        sig = self._r(out="It may not exist or you may not have access to it.")
+        self.assertFalse(rb.model_not_found(sig))
+        self.assertTrue(rb.model_not_found(sig, include_stdout=True))
 
     def test_clean_output_is_not_flagged(self):
         self.assertFalse(rb.model_not_found(self._r(out="ready")))
+        self.assertFalse(rb.model_not_found(self._r(out="ready"), include_stdout=True))
 
 
 class TestToolchainCheck(EnvMixin):
@@ -1354,10 +1368,23 @@ class TestClassifyRound1(unittest.TestCase):
                                           rb.REGISTRY["claude"])
         self.assertEqual((status, fail), ("dropped", rb.FAILURE_TIMEOUT))
 
-    def test_model_not_found(self):
-        out = "There's an issue with the selected model. It may not exist"
-        status, fail = rb.classify_round1(self._r(stdout=out, exit_code=1), rb.REGISTRY["claude"])
+    def test_model_not_found_on_stderr_is_dropped(self):
+        # Genuine detection preserved: a real model-not-found error on STDERR (codex's
+        # invalid_request_error form) still drops the seat as FAILURE_MODEL.
+        err = '{"type":"invalid_request_error","message":"The model is not supported when using Codex"}'
+        status, fail = rb.classify_round1(
+            self._r(stdout="", stderr=err, exit_code=1), rb.REGISTRY["codex"])
         self.assertEqual((status, fail), ("dropped", rb.FAILURE_MODEL))
+
+    def test_review_quoting_model_not_found_string_is_not_dropped(self):
+        # False-positive guard: a HEALTHY seat (exit 0) whose review quotes the
+        # board's own source containing the literal "ModelNotFound" — with a clean
+        # stderr — must NOT be dropped as FAILURE_MODEL. model_not_found scans stderr
+        # only for the round-1 path, mirroring auth_failed.
+        body = (_REAL_REVIEW + "\nThe registry exposes a `ModelNotFound` signal; "
+                "spawn.py raises it when the model id is unknown / no such model.\n")
+        self.assertEqual(rb.classify_round1(self._r(stdout=body), rb.REGISTRY["codex"]),
+                         ("ran", None))
 
     def test_retryable_set(self):
         self.assertEqual(rb.RETRYABLE_FAILURES, frozenset({rb.FAILURE_TIMEOUT, rb.FAILURE_INVALID}))


### PR DESCRIPTION
## The bug

`model_not_found()` (the failure classifier) substring-scanned a seat's **stdout** for tokens like `modelnotfound`. A *healthy* seat (exit 0, full review) got dropped as a non-retryable model failure whenever its answer happened to quote one of those strings — which is exactly what happens when the board reviews its **own source code** (GPT-5.5 quoted `ModelNotFound` from `spawn.py`). Preflight passed because its smoke prompt ("reply 'ready'") can't echo the trigger word.

## The fix

Scope the scan to **stderr only by default**, mirroring `auth_failed()` which already guards this identical hazard. Genuine stale/renamed model ids surface on stderr for codex/gemini, so real detection is preserved.

Nuance (grounded in `registry.py:353-356`, dated 2026-06-25): **claude** emits its genuine model-not-found notice on *stdout*, and only on the smoke-ping path. So `model_not_found(result, *, include_stdout=False)` gains an opt-in: the two **smoke-ping callers** (`preflight_seat`, `propose_model`) pass `include_stdout=True` (fixed `SMOKE_PROMPT` → stdout can't be poisoned), while the **review paths** (`classify_round1`, the synthesizer shape check) take the stderr-only default. Stale claude ids are still caught at preflight, before any review round.

## Tests

581 tests OK (+2 net): a false-positive guard (review quoting `ModelNotFound` + clean stderr → `ran`) and a genuine-detection guard (real error on stderr → `dropped`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)