### PR TITLE
advisory-board: opt-in --strict-exit for CI gates

### DIFF
--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -149,7 +149,11 @@ In CI, treat `3` as "don't auto-merge — a human must decide," distinct from a 
 
 Synthesis stays a reasoning task (§11): the conductor produces clean per-round packets and hands
 them to the orchestrating agent (or one neutral seat) to fill `verdict.json` — it does **not**
-generate the verdict in code. Then the deterministic chain runs:
+generate the verdict in code. When you let the conductor spawn the neutral seat (`run --synthesize`),
+a synth that fails to produce a usable `verdict.json` exits `0` by default (with a loud warning, so a
+synth hiccup never discards the successful rounds). **In CI, pass `run --synthesize --strict-exit`** so
+that failure exits non-zero (`4`, `EXIT_NO_VERDICT`) and the gate can't misread a missing verdict as a
+pass. Then the deterministic chain runs:
 
 ```
 run_board.py verify    verdict.json --source <src-tree> --run <run-dir>   # stamp evidence

--- a/skills/advisory-board/scripts/_conductor/cli.py
+++ b/skills/advisory-board/scripts/_conductor/cli.py
@@ -10,6 +10,7 @@ from _conductor.constants import (
     DEFAULT_LENS,
     DEFAULT_MAX_ROUNDS,
     EXIT_EGRESS_BLOCKED,
+    EXIT_NO_VERDICT,
     EXIT_OK,
     EXIT_PREFLIGHT_NOGO,
     EXIT_USAGE,
@@ -486,6 +487,14 @@ def _run_synthesis_step(config, rounds_done: list, args, last_dir: str, *,
           f"{verdict_path} (advisory-board/verdict@2; cite typed evidence on each "
           "blocker). Then run the deterministic M5 chain "
           f"(verify → consensus → validate --gate).")
+    # Default: exit 0 so a synth hiccup never discards the successful rounds (the
+    # warning + absent verdict.json is the signal). --strict-exit flips ONLY the
+    # return code to EXIT_NO_VERDICT so a CI gate can't misread synth failure as
+    # success — every print, the verdict-rejected.json write, and the fallback
+    # message above are byte-identical in both modes. Both synth-failure modes
+    # (parse error and schema-rejected) flow through here, so both honor the flag.
+    if getattr(args, "strict_exit", False):
+        return EXIT_NO_VERDICT
     return EXIT_OK
 
 
@@ -603,6 +612,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--timeout", type=int, default=None, metavar="SECONDS",
                        help="per-seat hard timeout for the round-1 fan-out "
                             "(default: the adapter cap, 900s = 15 min)")
+    p_run.add_argument("--strict-exit", dest="strict_exit", action="store_true",
+                       help="exit non-zero if --synthesize fails to produce a usable "
+                            "verdict.json (for CI gates). Default exits 0 with a warning "
+                            "so a synth hiccup never discards the successful rounds.")
     p_run.set_defaults(func=cmd_run)
 
     p_tool = sub.add_parser("toolchain",

--- a/skills/advisory-board/scripts/_conductor/constants.py
+++ b/skills/advisory-board/scripts/_conductor/constants.py
@@ -15,6 +15,7 @@ __all__ = [
     "EXIT_PREFLIGHT_NOGO",
     "EXIT_USAGE",
     "EXIT_EGRESS_BLOCKED",
+    "EXIT_NO_VERDICT",
     "PROVIDERS",
     "LENS_PRESETS",
     "DEFAULT_LENS",
@@ -44,6 +45,10 @@ EXIT_OK = 0
 EXIT_PREFLIGHT_NOGO = 1   # fewer than two seats GO, or a delegated gate failed
 EXIT_USAGE = 2            # bad arguments / config / IO
 EXIT_EGRESS_BLOCKED = 3   # consent not granted, or sensitivity forbids egress
+EXIT_NO_VERDICT = 4       # --synthesize failed to produce a usable verdict.json,
+                          # and --strict-exit was set (opt-in CI gate). Without
+                          # --strict-exit the same failure exits EXIT_OK (the
+                          # successful rounds are never discarded by a synth hiccup).
 
 PROVIDERS = {
     "claude": "Anthropic",

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3874,6 +3874,53 @@ class TestSynthesizerE2E(EnvMixin):
         self.assertFalse(os.path.exists(os.path.join(out, "verdict-rejected.json")))
         self.assertIn("synthesizer did NOT produce", text)
 
+    def test_strict_exit_returns_nonzero_on_schema_rejection(self):
+        # --strict-exit + a synth schema failure → EXIT_NO_VERDICT (non-zero), so a
+        # CI gate can't misread the synth failure as success. The warning, the
+        # verdict-rejected.json drop, and the fallback message are unchanged — only
+        # the exit code differs.
+        os.environ["MOCK_CLAUDE_SYNTH_MODE"] = "schema_fail"
+        out = self._out()
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",
+                                 "--synthesize", "--strict-exit"])
+        self.assertEqual(code, rb.EXIT_NO_VERDICT)
+        self.assertNotEqual(code, rb.EXIT_OK)
+        # Same side effects as the default mode — only the return code changed.
+        self.assertFalse(os.path.exists(os.path.join(out, "verdict.json")))
+        self.assertTrue(os.path.exists(os.path.join(out, "verdict-rejected.json")))
+        self.assertIn("synthesizer did NOT produce a usable verdict.json", text)
+
+    def test_strict_exit_returns_nonzero_on_parse_failure(self):
+        # The other synth-failure mode (unparseable output / dropped seat) also
+        # honors --strict-exit.
+        os.environ["MOCK_CLAUDE_SYNTH_MODE"] = "invalid_json"
+        out = self._out()
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",
+                                 "--synthesize", "--strict-exit"])
+        self.assertEqual(code, rb.EXIT_NO_VERDICT)
+        self.assertFalse(os.path.exists(os.path.join(out, "verdict.json")))
+        self.assertIn("synthesizer did NOT produce", text)
+
+    def test_default_exit_zero_on_synth_failure_without_strict(self):
+        # Regression guard: the DEFAULT (no --strict-exit) path must still exit 0 on
+        # a synth failure — a synth hiccup must never discard the successful rounds.
+        os.environ["MOCK_CLAUDE_SYNTH_MODE"] = "schema_fail"
+        out = self._out()
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",
+                                 "--synthesize"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertTrue(os.path.exists(os.path.join(out, "verdict-rejected.json")))
+        self.assertIn("synthesizer did NOT produce a usable verdict.json", text)
+
+    def test_strict_exit_does_not_bite_on_synth_success(self):
+        # --strict-exit only fires on synth FAILURE. A successful synthesis with the
+        # flag set still exits 0 and writes verdict.json.
+        out = self._out()
+        code, _, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",
+                              "--synthesize", "--strict-exit"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertTrue(os.path.exists(os.path.join(out, "verdict.json")))
+
     def test_synthesizer_seat_override_routes_to_codex(self):
         out = self._out()
         code, _, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes",


### PR DESCRIPTION
## The footgun

When `run --synthesize` fails to produce a usable `verdict.json` (malformed/schema-invalid model output, or the synth seat drops), the skill writes `verdict-rejected.json`, prints a `⚠` warning, falls back to manual authoring — and **exits 0**. That's intentional (a synth hiccup must never discard the successful rounds), but a **CI gate keying on the exit code could misread it as success**.

## The fix (opt-in, default-preserving)

New `--strict-exit` flag on the `run` subcommand. When set, a synthesizer failure returns a distinct **`EXIT_NO_VERDICT = 4`** instead of 0. Without the flag, behavior is **byte-identical to today** (exit 0 + warning + fallback) — the warning, the `verdict-rejected.json` write, and the fallback message are unchanged in both modes. CI gates opt in; interactive users are unaffected.

## Tests
585 OK (+4): strict-exit returns non-zero on schema-rejection and on parse-failure; default still returns 0 on synth failure (regression guard); strict-exit does not bite on synth success.

Surfaced during a reliability review prompted by unrelated tooling failures — the skill's own structured-output path is otherwise robust (graceful degrade, no retry-cap loop); this closes the one CI-relevant rough edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)