### PR TITLE
advisory-board: lens-aware auto-disclosure for legal/sensitive runs

### DIFF
--- a/skills/advisory-board/references/handoff-template.html
+++ b/skills/advisory-board/references/handoff-template.html
@@ -41,6 +41,9 @@
   {{VERDICT}}        Final verdict text, e.g. "Do not ship yet — unanimous".
   {{VERDICT_CLASS}}  One of: ship | caution | block  (colors the banner).
   {{VERDICT_NOTE}}   One-line explanation under the verdict headline.
+  {{DISCLAIMER}}     OPTIONAL lens-aware professional-advice caveat (subtle footer
+                     line). Empty for a software-lens board — leave blank and the
+                     line is dropped.
   {{PLAN}}           The plan that was reviewed (HTML allowed; use <p>).
   {{METADATA}}       Footer provenance (models, flags, paths, timestamps).
   ============================================================================
@@ -251,6 +254,10 @@
   }
   footer.meta code { background: #efeee8; }
   footer.meta .prov { display: block; margin-top: 6px; }
+  /* subtle, lens-aware professional-advice caveat; dropped when empty */
+  footer.meta .disclaimer {
+    display: block; margin: 0 0 12px; font-style: italic; color: var(--ink-faint);
+  }
 
   /* ---- responsive ---- */
   @media (max-width: 560px) {
@@ -411,7 +418,10 @@
   </section>
 
   <!-- ===================== FOOTER / PROVENANCE ===================== -->
+  <!-- {{DISCLAIMER}}: OPTIONAL lens-aware professional-advice caveat. Empty for a
+       software-lens board — the line is dropped when blank. -->
   <footer class="meta">
+    <span class="disclaimer">{{DISCLAIMER}}</span>
     {{METADATA}}
   </footer>
 

--- a/skills/advisory-board/scripts/_verdict_labels.py
+++ b/skills/advisory-board/scripts/_verdict_labels.py
@@ -45,6 +45,20 @@ PLAIN_NOTES = {
 # carried no `lens_preset`; see `human_label`).
 SOFTWARE_PRESET = "software-architecture"
 
+# Lens-aware professional-advice caveat for the human-facing artifacts. A software-lens
+# board (and the absent/None default, which maps to software) carries NO disclaimer, so
+# existing software runs are unchanged. The legal preset gets the lawyer-specific line;
+# every other non-software preset (and any unknown one) gets the universal one. These
+# strings are approved wording — keep them VERBATIM.
+LEGAL_DISCLAIMER = (
+    "Directional review to help you focus a conversation with a qualified attorney "
+    "— not legal advice."
+)
+UNIVERSAL_DISCLAIMER = (
+    "An advisory board sharpens your judgment; it doesn't replace professional advice "
+    "where your decision warrants it."
+)
+
 
 def is_software_lens(lens_preset: Optional[str]) -> bool:
     """True when the board-level preset is the software-architecture family.
@@ -75,3 +89,22 @@ def human_label(token: str, lens_preset: Optional[str] = None,
     if is_software_lens(lens_preset):
         return SOFTWARE_LABELS.get(token, str(token)), None
     return PLAIN_LABELS.get(token, str(token)), PLAIN_NOTES.get(token)
+
+
+def lens_disclaimer(lens_preset: Optional[str]) -> Optional[str]:
+    """The professional-advice caveat to render for a board's lens, or ``None``.
+
+    * a software-lens board — ``software-architecture`` or the absent/``None`` default
+      that :func:`is_software_lens` maps to software — carries no disclaimer (existing
+      software runs are unchanged);
+    * a ``legal-contract`` board gets the lawyer-specific line;
+    * every other non-software preset (business-decision, product-strategy,
+      research-paper, writing-editing, and any unknown non-software value) gets the
+      universal one.
+
+    Renderer-only: this never touches the verdict.json schema or the machine gate."""
+    if is_software_lens(lens_preset):
+        return None
+    if lens_preset == "legal-contract":
+        return LEGAL_DISCLAIMER
+    return UNIVERSAL_DISCLAIMER

--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -15,7 +15,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _verdict_labels import human_label, is_software_lens  # noqa: E402  lens-aware label
+from _verdict_labels import human_label, is_software_lens, lens_disclaimer  # noqa: E402  lens-aware label + disclaimer
 
 
 def die(message: str) -> None:
@@ -48,12 +48,19 @@ def verdict_line(data: dict) -> str:
     return f"{label} ({data.get('confidence', '?')} confidence, {stance})"
 
 
+def _disclaimer(data: dict):
+    """The lens-aware professional-advice caveat, or None for a software/absent lens."""
+    return lens_disclaimer(data.get("lens_preset"))
+
+
 def as_tldr(data: dict) -> str:
     blockers = data.get("blockers", [])
     tops = "; ".join(b.get("title", "blocker") for b in blockers[:3]) if blockers else ""
     title = data.get("title", "Review")
     tail = f" Top blockers: {tops}." if blockers else ""
-    return f"{title}: {verdict_line(data)}.{tail}"
+    disclaimer = _disclaimer(data)
+    note = f" ({disclaimer})" if disclaimer else ""
+    return f"{title}: {verdict_line(data)}.{tail}{note}"
 
 
 def as_pr(data: dict) -> str:
@@ -82,6 +89,9 @@ def as_pr(data: dict) -> str:
     rounds = data.get("rounds", "?")
     plural = "" if rounds == 1 else "s"
     out.append(f"<sub>Board: {seats} - {rounds} round{plural}.</sub>")
+    disclaimer = _disclaimer(data)
+    if disclaimer:
+        out += ["", f"<sub>_{disclaimer}_</sub>"]
     return "\n".join(out)
 
 
@@ -96,6 +106,9 @@ def as_slack(data: dict) -> str:
     actions = data.get("next_actions", [])
     if actions:
         out.append("*Next:* " + "; ".join(actions))
+    disclaimer = _disclaimer(data)
+    if disclaimer:
+        out.append(f"_{disclaimer}_")
     return "\n".join(out)
 
 

--- a/skills/advisory-board/scripts/render_handoff.py
+++ b/skills/advisory-board/scripts/render_handoff.py
@@ -18,7 +18,8 @@ Standard library only; no third-party dependencies.
 handoff-data.json shape (keys mirror the template's {{TOKENS}}, lowercased):
 
   Top level (scalars):  title, subtitle, date, board, rounds, verdict,
-                        verdict_class, verdict_note, plan, metadata, dissent_flag
+                        verdict_class, verdict_note, disclaimer, plan, metadata,
+                        dissent_flag
   Lists of objects:     seats[], blockers[], dissents[], caveats[],
                         questions[], actions[]
     seats[]:   seat_name, seat_lens, seat_model, seat_status, seat_status_class,
@@ -73,17 +74,18 @@ BLOCK_KEYS = {
 
 # Tokens whose values are authored HTML fragments and pass through unescaped.
 RAW_TOKENS = {
-    "SUBTITLE", "BOARD", "VERDICT_NOTE", "PLAN", "METADATA", "SEAT_HIGHLIGHT",
-    "ROUND_REVIEW", "BLOCKER_BODY", "DISSENT_BODY", "CAVEAT_CLAIM",
-    "CAVEAT_IMPACT", "QUESTION", "ACTION",
+    "SUBTITLE", "BOARD", "VERDICT_NOTE", "DISCLAIMER", "PLAN", "METADATA",
+    "SEAT_HIGHLIGHT", "ROUND_REVIEW", "BLOCKER_BODY", "DISSENT_BODY",
+    "CAVEAT_CLAIM", "CAVEAT_IMPACT", "QUESTION", "ACTION",
 }
 
 
 def drop_empty_optionals(out: str) -> str:
-    """Remove the three optional elements when their token rendered empty."""
+    """Remove the optional elements when their token rendered empty."""
     out = re.sub(r'\s*<span class="seat-status\s*">\s*</span>', "", out)
     out = re.sub(r'\s*<div class="highlight">\s*</div>', "", out)
     out = re.sub(r'\s*<span class="conf">confidence:\s*</span>', "", out)
+    out = re.sub(r'\s*<span class="disclaimer">\s*</span>', "", out)
     return out
 
 

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -37,7 +37,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _render_engine import die  # noqa: E402  shared with the other renderers
-from _verdict_labels import human_label  # noqa: E402  lens-aware label, shared with format_output
+from _verdict_labels import human_label, lens_disclaimer  # noqa: E402  lens-aware label + disclaimer
 
 STATUS_WORD = {"verified": "verified", "unverified": "unverified", "refuted": "REFUTED"}
 EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
@@ -179,6 +179,15 @@ def render_markdown(data: dict) -> str:
                    "inference drawn from it is sound (design §9)._")
         out.append("")
 
+    # A subtle, lens-aware professional-advice caveat in the footer. None for a
+    # software lens (and the absent-preset default), so existing software runs are
+    # unchanged. Separated by its own rule so it reads as a footnote, not the verdict.
+    disclaimer = lens_disclaimer(data.get("lens_preset"))
+    if disclaimer:
+        out.append("---")
+        out.append(f"_{disclaimer}_")
+        out.append("")
+
     return "\n".join(out).rstrip() + "\n"
 
 
@@ -273,6 +282,10 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     # An explicit verdict_note (authored) wins; else the plain lens note. The banner
     # color (verdict_class) stays keyed on the raw token, never the lens label.
     verdict_note = data.get("verdict_note") or note
+    # The subtle, lens-aware professional-advice caveat (None for a software lens and
+    # the absent-preset default). Empty string when absent so the template slot resolves
+    # to nothing and the footer line is dropped.
+    disclaimer = lens_disclaimer(lens_preset)
     hd = {
         # non-RAW slots (the renderer escapes them) -> _plain; RAW slots -> _raw.
         "title": _plain(data.get("title", "Advisory Board review")),
@@ -283,6 +296,7 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         "verdict": _plain(f"{label} — {_stance(data)}"),
         "verdict_class": _VERDICT_CLASS.get(verdict, ""),
         "verdict_note": _raw(verdict_note) if verdict_note else "",
+        "disclaimer": _raw(disclaimer) if disclaimer else "",
         "plan": _raw(data.get("title", "")),
         "metadata": "Rendered from <code>verdict.json</code> by <code>scripts/render_verdict.py</code>.",
         "dissent_flag": "Dissent on the record" if data.get("dissent") else "",

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3269,6 +3269,28 @@ class TestVerdictLabels(unittest.TestCase):
         self.assertEqual(vl.human_label("ship", "software-architecture", decision="invest"),
                          ("invest", None))
 
+    # --- the lens-aware professional-advice disclaimer (renderer-only) ------ #
+
+    def test_disclaimer_legal_lens(self):
+        self.assertEqual(vl.lens_disclaimer("legal-contract"), vl.LEGAL_DISCLAIMER)
+        self.assertIn("not legal advice", vl.lens_disclaimer("legal-contract"))
+
+    def test_disclaimer_software_lens_is_none(self):
+        # The software lens carries no disclaimer, preserving existing software runs.
+        self.assertIsNone(vl.lens_disclaimer("software-architecture"))
+
+    def test_disclaimer_absent_preset_is_none(self):
+        # Absent preset maps to software (backward compat) -> no disclaimer.
+        self.assertIsNone(vl.lens_disclaimer(None))
+
+    def test_disclaimer_other_non_software_lenses_are_universal(self):
+        for lens in ("business-decision", "product-strategy", "research-paper",
+                     "writing-editing"):
+            self.assertEqual(vl.lens_disclaimer(lens), vl.UNIVERSAL_DISCLAIMER)
+
+    def test_disclaimer_unknown_preset_is_universal(self):
+        self.assertEqual(vl.lens_disclaimer("totally-made-up"), vl.UNIVERSAL_DISCLAIMER)
+
     # --- render_verdict.py: Markdown + HTML handoff ------------------------ #
 
     def _plain_verdict(self):
@@ -3320,6 +3342,55 @@ class TestVerdictLabels(unittest.TestCase):
         self.assertIn("Authored override note.", md)
         self.assertNotIn(vl.PLAIN_NOTES["block"], md)
 
+    # --- render: the lens-aware disclaimer in Markdown + HTML handoff ------- #
+
+    def _html(self, data):
+        import render_handoff as rh
+        return rh.render(rv.build_handoff_data(data), open(rh.default_template()).read())
+
+    def test_legal_lens_renders_disclaimer_in_md_and_html(self):
+        data = _verdict("block", "block", "block", title="Vendor MSA",
+                        lens_preset="legal-contract")
+        md = rv.render_markdown(data)
+        self.assertIn(vl.LEGAL_DISCLAIMER, md)
+        self.assertIn("not legal advice", md)
+        # As a subtle italic footer line, separated from the verdict.
+        self.assertIn(f"_{vl.LEGAL_DISCLAIMER}_", md)
+        # HTML handoff carries it too (escaped only for &/</>; this string has none).
+        html_out = self._html(data)
+        self.assertIn(vl.LEGAL_DISCLAIMER, html_out)
+        self.assertIn('class="disclaimer"', html_out)
+
+    def test_business_lens_renders_universal_footer_in_md_and_html(self):
+        data = _verdict("block", "block", "block", title="Q3 expansion",
+                        lens_preset="business-decision")
+        md = rv.render_markdown(data)
+        self.assertIn(vl.UNIVERSAL_DISCLAIMER, md)
+        # The apostrophe is HTML-escaped in the handoff slot.
+        html_out = self._html(data)
+        self.assertIn("replace professional advice", html_out)
+        self.assertIn('class="disclaimer"', html_out)
+
+    def test_software_lens_renders_no_disclaimer(self):
+        data = _verdict("block", "block", "block", title="Cache layer",
+                        lens_preset="software-architecture")
+        md = rv.render_markdown(data)
+        self.assertNotIn("legal advice", md)
+        self.assertNotIn("professional advice", md)
+        html_out = self._html(data)
+        self.assertNotIn("professional advice", html_out)
+        # The empty footer slot is dropped, not left as a blank span.
+        self.assertNotIn('<span class="disclaimer">', html_out)
+        self.assertEqual(rv.build_handoff_data(data)["disclaimer"], "")
+
+    def test_absent_lens_renders_no_disclaimer(self):
+        data = _verdict("block", "block", "block", title="Legacy run")  # no lens_preset
+        md = rv.render_markdown(data)
+        self.assertNotIn("professional advice", md)
+        html_out = self._html(data)
+        self.assertNotIn("professional advice", html_out)
+        self.assertNotIn('<span class="disclaimer">', html_out)
+
     # --- format_output.py: verdict_line ------------------------------------ #
 
     def test_format_output_software_uppercases(self):
@@ -3336,6 +3407,30 @@ class TestVerdictLabels(unittest.TestCase):
         data = _verdict("block", "block", "block", lens_preset="business-decision",
                         decision="wind-down")
         self.assertIn("WIND-DOWN", fo.verdict_line(data))  # a decision still upper-cases
+
+    # --- format_output.py: the lens-aware disclaimer in short formats ------- #
+
+    def test_format_output_legal_appends_disclaimer(self):
+        data = _verdict("block", "block", "block", title="MSA", lens_preset="legal-contract")
+        for text in (fo.as_tldr(data), fo.as_pr(data), fo.as_slack(data)):
+            self.assertIn("not legal advice", text)
+
+    def test_format_output_business_appends_universal_disclaimer(self):
+        data = _verdict("block", "block", "block", title="Q3", lens_preset="business-decision")
+        for text in (fo.as_tldr(data), fo.as_pr(data), fo.as_slack(data)):
+            self.assertIn("replace professional advice", text)
+
+    def test_format_output_software_appends_no_disclaimer(self):
+        data = _verdict("block", "block", "block", title="Cache",
+                        lens_preset="software-architecture")
+        for text in (fo.as_tldr(data), fo.as_pr(data), fo.as_slack(data)):
+            self.assertNotIn("professional advice", text)
+            self.assertNotIn("legal advice", text)
+
+    def test_format_output_absent_lens_appends_no_disclaimer(self):
+        data = _verdict("block", "block", "block", title="Legacy")  # no lens_preset
+        for text in (fo.as_tldr(data), fo.as_pr(data), fo.as_slack(data)):
+            self.assertNotIn("professional advice", text)
 
     # --- the machine contract is untouched --------------------------------- #
 


### PR DESCRIPTION
Makes the professional-advice caveat **automatic and lens-aware**, instead of living only in the lens docs (where it never reached the artifacts).

New `lens_disclaimer(lens_preset)` in `_verdict_labels.py`, rendered into the consensus markdown, the HTML handoff (subtle footer), and the short formats:
- **legal-contract** → *"Directional review to help you focus a conversation with a qualified attorney — not legal advice."*
- **other non-software lenses** → *"An advisory board sharpens your judgment; it doesn't replace professional advice where your decision warrants it."*
- **software-architecture / absent lens** → no disclaimer (existing software examples unaffected).

Renderer-only — no `verdict.json` schema change (reuses the already-threaded `lens_preset`). 598 tests (+13) covering every branch in markdown, HTML, and short formats. Unblocks publishing a legal-adjacent example responsibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)