### PR TITLE
advisory-board: fix Codex false-drop when the board reviews its own source

### DIFF
--- a/skills/advisory-board/scripts/_conductor/spawn.py
+++ b/skills/advisory-board/scripts/_conductor/spawn.py
@@ -190,21 +190,34 @@ def classify_round1(result: SpawnResult, adapter: SeatAdapter) -> tuple:
     Stricter than the preflight classify(): the captured artifact must pass the
     shape/length check (check_round1_shape), which is how a short plan-mode reply
     or an "I saved it to a file" stub is caught (the {{CLAUDE_OUTPUT_OVERRIDE}}
-    detection half). Ordering matters — timeout, then model-not-found, then the
-    empty/auth split, then shape, then the usable-but-nonzero degrade.
+    detection half). Ordering matters — timeout, then the SHAPE GATE, then (only
+    when no usable review came back) the model-not-found / empty-auth split, then
+    the usable-but-nonzero degrade.
+
+    The shape gate comes BEFORE the model-not-found / auth screens on purpose. A
+    genuine ModelNotFound or auth failure yields NO usable review — the model
+    never answered. So a complete, well-formed review on stdout is itself proof
+    the model resolved and ran; a model-not-found / auth SIGNAL on stderr is then
+    echoed MATERIAL UNDER REVIEW, not a real failure. The acute case: a seat
+    reviewing this skill's own source — codex's file-read trace echoes
+    registry.py's literal `_MODEL_NOT_FOUND_SIGNALS` list to stderr, which would
+    otherwise drop a healthy seat. (PR #27 stopped scanning stdout for exactly
+    this; the same echo also lands on stderr — still scanned — so screening only
+    when the review is absent/stub-shaped is what actually closes it.)
     """
     if result.timed_out:
         return "dropped", FAILURE_TIMEOUT
-    if model_not_found(result):
-        return "dropped", FAILURE_MODEL
-    if not result.stdout.strip():
-        # No usable stdout: distinguish an actionable auth failure (look only at
-        # stderr) from a bare empty run.
-        if auth_failed(result.stderr):
-            return "dropped", FAILURE_AUTH
-        return "dropped", FAILURE_NOOUTPUT
     shape_ok, _reason = check_round1_shape(result.stdout)
     if not shape_ok:
+        # No usable review: NOW the stderr signals are trustworthy failure modes.
+        if model_not_found(result):
+            return "dropped", FAILURE_MODEL
+        if not result.stdout.strip():
+            # No usable stdout: distinguish an actionable auth failure (look only
+            # at stderr) from a bare empty run.
+            if auth_failed(result.stderr):
+                return "dropped", FAILURE_AUTH
+            return "dropped", FAILURE_NOOUTPUT
         return "dropped", FAILURE_INVALID   # retryable once
     if result.exit_code != 0:
         return "degraded", None             # usable review despite a non-zero exit

--- a/skills/advisory-board/scripts/_conductor/synthesizer.py
+++ b/skills/advisory-board/scripts/_conductor/synthesizer.py
@@ -636,6 +636,13 @@ def _classify_synthesizer_shape(result, adapter) -> tuple:
     should be JSON, not a seven-section review). InvalidOutput here means an
     empty stdout, which would otherwise pass classify_round1 with stdout='' as
     NoOutput — keep that semantic intact.
+
+    Like classify_round1, the model-not-found / auth screens fire ONLY when no
+    usable output came back (empty stdout). A genuine model/auth failure yields
+    nothing; when the synthesizer DID produce output, a model-not-found / auth
+    signal on stderr is echoed material — the packet under synthesis can quote
+    the skill's own model-error strings (e.g. a board deliberating this very
+    classifier) — not a real failure.
     """
     from _conductor.constants import (
         FAILURE_AUTH, FAILURE_MODEL, FAILURE_NOOUTPUT, FAILURE_TIMEOUT,
@@ -647,9 +654,10 @@ def _classify_synthesizer_shape(result, adapter) -> tuple:
         return "dropped", FAILURE_NOOUTPUT
     if result.timed_out:
         return "dropped", FAILURE_TIMEOUT
-    if model_not_found(result):
-        return "dropped", FAILURE_MODEL
     if not result.stdout.strip():
+        # No usable output: NOW the stderr signals are trustworthy failure modes.
+        if model_not_found(result):
+            return "dropped", FAILURE_MODEL
         if auth_failed(result.stderr):
             return "dropped", FAILURE_AUTH
         return "dropped", FAILURE_NOOUTPUT

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -373,6 +373,80 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(status, "degraded")
 
 
+class TestModelNotFoundSelfReview(unittest.TestCase):
+    """Regression: a healthy seat must not be dropped as ModelNotFound just
+    because its stderr echoes the signal strings. The acute case is a board
+    reviewing THIS skill's own source — codex's file-read trace echoes
+    registry.py's `_MODEL_NOT_FOUND_SIGNALS` list to stderr. PR #27 closed the
+    stdout leak; the shape gate in classify_round1 / _classify_synthesizer_shape
+    closes the stderr-echo path: screen for model-not-found / auth ONLY when no
+    usable output came back.
+    """
+
+    # A complete, well-formed round-1 review (passes check_round1_shape).
+    REVIEW = (
+        "## Verdict\nVERDICT: caution\n\n"
+        "## Strongest objections\nThe proposal trades safety for embeddability "
+        "and needs a hard isolation boundary before any execution seat ships.\n\n"
+        "## Execution & sequencing\nStage the work behind a flag; verify the gate "
+        "abstains on a refuted citation first.\n\n"
+        "## Invariants\nRead XOR network must hold for every grounded seat.\n\n"
+        "## Risks\nPrompt injection from a poisoned repo could drive a seat to "
+        "run code.\n\n"
+        "## Evidence\nSee references/data-handling.md for the rule.\n\n"
+        "## Challenge other seats\nWhat virtualization boundary is sufficient?"
+    )
+    # What codex echoes to stderr when it reads registry.py during self-review.
+    SIGNAL_ECHO = (
+        'reading scripts/_conductor/registry.py\n'
+        '_MODEL_NOT_FOUND_SIGNALS = ("modelnotfound", "model not found",\n'
+        '    "no such model", "unknown model")'
+    )
+
+    def _r(self, **kw):
+        base = dict(exit_code=0, stdout=self.REVIEW, stderr=self.SIGNAL_ECHO,
+                    elapsed_s=180.0, timed_out=False)
+        base.update(kw)
+        return rb.SpawnResult(**base)
+
+    def test_round1_healthy_review_not_dropped_despite_signal_on_stderr(self):
+        # the bug dropped this as ModelNotFound; the fix keeps it as 'ran'.
+        self.assertTrue(rb.check_round1_shape(self.REVIEW)[0])
+        self.assertEqual(rb.classify_round1(self._r(), rb.REGISTRY["codex"]),
+                         ("ran", None))
+
+    def test_round1_healthy_review_nonzero_exit_degrades_not_drops(self):
+        self.assertEqual(
+            rb.classify_round1(self._r(exit_code=1), rb.REGISTRY["codex"])[0],
+            "degraded")
+
+    def test_round1_genuine_model_not_found_still_drops(self):
+        # no usable review (empty stdout) + a real signal on stderr -> drop.
+        r = self._r(exit_code=1, stdout="",
+                    stderr="stream error: requested entity was not found")
+        self.assertEqual(rb.classify_round1(r, rb.REGISTRY["codex"]),
+                         ("dropped", rb.FAILURE_MODEL))
+
+    def test_round1_genuine_auth_failure_still_drops(self):
+        r = self._r(exit_code=1, stdout="", stderr="Error: please sign in (401)")
+        self.assertEqual(rb.classify_round1(r, rb.REGISTRY["codex"]),
+                         ("dropped", rb.FAILURE_AUTH))
+
+    def test_synthesizer_usable_output_not_dropped_despite_signal(self):
+        from _conductor.synthesizer import _classify_synthesizer_shape
+        r = rb.SpawnResult(exit_code=0, stdout='{"verdict": "caution"}',
+                           stderr=self.SIGNAL_ECHO, elapsed_s=60.0, timed_out=False)
+        self.assertEqual(_classify_synthesizer_shape(r, rb.REGISTRY["claude"]),
+                         ("ran", None))
+
+    def test_synthesizer_genuine_model_not_found_still_drops(self):
+        from _conductor.synthesizer import _classify_synthesizer_shape
+        r = rb.SpawnResult(exit_code=1, stdout="", stderr="model not found",
+                           elapsed_s=2.0, timed_out=False)
+        self.assertEqual(_classify_synthesizer_shape(r, rb.REGISTRY["claude"]),
+                         ("dropped", rb.FAILURE_MODEL))
+
+
 # --------------------------------------------------------------------------- #
 # Preflight (against mock CLIs)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem
`model_not_found()` substring-scans a seat's **stderr** for signals like `modelnotfound` / `model not found`. The Codex CLI echoes its agentic file-reads to stderr, so when the board reviews **this skill's own source**, Codex reads `registry.py` — which *defines* `_MODEL_NOT_FOUND_SIGNALS` — and echoes that list to stderr. A **healthy** seat (exit 0, complete 7-section review ending in `VERDICT:`) was then wrongly dropped as `ModelNotFound`.

This is the **stderr** sibling of the bug PR #27 fixed on stdout. It reproduces on current `main` (which has #27): a unit-level repro shows a complete review + signals-on-stderr classified `dropped/ModelNotFound`. It bites any board reviewing its own code (e.g. dogfooding the conductor).

## Fix
Gate the model-not-found / auth screens behind **"no usable output came back"** in both classifiers:
- `spawn.py::classify_round1` — run `check_round1_shape` **first**; the failure screens fire only when the review is absent/stub-shaped.
- `synthesizer.py::_classify_synthesizer_shape` — same, gated on empty stdout.

Rationale: a genuine `ModelNotFound`/auth failure yields **no usable review** (the model never answered). So a complete, well-formed review is itself proof the model resolved and ran — an echoed stderr signal is then *material under review*, not a real failure. Genuine failures (empty/stub output + a real signal) still drop, unchanged.

## Tests
- New `TestModelNotFoundSelfReview` (6 tests): the false-positive now classifies `ran`; genuine model-not-found / auth still drop; nonzero-exit healthy review degrades; both call sites covered. The healthy-review test also pins the ordering (a reordering regression fails it).
- Full suite: **604 OK**.

## Review
Adversarial review (3 parallel finders + per-finding skeptic verification): **8 findings, 0 confirmed defects** — no new bypass, genuine-failure detection preserved (strictly stronger), tests non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
