### PR TITLE
advisory-board: render nested lists in handoff HTML (indentation fix)

### DIFF
--- a/skills/advisory-board/scripts/_md.py
+++ b/skills/advisory-board/scripts/_md.py
@@ -8,9 +8,10 @@ the data author to hand-build HTML — the fragile step that previously left lit
 `##` and `**` in the published artifact.
 
 Scope is deliberately the subset models actually produce in a review: ATX headings,
-bold/italic, inline code, fenced code, ordered/unordered lists, blockquotes, links,
-and blank-line-separated paragraphs. Not a CommonMark engine; no nested lists, no
-tables, no reference links. Standard library only.
+bold/italic, inline code, fenced code, ordered/unordered lists (including indented
+sub-lists, which nest inside their parent <li> so the handoff indents them under the
+parent), blockquotes, links, and blank-line-separated paragraphs. Not a CommonMark
+engine; no tables, no reference links. Standard library only.
 
 Safety: all text is HTML-escaped BEFORE markup tags are inserted, so a review that
 contains `<script>` or `&` renders as literal text, never live HTML. Inline code is
@@ -38,6 +39,10 @@ _UL_ITEM = re.compile(r"^\s*[-*+]\s+")
 # unbounded run would feed int() a 4300+-digit string (Python's int-from-str limit) and
 # raise — a pathological line just falls through to a paragraph instead.
 _OL_ITEM = re.compile(r"^\s*(\d{1,9})[.)]\s+")
+# Indentation-capturing variants used by the nesting walker: group 1 is the leading
+# whitespace (its visual width keys nesting depth), group 2 the ordered number (ul: none).
+_UL_INDENT = re.compile(r"^([ \t]*)[-*+]\s+")
+_OL_INDENT = re.compile(r"^([ \t]*)(\d{1,9})[.)]\s+")
 # Link schemes that are safe in an href. Anything else (javascript:, data:, vbscript:,
 # protocol-relative //host, …) collapses to '#' so a review cannot plant a
 # code-execution or off-site-phishing link. A single leading '/' (site-relative) is
@@ -97,27 +102,76 @@ def _inline(text: str) -> str:
     return text
 
 
-def _emit_list(lines, i, n, item_re, tag, out):
-    """Collect a (possibly loose) list of one type into a single <ul>/<ol>, absorbing
-    a single blank line between items so blank-separated points render as ONE list
-    with correct numbering — and return the index past the list. For an ordered list
-    the first item's number becomes `start=`, so a list that begins at N (or a lone
-    "N. ..." line) never silently loses its number."""
+def _indent_width(ws: str) -> int:
+    """Visual width of a list item's leading whitespace, so a tab and a run of spaces
+    compare sensibly when deciding nesting depth (tab = next multiple of 4)."""
+    width = 0
+    for ch in ws:
+        width = width + (4 - width % 4) if ch == "\t" else width + 1
+    return width
+
+
+def _list_item(line: str):
+    """If `line` is a list item, return (indent_width, tag, number, body); else None.
+    `tag` is 'ul'/'ol'; `number` is the ordered start (or None); `body` is the text
+    after the marker, with the marker and its indentation removed."""
+    m = _OL_INDENT.match(line)
+    if m:
+        return _indent_width(m.group(1)), "ol", int(m.group(2)), line[m.end():].strip()
+    m = _UL_INDENT.match(line)
+    if m:
+        return _indent_width(m.group(1)), "ul", None, line[m.end():].strip()
+    return None
+
+
+def _emit_list(lines, i, n, out, base_indent=None):
+    """Render a (possibly nested, possibly loose) Markdown list to nested <ul>/<ol>,
+    returning the index past it.
+
+    A deeper-indented run of items becomes a child list spliced INSIDE the preceding
+    <li> (so sub-bullets visibly sit under their parent, not at the left margin); a
+    same-indent marker switch (e.g. `1.` then `-`) ends this list and lets the caller
+    start a sibling one, matching the prior flat behavior at a single level. A single
+    blank line between two items of this list is absorbed so blank-separated points
+    stay ONE list with correct numbering. The first ordered item's number becomes
+    `start=`, so a list beginning at N (or a lone "N. ..." line) keeps its number."""
+    first = _list_item(lines[i])
+    indent, tag, start = first[0], first[1], first[2]
+    if base_indent is None:
+        base_indent = indent
     items: list = []
-    start = None
     while i < n:
-        m = item_re.match(lines[i])
-        if m:
-            if tag == "ol" and start is None:
-                start = int(m.group(1))
-            items.append(item_re.sub("", lines[i]).strip())
-            i += 1
-        elif lines[i].strip() == "" and i + 1 < n and item_re.match(lines[i + 1]):
-            i += 1   # blank line between two items of the same kind — stay in the list
-        else:
-            break
+        info = _list_item(lines[i])
+        if info is not None:
+            it_indent, it_tag, _, body = info
+            if it_indent < base_indent:
+                break                       # belongs to an outer list — let it close
+            if it_indent <= base_indent + 1:
+                if it_tag != tag:
+                    break                   # marker switched at this level -> sibling list
+                items.append([body, ""])    # [text, rendered-children]
+                i += 1
+                continue
+            # deeper indent -> a child list nested in the current item
+            if not items:
+                items.append(["", ""])      # defensive: a child with no parent line
+            child: list = []
+            i = _emit_list(lines, i, n, child, base_indent=it_indent)
+            items[-1][1] += "".join(child)
+            continue
+        if lines[i].strip() == "":
+            nxt = lines[i + 1] if i + 1 < n else ""
+            ni = _list_item(nxt)
+            if ni is not None and ni[0] >= base_indent:
+                i += 1                       # blank line within the list — stay in it
+                continue
+        break
     attr = f' start="{start}"' if (tag == "ol" and start not in (None, 1)) else ""
-    out.append(f"<{tag}{attr}>" + "".join(f"<li>{_inline(it)}</li>" for it in items) + f"</{tag}>")
+    out.append(
+        f"<{tag}{attr}>"
+        + "".join(f"<li>{_inline(text)}{children}</li>" for text, children in items)
+        + f"</{tag}>"
+    )
     return i
 
 
@@ -189,14 +243,9 @@ def md_to_html(text: str) -> str:
             out.append("<blockquote>" + _inline(" ".join(quoted).strip()) + "</blockquote>")
             continue
 
-        if _UL_ITEM.match(line):
+        if _UL_ITEM.match(line) or _OL_ITEM.match(line):
             flush_para()
-            i = _emit_list(lines, i, n, _UL_ITEM, "ul", out)
-            continue
-
-        if _OL_ITEM.match(line):
-            flush_para()
-            i = _emit_list(lines, i, n, _OL_ITEM, "ol", out)
+            i = _emit_list(lines, i, n, out)
             continue
 
         para.append(stripped)

--- a/skills/advisory-board/tests/test_md.py
+++ b/skills/advisory-board/tests/test_md.py
@@ -82,6 +82,56 @@ class Blocks(unittest.TestCase):
         self.assertEqual(out, "<p>para one</p>\n<p>para two</p>")
 
 
+class NestedLists(unittest.TestCase):
+    """Indented sub-bullets/steps must nest INSIDE their parent <li> so the rendered
+    handoff indents them under the parent (the artifact-formatting bug: a deeper run of
+    items was emitted as a flat sibling list at the left margin)."""
+
+    def test_indented_bullets_nest_inside_parent_item(self):
+        # a numbered step with three indented sub-bullets, as models actually emit
+        src = ("1. First step\n"
+               "2. Second step:\n"
+               "    - sub a\n"
+               "    - sub b\n"
+               "3. Third step")
+        out = md_to_html(src)
+        # ONE ordered list (not split by the sub-bullets), with a child <ul> nested
+        # inside the second <li> — never a sibling list after a closed </ol>.
+        self.assertEqual(out.count("<ol>"), 1)
+        self.assertEqual(out.count("</ol>"), 1)
+        self.assertIn("Second step:<ul><li>sub a</li><li>sub b</li></ul></li>", out)
+        # numbering is NOT broken: no spurious start= reset for the resumed top level
+        self.assertNotIn("start=", out)
+
+    def test_nested_list_keeps_a_single_outer_list(self):
+        # the exact shape from the real run (gemini round-1): the nested <ul> closes
+        # inside the parent <li>, so '</ul></li>' appears and the <ol> stays whole.
+        src = ("1. a\n2. b:\n    * x\n    * y\n3. c")
+        out = md_to_html(src)
+        self.assertIn("</ul></li>", out)
+        self.assertEqual(out.count("<ol"), 1)
+
+    def test_unordered_nesting(self):
+        src = ("- top one\n- top two\n  - child of two\n- top three")
+        out = md_to_html(src)
+        self.assertIn("top two<ul><li>child of two</li></ul></li>", out)
+        # exactly one nested <ul> inside an <li>; the outer list is still one <ul>
+        self.assertEqual(out.count("<li>top three</li>"), 1)
+
+    def test_same_level_marker_switch_stays_a_sibling_list(self):
+        # an OL followed by a UL at the SAME indent must remain two sibling lists
+        # (unchanged behavior), not get nested into the last item.
+        out = md_to_html("1. one\n2. two\n- bullet\n- bullet2")
+        self.assertNotIn("two<ul>", out)
+        self.assertIn("</ol>", out)
+        self.assertIn("<ul><li>bullet</li>", out)
+
+    def test_deep_three_levels(self):
+        src = ("- a\n  - b\n    - c")
+        out = md_to_html(src)
+        self.assertIn("a<ul><li>b<ul><li>c</li></ul></li></ul></li>", out)
+
+
 class Robustness(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(md_to_html(""), "")

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3232,6 +3232,32 @@ class TestRenderVerdict(unittest.TestCase):
             html_out = rh.render(hd, open(rh.default_template()).read())
             self.assertIn("<code>SET NX</code>", html_out)
 
+    def test_nested_seat_review_indents_in_rendered_handoff(self):
+        # artifact-formatting regression: a step with indented sub-bullets in a seat's
+        # round-N/<seat>.md must render as a nested <ul> INSIDE the parent <li> (so the
+        # handoff CSS '.review-body ul' padding-left indents it), not a flat sibling list.
+        import render_handoff as rh
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "round-1"))
+            with open(os.path.join(d, "round-1", "claude.md"), "w") as fh:
+                fh.write("1. First step\n"
+                         "2. Fix the money:\n"
+                         "    - smaller deposit\n"
+                         "    - net 30 terms\n"
+                         "3. Then scope")
+            hd = rv.build_handoff_data(self.data, run_dir=d)
+            html_out = rh.render(hd, open(rh.default_template()).read())
+            # the sub-bullets are nested in the parent <li>, closing with </ul></li>
+            self.assertIn(
+                "Fix the money:<ul><li>smaller deposit</li>"
+                "<li>net 30 terms</li></ul></li>",
+                html_out,
+            )
+            self.assertIn("</ul></li>", html_out)
+            # the descendant rule that indents review-body lists (incl. nested) is present
+            self.assertIn(".review-body ul, .review-body ol { margin: 6px 0; padding-left: 22px; }",
+                          html_out)
+
 
 class TestVerdictLabels(unittest.TestCase):
     """The plain-language, lens-aware verdict label (v1.6.0)."""


### PR DESCRIPTION
User feedback on a real rendered example: nested subsections in the HTML handoff sat flat at the left margin instead of indented.

**Root cause:** not CSS (the template already has `.review-body ul,ol { padding-left:22px }`) — the markdown→HTML converter `scripts/_md.py` was single-level only (its docstring literally said "no nested lists"), so an indented sub-bullet under a numbered step rendered as a *separate flat list*.

**Fix:** rewrote `_emit_list` to be indentation-aware — a more-deeply-indented run nests as a child `<ul>/<ol>` inside the preceding `<li>` (recursively). The existing CSS then indents it. Same-level marker switches still end the list (sibling behavior preserved); loose lists and ordered `start=` preserved. No CSS, no other rendering touched.

**Verified** on a real run: before = 0 nested lists; after = proper `<ul></li>` nesting under the parent step. Banner, plain-language pills, legal disclaimer, and verbatim content all intact; **no** first-line paragraph indents. 604 tests (+6: a `NestedLists` suite in test_md.py + an end-to-end handoff nesting test).

Improves every HTML artifact going forward. Only touches `_md.py` + tests (no overlap with recent main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)