### PR TITLE
advisory-board: Panely brand artifact + kill dev-string leaks (v1.7.0)

### DIFF
--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -8,6 +8,31 @@ Pre-1.0 the minor tracks the conductor milestone (M5 → `v0.5.0`, M6 → `v0.6.
 reserved for an explicit production-ready call. The verdict-JSON schema is versioned separately
 (`advisory-board/verdict@N`) and is not the same axis as the release version.
 
+## [v1.7.0] - 2026-06-26 — Panely Advisory Board brand
+
+The human-facing artifact is now a branded **Panely Advisory Board** deliverable — the
+review's strongest marketing surface. The body stays light and readable, bookended by
+dark masthead and footer bands carrying the Panely "decision core" mark, the *Panely
+Advisory Board* lockup, the "use your own subscriptions to Claude, Codex, and Gemini"
+line, and a **panely.ai** call-to-action. The verdict-JSON contract, the section
+structure, the honesty sections, and the lens-aware label/disclaimer are all unchanged.
+
+### Changed
+- **`references/handoff-template.html`** — re-skinned into the Panely identity: a dual
+  theme (light "Boardroom" body + dark "Signal" masthead/footer bands), cobalt `#2347FF`
+  signature accent, gold `#E2B658` lead-seat secondary, muted verdict colors, Signal
+  font stacks, and an inline self-contained glowing avatar in the masthead with a flat
+  favicon in the footer. Every `{{TOKEN}}`/block and the renderer-contract shapes (the
+  `verdict {{VERDICT_CLASS}}` class, the `disclaimer`/`seat-status`/`highlight`/`conf`
+  spans, the `.review-body` list-indent rule) are preserved — the suite stays green.
+
+### Fixed
+- **Two developer strings no longer leak onto the page** (`scripts/render_verdict.py`):
+  the masthead **subtitle** now describes what was reviewed (was "Rendered from the
+  canonical verdict.json."), and the footer **provenance** reads in human terms —
+  "Board: … · N rounds · date" (was "Rendered from verdict.json by
+  scripts/render_verdict.py.").
+
 ## [v1.6.0] - 2026-06-26 — Plain-language, lens-aware verdict label
 
 The machine token `verdict: ship|caution|block` stays byte-identical (the gate

--- a/skills/advisory-board/references/handoff-template.html
+++ b/skills/advisory-board/references/handoff-template.html
@@ -1,10 +1,16 @@
 <!DOCTYPE html>
 <!--
   ============================================================================
-  ADVISORY BOARD — HANDOFF TEMPLATE
+  PANELY ADVISORY BOARD — HANDOFF TEMPLATE
   ============================================================================
   A SELF-CONTAINED HTML template for rendering a finished multi-model advisory
-  board review into a clean, human-readable handoff page.
+  board review into a clean, human-readable, Panely-branded handoff page.
+
+  Brand: a light, readable body (the "Boardroom" light theme) bookended by dark
+  ("Signal") masthead and footer bands carrying the Panely Advisory Board mark,
+  lockup, the subscriptions line, and the panely.ai call-to-action. Brand kit:
+  ~/Desktop/panely-brand-kit (cobalt #2347FF signature accent, gold #E2B658
+  secondary / lead seat; muted verdict colors).
 
   OUTPUT CONTRACT (read first)
   ----------------------------
@@ -14,8 +20,8 @@
       section dividers may stay.
     - be a faithful VIEW of final-consensus.md — the Markdown handoff is the
       source of truth; the HTML must not contradict it.
-    - stay fully self-contained: inline CSS only, no external fonts, CDNs, JS,
-      <link>, or <script src>. It MUST render offline on a double-click.
+    - stay fully self-contained: inline CSS + inline SVG only, no external
+      fonts, CDNs, JS, <link>, or <script src>. It MUST render offline.
     - HTML-escape every injected string ( & -> &amp;  < -> &lt;  > -> &gt; );
       wrap inline code in <code>...</code>.
 
@@ -33,19 +39,19 @@
 
   SINGLE TOKENS
   -------------
-  {{TITLE}}          Page + banner title, e.g. "Advisory Board Review".
+  {{TITLE}}          Page + banner title (what the board was asked).
   {{SUBTITLE}}       One-line description of what was reviewed.
   {{DATE}}           Review date, e.g. "2026-06-24".
   {{BOARD}}          Board roster: models + lenses (HTML allowed).
   {{ROUNDS}}         Number of rounds, e.g. "2".
-  {{VERDICT}}        Final verdict text, e.g. "Do not ship yet — unanimous".
+  {{VERDICT}}        Final verdict text, plain-language (e.g. "Negotiate before signing").
   {{VERDICT_CLASS}}  One of: ship | caution | block  (colors the banner).
   {{VERDICT_NOTE}}   One-line explanation under the verdict headline.
   {{DISCLAIMER}}     OPTIONAL lens-aware professional-advice caveat (subtle footer
                      line). Empty for a software-lens board — leave blank and the
                      line is dropped.
-  {{PLAN}}           The plan that was reviewed (HTML allowed; use <p>).
-  {{METADATA}}       Footer provenance (models, flags, paths, timestamps).
+  {{PLAN}}           What was reviewed (HTML allowed; use <p>).
+  {{METADATA}}       Footer provenance (board, rounds, date).
   ============================================================================
 -->
 <html lang="en">
@@ -56,19 +62,36 @@
 <style>
   :root {
     --maxw: 820px;
-    --ink: #1c1d22;
-    --ink-soft: #4a4d57;
-    --ink-faint: #74777f;
-    --line: #e4e3dd;
-    --line-strong: #d2d1c9;
+    /* light "Boardroom" body */
+    --page: #faf8f3;
     --surface: #ffffff;
-    --page: #f6f5f1;
-    --surface-soft: #faf9f5;
-    --accent: #4f46b8;
-    /* verdict palettes */
-    --ship-bg: #e9f5ec;     --ship-edge: #2f7d46;   --ship-ink: #1d5e31;
-    --caution-bg: #fdf2dd;  --caution-edge: #b9791b; --caution-ink: #7a4d09;
-    --block-bg: #fbe9e9;    --block-edge: #b23535;  --block-ink: #7e1f1f;
+    --surface-soft: #faf7f0;
+    --vellum: #f3eee3;
+    --ink: #11192b;
+    --ink-soft: #3a4459;
+    --ink-faint: #6e768a;
+    --line: #e4ddce;
+    --line-strong: #d8cfb8;
+    /* brand accents (both themes) */
+    --accent: #2347ff;          /* cobalt — signature */
+    --accent-deep: #0f2bc2;
+    --accent-tint: #eaedff;
+    --gold: #a8843c;            /* secondary — the lead seat */
+    /* dark "Signal" bands */
+    --dark: #0a0e1a;
+    --dark-2: #111726;
+    --dark-line: #232b3e;
+    --on-dark: #fbfaf7;
+    --on-dark-soft: #b9c0d0;
+    --on-dark-faint: #8a93a8;
+    --accent-bright: #5b8cff;
+    --gold-bright: #e2b658;
+    /* verdict palettes (muted — counsel, not error toasts) */
+    --ship-bg: #e9f1ec;     --ship-edge: #2f6f57;   --ship-ink: #235540;
+    --caution-bg: #fbf1de;  --caution-edge: #b07a1e; --caution-ink: #7a5410;
+    --block-bg: #f7e9e9;    --block-edge: #9e3636;  --block-ink: #7a2525;
+    --font-sans: "Panely Grotesk","Söhne","Inter","Helvetica Neue",Helvetica,Arial,"Segoe UI",system-ui,sans-serif;
+    --font-mono: "Berkeley Mono","JetBrains Mono",ui-monospace,"Menlo","Consolas",monospace;
   }
   * { box-sizing: border-box; }
   html { -webkit-text-size-adjust: 100%; }
@@ -76,32 +99,36 @@
     margin: 0;
     background: var(--page);
     color: var(--ink);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-                 Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+    font-family: var(--font-sans);
     font-size: 17px;
     line-height: 1.65;
   }
-  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 32px 20px 72px; }
 
-  /* ---- header ---- */
-  header.masthead { margin-bottom: 24px; }
-  .eyebrow {
-    font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
-    color: var(--ink-faint); font-weight: 600; margin: 0 0 8px;
-  }
-  h1 { font-size: 30px; line-height: 1.2; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
-  .subtitle { font-size: 17px; color: var(--ink-soft); margin: 0 0 18px; }
+  /* ---- dark masthead band ---- */
+  header.masthead { background: var(--dark); color: var(--on-dark); padding: 30px 20px 28px; }
+  .band-inner { max-width: var(--maxw); margin: 0 auto; }
+  .brand-lockup { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+  .brand-mark { width: 46px; height: 46px; border-radius: 11px; overflow: hidden; flex: 0 0 auto; }
+  .brand-mark svg { display: block; width: 100%; height: 100%; }
+  .brand-name { display: flex; flex-direction: column; line-height: 1.1; }
+  .brand-name .p { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--on-dark); }
+  .brand-name .ab { font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-bright); margin-top: 4px; }
+  header.masthead h1 { font-size: 29px; line-height: 1.18; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; color: var(--on-dark); }
+  .subtitle { font-size: 16px; color: var(--on-dark-soft); margin: 0 0 18px; max-width: 60ch; }
   .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
   .chip {
     display: inline-flex; align-items: center; gap: 6px;
-    background: var(--surface); border: 1px solid var(--line-strong);
-    border-radius: 999px; padding: 5px 13px; font-size: 13.5px; color: var(--ink-soft);
+    background: rgba(255,255,255,0.05); border: 1px solid var(--dark-line);
+    border-radius: 999px; padding: 5px 13px; font-size: 13px; color: var(--on-dark-soft);
   }
-  .chip b { font-weight: 600; color: var(--ink); }
+  .chip b { font-weight: 600; color: var(--on-dark); }
+
+  /* ---- body column ---- */
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 30px 20px 56px; }
 
   /* ---- verdict banner ---- */
   .verdict {
-    border-radius: 14px; padding: 22px 24px; margin: 8px 0 32px;
+    border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
     border: 1px solid transparent; border-left-width: 6px;
   }
   .verdict .label {
@@ -133,20 +160,20 @@
   /* ---- seat cards ---- */
   .seat {
     background: var(--surface); border: 1px solid var(--line-strong);
-    border-radius: 14px; padding: 20px 22px; margin: 0 0 18px;
+    border-radius: 12px; padding: 20px 22px; margin: 0 0 18px;
   }
   .seat-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 12px; margin-bottom: 4px; }
   .seat-name { font-size: 19px; font-weight: 700; margin: 0; }
   .seat-lens {
     font-size: 12.5px; font-weight: 600; color: var(--accent);
-    background: #efeefb; border-radius: 999px; padding: 3px 11px;
+    background: var(--accent-tint); border-radius: 999px; padding: 3px 11px;
   }
-  .seat-model { font-size: 13px; color: var(--ink-faint); }
+  .seat-model { font-size: 13px; color: var(--ink-faint); font-family: var(--font-mono); }
   .seat-status {
     font-size: 11.5px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
     border-radius: 999px; padding: 3px 10px;
   }
-  .seat-status.ran      { background: #efeee8;           color: var(--ink-faint); }
+  .seat-status.ran      { background: var(--vellum);     color: var(--ink-faint); }
   .seat-status.degraded { background: var(--caution-bg); color: var(--caution-ink); }
   .seat-status.dropped  { background: var(--block-bg);   color: var(--block-ink); }
   .round { margin-top: 16px; padding-top: 16px; border-top: 1px dashed var(--line); }
@@ -184,14 +211,14 @@
   }
   .review-body pre code { background: none; border: 0; padding: 0; font-size: inherit; }
   code {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    font-size: 0.86em; background: #f0efe9; border: 1px solid var(--line);
+    font-family: var(--font-mono);
+    font-size: 0.86em; background: var(--vellum); border: 1px solid var(--line);
     border-radius: 5px; padding: 1px 5px;
   }
 
   /* highlight callout (e.g. a seat that changed its verdict) */
   .highlight {
-    background: #fff8e8; border: 1px solid #ecd9a3; border-radius: 10px;
+    background: #fff6e3; border: 1px solid #ecd9a3; border-radius: 10px;
     padding: 12px 16px; margin: 14px 0 0; font-size: 14.5px; color: #6f5212;
   }
   .highlight b { color: #5a4209; }
@@ -247,51 +274,68 @@
   .actions ol { margin: 0; padding-left: 20px; }
   .actions li { margin: 6px 0; }
 
-  /* ---- footer ---- */
-  footer.meta {
-    margin-top: 40px; padding-top: 18px; border-top: 1px solid var(--line);
-    font-size: 13px; color: var(--ink-faint); line-height: 1.7;
+  /* ---- dark footer / colophon band ---- */
+  footer.colophon { background: var(--dark); color: var(--on-dark-soft); padding: 26px 20px 32px; }
+  footer.colophon .disclaimer {
+    display: block; margin: 0 0 16px; font-style: italic;
+    color: var(--on-dark-faint); font-size: 13.5px;
   }
-  footer.meta code { background: #efeee8; }
-  footer.meta .prov { display: block; margin-top: 6px; }
-  /* subtle, lens-aware professional-advice caveat; dropped when empty */
-  footer.meta .disclaimer {
-    display: block; margin: 0 0 12px; font-style: italic; color: var(--ink-faint);
+  .colophon-grid { display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-start; justify-content: space-between; }
+  .colophon-about { flex: 1 1 320px; }
+  .footer-lockup { display: flex; align-items: center; gap: 9px; font-weight: 700; color: var(--on-dark); font-size: 14px; margin-bottom: 9px; }
+  .footer-lockup svg { width: 26px; height: 26px; display: block; }
+  .colophon-about p { margin: 0; font-size: 13.5px; line-height: 1.6; color: var(--on-dark-soft); max-width: 54ch; }
+  .colophon-cta { flex: 0 0 auto; }
+  .cta {
+    display: inline-block; background: var(--accent); color: #ffffff;
+    font-weight: 600; font-size: 14.5px; text-decoration: none;
+    padding: 10px 20px; border-radius: 9px;
   }
+  .cta::after { content: " →"; }
+  footer.colophon .prov { display: block; margin-top: 12px; font-size: 11.5px; color: var(--on-dark-faint); font-family: var(--font-mono); }
 
   /* ---- responsive ---- */
   @media (max-width: 560px) {
     body { font-size: 16px; }
-    .wrap { padding: 22px 15px 56px; }
-    h1 { font-size: 25px; }
+    .wrap { padding: 22px 15px 44px; }
+    header.masthead, footer.colophon { padding-left: 15px; padding-right: 15px; }
+    header.masthead h1 { font-size: 25px; }
     .verdict .headline { font-size: 20px; }
     .seat, ol.blockers > li { padding-left: 16px; padding-right: 16px; }
     ol.blockers > li { padding-left: 50px; }
+    .colophon-cta { width: 100%; }
   }
 
   /* ---- print / PDF (Print -> Save as PDF) ---- */
   @media print {
     body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-    .wrap { max-width: none; padding: 8px 0 0; }
+    header.masthead, footer.colophon { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .wrap { max-width: none; }
     .verdict, .plan, .seat, .round, ol.blockers > li, .dissent, .actions { break-inside: avoid; }
     a { color: inherit; text-decoration: none; }
   }
 </style>
 </head>
 <body>
-<div class="wrap">
 
-  <!-- ===================== HEADER ===================== -->
+  <!-- ===================== MASTHEAD (Panely / dark band) ===================== -->
   <header class="masthead">
-    <p class="eyebrow">Advisory Board · Multi-model review</p>
-    <h1>{{TITLE}}</h1>
-    <p class="subtitle">{{SUBTITLE}}</p>
-    <div class="meta-row">
-      <span class="chip"><b>Date</b> {{DATE}}</span>
-      <span class="chip"><b>Rounds</b> {{ROUNDS}}</span>
-      <span class="chip"><b>Board</b> {{BOARD}}</span>
+    <div class="band-inner">
+      <div class="brand-lockup">
+        <span class="brand-mark"><svg viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg"><defs><radialGradient id="bg" cx="50%" cy="38%" r="74%"><stop offset="0%" stop-color="#122046"/><stop offset="55%" stop-color="#0a1024"/><stop offset="100%" stop-color="#05070f"/></radialGradient><radialGradient id="vig" cx="50%" cy="50%" r="62%"><stop offset="60%" stop-color="#000000" stop-opacity="0"/><stop offset="100%" stop-color="#000000" stop-opacity="0.5"/></radialGradient><linearGradient id="cobalt" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a9c2ff"/><stop offset="52%" stop-color="#5b8cff"/><stop offset="100%" stop-color="#2347ff"/></linearGradient><linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffe6a3"/><stop offset="55%" stop-color="#e2b658"/><stop offset="100%" stop-color="#b9842e"/></linearGradient><radialGradient id="core" cx="50%" cy="42%" r="62%"><stop offset="0%" stop-color="#ffffff"/><stop offset="34%" stop-color="#dbe6ff"/><stop offset="70%" stop-color="#6f93ff"/><stop offset="100%" stop-color="#2347ff"/></radialGradient><radialGradient id="spark" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#eaf1ff"/><stop offset="100%" stop-color="#5b8cff"/></radialGradient><filter id="gM" x="-180%" y="-180%" width="460%" height="460%"><feGaussianBlur stdDeviation="14"/></filter><filter id="gL" x="-220%" y="-220%" width="540%" height="540%"><feGaussianBlur stdDeviation="32"/></filter></defs><rect width="1000" height="1000" fill="#05070f"/><rect width="1000" height="1000" fill="url(#bg)"/><circle cx="500" cy="500" r="220" fill="#3a5fff" opacity="0.12" filter="url(#gL)"/><circle cx="500" cy="500" r="312" fill="none" stroke="url(#cobalt)" stroke-width="3" opacity="0.7"/><circle cx="500" cy="500" r="210" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.32"/><circle cx="500" cy="500" r="120" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.22"/><g stroke="#4f7bff" stroke-width="2"><line x1="830" y1="500" x2="850" y2="500" opacity="0.4"/><line x1="500" y1="830" x2="500" y2="850" opacity="0.4"/><line x1="170" y1="500" x2="150" y2="500" opacity="0.4"/><line x1="500" y1="170" x2="500" y2="150" opacity="0.4"/><line x1="733.3" y1="733.3" x2="743.2" y2="743.2" opacity="0.16"/><line x1="266.7" y1="733.3" x2="256.8" y2="743.2" opacity="0.16"/><line x1="266.7" y1="266.7" x2="256.8" y2="256.8" opacity="0.16"/><line x1="733.3" y1="266.7" x2="743.2" y2="256.8" opacity="0.16"/></g><line x1="500" y1="250" x2="500" y2="188" stroke="#f7b500" stroke-width="3" opacity="0.45"/><circle cx="500" cy="188" r="46" fill="#e2b658" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="188" r="34" fill="#0a1430" stroke="url(#gold)" stroke-width="5"/><circle cx="500" cy="188" r="15" fill="url(#gold)"/><circle cx="770.2" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="344" r="15" fill="url(#spark)"/><circle cx="770.2" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="656" r="15" fill="url(#spark)"/><circle cx="500" cy="812" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="812" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="500" cy="812" r="15" fill="url(#spark)"/><circle cx="229.8" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="656" r="15" fill="url(#spark)"/><circle cx="229.8" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="344" r="15" fill="url(#spark)"/><circle cx="500" cy="500" r="74" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.5"/><circle cx="500" cy="500" r="144" fill="#3a5fff" opacity="0.16" filter="url(#gL)"/><circle cx="500" cy="500" r="77" fill="url(#core)" opacity="0.5" filter="url(#gM)"/><circle cx="500" cy="500" r="48" fill="url(#core)" stroke="#ffffff" stroke-width="3"/><circle cx="500" cy="489" r="13" fill="#ffffff" opacity="0.92"/><rect width="1000" height="1000" fill="url(#vig)"/></svg></span>
+        <span class="brand-name"><span class="p">Panely</span><span class="ab">Advisory Board</span></span>
+      </div>
+      <h1>{{TITLE}}</h1>
+      <p class="subtitle">{{SUBTITLE}}</p>
+      <div class="meta-row">
+        <span class="chip"><b>Date</b> {{DATE}}</span>
+        <span class="chip"><b>Rounds</b> {{ROUNDS}}</span>
+        <span class="chip"><b>Board</b> {{BOARD}}</span>
+      </div>
     </div>
   </header>
+
+  <main class="wrap">
 
   <!-- ===================== VERDICT BANNER ===================== -->
   <!-- {{VERDICT_CLASS}} = ship | caution | block  (controls color) -->
@@ -303,7 +347,7 @@
 
   <!-- ===================== PLAN UNDER REVIEW ===================== -->
   <section>
-    <h2>Plan under review</h2>
+    <h2>What was reviewed</h2>
     <div class="plan">
       {{PLAN}}
     </div>
@@ -417,14 +461,29 @@
     </div>
   </section>
 
-  <!-- ===================== FOOTER / PROVENANCE ===================== -->
+  </main>
+
+  <!-- ===================== FOOTER / COLOPHON (Panely / dark band) ===================== -->
   <!-- {{DISCLAIMER}}: OPTIONAL lens-aware professional-advice caveat. Empty for a
-       software-lens board — the line is dropped when blank. -->
-  <footer class="meta">
-    <span class="disclaimer">{{DISCLAIMER}}</span>
-    {{METADATA}}
+       software-lens board — the line is dropped when blank. {{METADATA}} = provenance. -->
+  <footer class="colophon">
+    <div class="band-inner">
+      <span class="disclaimer">{{DISCLAIMER}}</span>
+      <div class="colophon-grid">
+        <div class="colophon-about">
+          <div class="footer-lockup">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="22" fill="#0a0e1a"/><circle cx="50" cy="50" r="30" fill="none" stroke="#3a5fd9" stroke-width="3" opacity="0.55"/><circle cx="50" cy="20" r="10" fill="#0a0e1a" stroke="#e2b658" stroke-width="4"/><circle cx="50" cy="20" r="4" fill="#e2b658"/><circle cx="76" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="76" cy="65" r="4" fill="#3d6bff"/><circle cx="24" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="24" cy="65" r="4" fill="#3d6bff"/><circle cx="50" cy="50" r="13" fill="#5b8cff"/><circle cx="50" cy="50" r="5.5" fill="#ffffff"/></svg>
+            Panely Advisory Board
+          </div>
+          <p>Convene Claude, Codex, and Gemini on your own subscriptions — the ones you already pay for, no new accounts and no API keys — to review the same material and reach one clear verdict.</p>
+        </div>
+        <div class="colophon-cta">
+          <a class="cta" href="https://panely.ai">panely.ai</a>
+        </div>
+      </div>
+      <span class="prov">{{METADATA}}</span>
+    </div>
   </footer>
 
-</div>
 </body>
 </html>

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -286,19 +286,31 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     # the absent-preset default). Empty string when absent so the template slot resolves
     # to nothing and the footer line is dropped.
     disclaimer = lens_disclaimer(lens_preset)
+    board_str = " · ".join(s.get("seat", "?") for s in data.get("board", []))
+    rounds_str = str(data.get("rounds", ""))
+    # Footer provenance, in human terms — no internal file/script names. (The old
+    # "Rendered from verdict.json by scripts/render_verdict.py" was a developer string
+    # that leaked onto the page; same for the subtitle below.)
+    metadata = " · ".join(p for p in (
+        f"Board: {board_str}" if board_str else "",
+        f"{rounds_str} rounds" if rounds_str else "",
+        data.get("date", ""),
+    ) if p)
     hd = {
         # non-RAW slots (the renderer escapes them) -> _plain; RAW slots -> _raw.
         "title": _plain(data.get("title", "Advisory Board review")),
-        "subtitle": "Rendered from the canonical verdict.json.",
+        # SUBTITLE describes WHAT was reviewed (shown in the masthead); an authored
+        # subtitle wins, else a neutral default. Never a developer/render string.
+        "subtitle": _raw(data.get("subtitle") or "An independent multi-model review."),
         "date": _plain(data.get("date", "")),
-        "board": _raw(" · ".join(s.get("seat", "?") for s in data.get("board", []))),
-        "rounds": str(data.get("rounds", "")),
+        "board": _raw(board_str),
+        "rounds": rounds_str,
         "verdict": _plain(f"{label} — {_stance(data)}"),
         "verdict_class": _VERDICT_CLASS.get(verdict, ""),
         "verdict_note": _raw(verdict_note) if verdict_note else "",
         "disclaimer": _raw(disclaimer) if disclaimer else "",
         "plan": _raw(data.get("title", "")),
-        "metadata": "Rendered from <code>verdict.json</code> by <code>scripts/render_verdict.py</code>.",
+        "metadata": _raw(metadata),
         "dissent_flag": "Dissent on the record" if data.get("dissent") else "",
         "seats": [],
         "blockers": [{"blocker_title": _plain(b.get("title", "blocker")),


### PR DESCRIPTION
Wires the approved **Panely Advisory Board** identity into the skill's renderer, so every future review comes out as a branded marketing-grade deliverable — not just a one-off mockup.

## What changed
- **`references/handoff-template.html`** — re-skinned into the Panely identity: a light "Boardroom" body bookended by dark "Signal" masthead + footer bands carrying the glowing decision-core avatar (inline, self-contained) + a flat favicon, the *Panely Advisory Board* lockup, cobalt `#2347FF` + gold `#E2B658` accents, muted verdict colors, Signal font stacks, the "use your own subscriptions to Claude, Codex, and Gemini" line, and a **panely.ai** call-to-action.
- **`scripts/render_verdict.py`** — fixed two developer strings that leaked onto the page: the masthead **subtitle** (was *"Rendered from the canonical verdict.json."*) now describes what was reviewed; the footer **provenance** (was *"Rendered from verdict.json by scripts/render_verdict.py."*) now reads *"Board: … · N rounds · date"*.

## Contract preserved
Every `{{TOKEN}}`/block and the exact shapes the tests assert — the `verdict {{VERDICT_CLASS}}` class, the `disclaimer`/`seat-status`/`highlight`/`conf` spans, the `.review-body` list-indent rule — are kept. Honesty sections, the verdict-JSON contract, and the lens-aware label/disclaimer are unchanged.

## Verification
- Full suite **610 OK**.
- Rendered the real freelance-contract review through the updated renderer: branded masthead + footer, plain-language verdict, legal disclaimer intact, **zero** leftover tokens, **zero** dev-strings.
- Adversarial review (parallel finders → skeptic verify): **clean, 0 findings**.

Design source: the standalone Panely brand kit (spec, tokens, logo SVGs) lives at `~/Desktop/panely-brand-kit/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)