### PR TITLE
README: provider-agnostic 'agent skill' framing + Panely cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Use it to:
 
 Default behavior: two rounds of review and rebuttal; read-only unless edits are explicitly requested; you see exactly what would be sent to each provider and approve it before anything leaves your machine — redact what's sensitive, or run a fully local board where nothing is sent at all.
 
+**Run it your way.** Advisory Board is a provider-agnostic agent skill — convene the board through Claude Code, Codex, or whatever harness you prefer.
+
+> **Prefer a polished app instead?** [Panely](https://github.com/timharris707/panely) is a sibling product built around the same idea — a local-first advisory room. Advisory Board is the open agent skill; Panely is the app. Same maker.
+
 ## See It In Action
 
 Here's a real board debating a real decision — *"Should I go full-time on my side project?"*


### PR DESCRIPTION
Clarifies Advisory Board is a provider-agnostic **agent skill** (run via Claude Code, Codex, or any harness) and adds a cross-link to the sibling **Panely** app — honest 'same idea, same maker, not the same engine' framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)