### PR TITLE
advisory-board: quick-verdict (skim-brief) shape + banner confidence pill

### DIFF
--- a/examples/payments-idempotency-review/final-consensus.html
+++ b/examples/payments-idempotency-review/final-consensus.html
@@ -81,6 +81,11 @@
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
     font-weight: 700; margin: 0 0 6px; opacity: 0.85;
   }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
   .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
@@ -286,7 +291,7 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict block">
-    <p class="label">Final verdict</p>
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
     <p class="headline">DO NOT SHIP YET — unanimous</p>
     <p class="note"></p>
   </div>

--- a/examples/payments-idempotency-review/handoff-data.json
+++ b/examples/payments-idempotency-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "DO NOT SHIP YET — unanimous",
   "verdict_class": "block",
   "verdict_note": "",
+  "confidence": "high confidence",
   "blockers_heading": "Consensus blockers — must fix before ship",
   "disclaimer": "",
   "plan": "Payments API idempotency keys",
@@ -89,41 +90,50 @@
   "blockers": [
     {
       "blocker_title": "Concurrency window → double charge (no atomic reserve-before-charge)",
-      "blocker_body": "Storing the response only after the charge completes leaves a race: two same-key requests arriving concurrently (retry storm, double-click, client-timeout-and-retry) both miss the cache and both charge. Atomically reserve the key (durable INSERT … ON CONFLICT, or SET NX) BEFORE the side effect; the loser blocks-and-polls for the original result. All three seats raised this independently."
+      "blocker_body": "Storing the response only after the charge completes leaves a race: two same-key requests arriving concurrently (retry storm, double-click, client-timeout-and-retry) both miss the cache and both charge. Atomically reserve the key (durable INSERT … ON CONFLICT, or SET NX) BEFORE the side effect; the loser blocks-and-polls for the original result. All three seats raised this independently.",
+      "blocker_summary": "Storing the response only after the charge completes leaves a race: two same-key requests arriving concurrently (retry storm, double-click, client-timeout-and-retry) both miss the…"
     },
     {
       "blocker_title": "No key→payload binding (same key, different body served stale)",
-      "blocker_body": "Nothing binds the key to the request. A client reusing a key with a different amount/recipient/currency gets the prior cached response — a silent under-charge or a replay of an unrelated charge. Bind the key to a hash of the canonicalized request body; same-key/different-payload must return 409/422, never a cached success."
+      "blocker_body": "Nothing binds the key to the request. A client reusing a key with a different amount/recipient/currency gets the prior cached response — a silent under-charge or a replay of an unrelated charge. Bind the key to a hash of the canonicalized request body; same-key/different-payload must return 409/422, never a cached success.",
+      "blocker_summary": "Nothing binds the key to the request. A client reusing a key with a different amount/recipient/currency gets the prior cached response — a silent under-charge or a replay of an…"
     },
     {
       "blocker_title": "No per-tenant scoping → cross-tenant response leak",
-      "blocker_body": "Keys are client-supplied strings with no stated namespace. Enabling a single shared keyspace for all clients means Client B sending a key Client A already used receives Client A&#x27;s cached charge response — a cross-tenant data leak. The lookup key must be (account_id, idempotency_key), never the raw header."
+      "blocker_body": "Keys are client-supplied strings with no stated namespace. Enabling a single shared keyspace for all clients means Client B sending a key Client A already used receives Client A&#x27;s cached charge response — a cross-tenant data leak. The lookup key must be (account_id, idempotency_key), never the raw header.",
+      "blocker_summary": "Keys are client-supplied strings with no stated namespace. Enabling a single shared keyspace for all clients means Client B sending a key Client A already used receives Client A's…"
     },
     {
       "blocker_title": "Redis as sole system of record → non-durable idempotency",
-      "blocker_body": "Redis is not durable by default; failover, restart without AOF, or maxmemory eviction can drop idempotency records early, after which a retry re-charges. The durable transactional DB must be the system of record; Redis, if used, is a fast-path cache in front of it. (Gemini&#x27;s noeviction does not make Redis durable — it trades the double-charge for a write-availability cliff.)"
+      "blocker_body": "Redis is not durable by default; failover, restart without AOF, or maxmemory eviction can drop idempotency records early, after which a retry re-charges. The durable transactional DB must be the system of record; Redis, if used, is a fast-path cache in front of it. (Gemini&#x27;s noeviction does not make Redis durable — it trades the double-charge for a write-availability cliff.)",
+      "blocker_summary": "Redis is not durable by default; failover, restart without AOF, or maxmemory eviction can drop idempotency records early, after which a retry re-charges. The durable transactional…"
     },
     {
       "blocker_title": "Indeterminate downstream outcome + non-idempotent processor",
-      "blocker_body": "API-layer idempotency cannot make a non-idempotent money movement exactly-once. A processor timeout leaves the charge state unknown; on retry you must neither replay a fabricated success nor blind-recharge — you must propagate the key to the processor and reconcile by it. Claude elevated this above the concurrency window as the requirement the plan is furthest from."
+      "blocker_body": "API-layer idempotency cannot make a non-idempotent money movement exactly-once. A processor timeout leaves the charge state unknown; on retry you must neither replay a fabricated success nor blind-recharge — you must propagate the key to the processor and reconcile by it. Claude elevated this above the concurrency window as the requirement the plan is furthest from.",
+      "blocker_summary": "API-layer idempotency cannot make a non-idempotent money movement exactly-once. A processor timeout leaves the charge state unknown; on retry you must neither replay a fabricated…"
     },
     {
       "blocker_title": "Caching of transient / indeterminate failures",
-      "blocker_body": "An unqualified &#x27;cached response&#x27; pins every retry to a cached 5xx/timeout for 24h, turning a brief downstream glitch into a prolonged checkout outage — and caching an indeterminate result as terminal is unsafe. Cache only KNOWN-terminal outcomes; never cache in-flight or indeterminate-failure states (deterministic pre-side-effect validation errors are a documented exception)."
+      "blocker_body": "An unqualified &#x27;cached response&#x27; pins every retry to a cached 5xx/timeout for 24h, turning a brief downstream glitch into a prolonged checkout outage — and caching an indeterminate result as terminal is unsafe. Cache only KNOWN-terminal outcomes; never cache in-flight or indeterminate-failure states (deterministic pre-side-effect validation errors are a documented exception).",
+      "blocker_summary": "An unqualified 'cached response' pins every retry to a cached 5xx/timeout for 24h, turning a brief downstream glitch into a prolonged checkout outage — and caching an…"
     },
     {
       "blocker_title": "Big-bang rollout on the money path (no shadow/canary/kill switch)",
-      "blocker_body": "Flipping a correctness-critical charge-path interceptor on for everyone at once is volatile: existing clients sending static/placeholder keys would have their checkout funnels break on enforcement. Ship staged — shadow → canary → percentage ramp behind a kill switch — with hit/miss/payload-mismatch/conflict/Redis-latency metrics wired up before the canary."
+      "blocker_body": "Flipping a correctness-critical charge-path interceptor on for everyone at once is volatile: existing clients sending static/placeholder keys would have their checkout funnels break on enforcement. Ship staged — shadow → canary → percentage ramp behind a kill switch — with hit/miss/payload-mismatch/conflict/Redis-latency metrics wired up before the canary.",
+      "blocker_summary": "Flipping a correctness-critical charge-path interceptor on for everyone at once is volatile: existing clients sending static/placeholder keys would have their checkout funnels…"
     }
   ],
   "dissents": [
     {
       "dissent_who": "Gemini",
-      "dissent_body": "Returning a raw 409 to a duplicate in-flight request is dangerous for naive client SDKs: on a client-side timeout retry the SDK shows &#x27;Payment Failed&#x27;, the consumer retries on another card, and the original charge then succeeds. Prefer block-and-poll (≈3–5s) or a 202 + Retry-After, plus a published client retry-integration guide. (Claude and Codex favor 409 for the in-flight loser.)"
+      "dissent_body": "Returning a raw 409 to a duplicate in-flight request is dangerous for naive client SDKs: on a client-side timeout retry the SDK shows &#x27;Payment Failed&#x27;, the consumer retries on another card, and the original charge then succeeds. Prefer block-and-poll (≈3–5s) or a 202 + Retry-After, plus a published client retry-integration guide. (Claude and Codex favor 409 for the in-flight loser.)",
+      "dissent_summary": "Returning a raw 409 to a duplicate in-flight request is dangerous for naive client SDKs: on a client-side timeout retry the SDK shows 'Payment Failed', the consumer retries on…"
     },
     {
       "dissent_who": "Claude",
-      "dissent_body": "Dissents from Gemini&#x27;s resiliency mechanics — fail-closed (503) on Redis-down and noeviction — and from any short-TTL auto-expiring lock as the primary guarantee: a lock that expires while the side effect is still in flight re-opens the exact double-charge it exists to prevent. These problems largely dissolve once the durable store, not Redis, holds the invariant; then a Redis outage is a fast-path degradation, not a payments outage."
+      "dissent_body": "Dissents from Gemini&#x27;s resiliency mechanics — fail-closed (503) on Redis-down and noeviction — and from any short-TTL auto-expiring lock as the primary guarantee: a lock that expires while the side effect is still in flight re-opens the exact double-charge it exists to prevent. These problems largely dissolve once the durable store, not Redis, holds the invariant; then a Redis outage is a fast-path degradation, not a payments outage.",
+      "dissent_summary": "Dissents from Gemini's resiliency mechanics — fail-closed (503) on Redis-down and noeviction — and from any short-TTL auto-expiring lock as the primary guarantee: a lock that…"
     }
   ],
   "caveats": [
@@ -179,5 +189,24 @@
     {
       "action": "Roll out shadow → canary → ramp behind a kill switch, then re-review."
     }
-  ]
+  ],
+  "dissents_brief": [
+    {
+      "dissent_who": "Gemini",
+      "dissent_summary": "Returning a raw 409 to a duplicate in-flight request is dangerous for naive client SDKs: on a client-side timeout retry the SDK shows 'Payment Failed', the consumer retries on…",
+      "dissent_more": "(+1 more in the full handoff)"
+    }
+  ],
+  "actions_brief": [
+    {
+      "action": "Write the contract first: scope (account_id, key); key format/length; what 24h expiry means to clients; same-key/different-payload behavior; Redis-down policy; which outcomes are cached."
+    },
+    {
+      "action": "Add a durable idempotency record in the primary DB — unique on (account_id, endpoint, key) — storing request fingerprint, state (in_flight|completed|failed_terminal), and the response."
+    },
+    {
+      "action": "Reserve-then-process: atomic durable insert of in_flight BEFORE charging; loser polls for the terminal result or returns a deterministic conflict."
+    }
+  ],
+  "actions_more": "…3 more in the full handoff"
 }

--- a/examples/payments-idempotency-review/quick-verdict.html
+++ b/examples/payments-idempotency-review/quick-verdict.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Payments API idempotency keys</title>
+<style>
+  :root {
+    --maxw: 820px;
+    /* light "Boardroom" body */
+    --page: #faf8f3;
+    --surface: #ffffff;
+    --surface-soft: #faf7f0;
+    --vellum: #f3eee3;
+    --ink: #11192b;
+    --ink-soft: #3a4459;
+    --ink-faint: #6e768a;
+    --line: #e4ddce;
+    --line-strong: #d8cfb8;
+    /* brand accents (both themes) */
+    --accent: #2347ff;          /* cobalt — signature */
+    --accent-deep: #0f2bc2;
+    --accent-tint: #eaedff;
+    --gold: #a8843c;            /* secondary — the lead seat */
+    /* dark "Signal" bands */
+    --dark: #0a0e1a;
+    --dark-2: #111726;
+    --dark-line: #232b3e;
+    --on-dark: #fbfaf7;
+    --on-dark-soft: #b9c0d0;
+    --on-dark-faint: #8a93a8;
+    --accent-bright: #5b8cff;
+    --gold-bright: #e2b658;
+    /* verdict palettes (muted — counsel, not error toasts) */
+    --ship-bg: #e9f1ec;     --ship-edge: #2f6f57;   --ship-ink: #235540;
+    --caution-bg: #fbf1de;  --caution-edge: #b07a1e; --caution-ink: #7a5410;
+    --block-bg: #f7e9e9;    --block-edge: #9e3636;  --block-ink: #7a2525;
+    --font-sans: "Panely Grotesk","Söhne","Inter","Helvetica Neue",Helvetica,Arial,"Segoe UI",system-ui,sans-serif;
+    --font-mono: "Berkeley Mono","JetBrains Mono",ui-monospace,"Menlo","Consolas",monospace;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 17px;
+    line-height: 1.65;
+  }
+
+  /* ---- dark masthead band ---- */
+  header.masthead { background: var(--dark); color: var(--on-dark); padding: 30px 20px 28px; }
+  .band-inner { max-width: var(--maxw); margin: 0 auto; }
+  .brand-lockup { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+  .brand-mark { width: 46px; height: 46px; border-radius: 11px; overflow: hidden; flex: 0 0 auto; }
+  .brand-mark svg { display: block; width: 100%; height: 100%; }
+  .brand-name { display: flex; flex-direction: column; line-height: 1.1; }
+  .brand-name .p { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--on-dark); }
+  .brand-name .ab { font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-bright); margin-top: 4px; }
+  header.masthead h1 { font-size: 29px; line-height: 1.18; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; color: var(--on-dark); }
+  .subtitle { font-size: 16px; color: var(--on-dark-soft); margin: 0 0 18px; max-width: 60ch; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(255,255,255,0.05); border: 1px solid var(--dark-line);
+    border-radius: 999px; padding: 5px 13px; font-size: 13px; color: var(--on-dark-soft);
+  }
+  .chip b { font-weight: 600; color: var(--on-dark); }
+
+  /* ---- body column ---- */
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 30px 20px 56px; }
+
+  /* ---- verdict banner ---- */
+  .verdict {
+    border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
+    border: 1px solid transparent; border-left-width: 6px;
+  }
+  .verdict .label {
+    font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
+    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+  }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
+  .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
+  .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
+  .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
+  .verdict.caution { background: var(--caution-bg); border-color: var(--caution-edge); color: var(--caution-ink); }
+  .verdict.block   { background: var(--block-bg);   border-color: var(--block-edge);   color: var(--block-ink); }
+
+  /* ---- sections ---- */
+  .qv-sec { margin: 0 0 30px; }
+  h2 {
+    font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-faint); margin: 0 0 14px;
+    padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+
+  /* ---- compact blocker list (one line per item) ---- */
+  ol.qv-blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
+  ol.qv-blockers > li {
+    counter-increment: blk; position: relative;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 11px; padding: 14px 18px 14px 56px; margin: 0 0 10px;
+  }
+  ol.qv-blockers > li::before {
+    content: counter(blk); position: absolute; left: 14px; top: 13px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--block-bg); color: var(--block-ink);
+    font-size: 14px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  }
+  ol.qv-blockers .b-title { font-weight: 600; }
+  ol.qv-blockers .b-sub { font-size: 15px; color: var(--ink-soft); margin-top: 2px; }
+
+  /* ---- dissent line ---- */
+  .qv-dissent {
+    background: #fbf3ec; border: 1px dashed var(--caution-edge);
+    border-radius: 12px; padding: 14px 20px; margin: 0 0 30px;
+  }
+  .qv-dflag {
+    display: inline-block; font-size: 11.5px; font-weight: 700;
+    letter-spacing: 0.07em; text-transform: uppercase; color: var(--caution-ink);
+    background: var(--caution-bg); border-radius: 999px; padding: 3px 10px; margin-bottom: 8px;
+  }
+  .qv-d { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
+  .qv-d .who { font-weight: 700; color: var(--caution-ink); }
+  .qv-more { color: var(--ink-faint, #6b665c); font-size: 0.92em; }
+
+  /* ---- next steps ---- */
+  .qv-actions {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 12px; padding: 14px 20px 14px 38px; margin: 0; font-size: 15.5px;
+  }
+  ol.qv-actions li { margin: 6px 0; }
+  .qv-more-li { color: var(--ink-faint, #6b665c); list-style: none; font-size: 0.92em; }
+
+  /* ---- dark footer / colophon band ---- */
+  footer.colophon { background: var(--dark); color: var(--on-dark-soft); padding: 26px 20px 32px; }
+  footer.colophon .disclaimer {
+    display: block; margin: 0 0 16px; font-style: italic;
+    color: var(--on-dark-faint); font-size: 13.5px;
+  }
+  .colophon-grid { display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-start; justify-content: space-between; }
+  .colophon-about { flex: 1 1 320px; }
+  .footer-lockup { display: flex; align-items: center; gap: 9px; font-weight: 700; color: var(--on-dark); font-size: 14px; margin-bottom: 9px; }
+  .footer-lockup svg { width: 26px; height: 26px; display: block; }
+  .colophon-about p { margin: 0; font-size: 13.5px; line-height: 1.6; color: var(--on-dark-soft); max-width: 54ch; }
+  .colophon-cta { flex: 0 0 auto; }
+  .cta {
+    display: inline-block; background: var(--accent); color: #ffffff;
+    font-weight: 600; font-size: 14.5px; text-decoration: none;
+    padding: 10px 20px; border-radius: 9px;
+  }
+  .cta::after { content: " →"; }
+  footer.colophon .prov { display: block; margin-top: 12px; font-size: 11.5px; color: var(--on-dark-faint); font-family: var(--font-mono); }
+
+  /* ---- responsive ---- */
+  @media (max-width: 560px) {
+    body { font-size: 16px; }
+    .wrap { padding: 22px 15px 44px; }
+    header.masthead, footer.colophon { padding-left: 15px; padding-right: 15px; }
+    header.masthead h1 { font-size: 25px; }
+    .verdict .headline { font-size: 20px; }
+    ol.qv-blockers > li { padding-left: 50px; padding-right: 16px; }
+    .colophon-cta { width: 100%; }
+  }
+
+  /* ---- print / PDF (Print -> Save as PDF) ---- */
+  @media print {
+    body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    header.masthead, footer.colophon { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .wrap { max-width: none; }
+    .verdict, ol.qv-blockers > li, .qv-dissent, .qv-actions { break-inside: avoid; }
+    a { color: inherit; text-decoration: none; }
+  }
+</style>
+</head>
+<body>
+
+  <!-- ===================== MASTHEAD (Panely / dark band) ===================== -->
+  <header class="masthead">
+    <div class="band-inner">
+      <div class="brand-lockup">
+        <span class="brand-mark"><svg viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg"><defs><radialGradient id="bg" cx="50%" cy="38%" r="74%"><stop offset="0%" stop-color="#122046"/><stop offset="55%" stop-color="#0a1024"/><stop offset="100%" stop-color="#05070f"/></radialGradient><radialGradient id="vig" cx="50%" cy="50%" r="62%"><stop offset="60%" stop-color="#000000" stop-opacity="0"/><stop offset="100%" stop-color="#000000" stop-opacity="0.5"/></radialGradient><linearGradient id="cobalt" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a9c2ff"/><stop offset="52%" stop-color="#5b8cff"/><stop offset="100%" stop-color="#2347ff"/></linearGradient><linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffe6a3"/><stop offset="55%" stop-color="#e2b658"/><stop offset="100%" stop-color="#b9842e"/></linearGradient><radialGradient id="core" cx="50%" cy="42%" r="62%"><stop offset="0%" stop-color="#ffffff"/><stop offset="34%" stop-color="#dbe6ff"/><stop offset="70%" stop-color="#6f93ff"/><stop offset="100%" stop-color="#2347ff"/></radialGradient><radialGradient id="spark" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#eaf1ff"/><stop offset="100%" stop-color="#5b8cff"/></radialGradient><filter id="gM" x="-180%" y="-180%" width="460%" height="460%"><feGaussianBlur stdDeviation="14"/></filter><filter id="gL" x="-220%" y="-220%" width="540%" height="540%"><feGaussianBlur stdDeviation="32"/></filter></defs><rect width="1000" height="1000" fill="#05070f"/><rect width="1000" height="1000" fill="url(#bg)"/><circle cx="500" cy="500" r="220" fill="#3a5fff" opacity="0.12" filter="url(#gL)"/><circle cx="500" cy="500" r="312" fill="none" stroke="url(#cobalt)" stroke-width="3" opacity="0.7"/><circle cx="500" cy="500" r="210" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.32"/><circle cx="500" cy="500" r="120" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.22"/><g stroke="#4f7bff" stroke-width="2"><line x1="830" y1="500" x2="850" y2="500" opacity="0.4"/><line x1="500" y1="830" x2="500" y2="850" opacity="0.4"/><line x1="170" y1="500" x2="150" y2="500" opacity="0.4"/><line x1="500" y1="170" x2="500" y2="150" opacity="0.4"/><line x1="733.3" y1="733.3" x2="743.2" y2="743.2" opacity="0.16"/><line x1="266.7" y1="733.3" x2="256.8" y2="743.2" opacity="0.16"/><line x1="266.7" y1="266.7" x2="256.8" y2="256.8" opacity="0.16"/><line x1="733.3" y1="266.7" x2="743.2" y2="256.8" opacity="0.16"/></g><line x1="500" y1="250" x2="500" y2="188" stroke="#f7b500" stroke-width="3" opacity="0.45"/><circle cx="500" cy="188" r="46" fill="#e2b658" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="188" r="34" fill="#0a1430" stroke="url(#gold)" stroke-width="5"/><circle cx="500" cy="188" r="15" fill="url(#gold)"/><circle cx="770.2" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="344" r="15" fill="url(#spark)"/><circle cx="770.2" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="656" r="15" fill="url(#spark)"/><circle cx="500" cy="812" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="812" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="500" cy="812" r="15" fill="url(#spark)"/><circle cx="229.8" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="656" r="15" fill="url(#spark)"/><circle cx="229.8" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="344" r="15" fill="url(#spark)"/><circle cx="500" cy="500" r="74" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.5"/><circle cx="500" cy="500" r="144" fill="#3a5fff" opacity="0.16" filter="url(#gL)"/><circle cx="500" cy="500" r="77" fill="url(#core)" opacity="0.5" filter="url(#gM)"/><circle cx="500" cy="500" r="48" fill="url(#core)" stroke="#ffffff" stroke-width="3"/><circle cx="500" cy="489" r="13" fill="#ffffff" opacity="0.92"/><rect width="1000" height="1000" fill="url(#vig)"/></svg></span>
+        <span class="brand-name"><span class="p">Advisory Board</span><span class="ab" style="text-transform:none; letter-spacing:0.03em; font-weight:600; margin-top:3px;">powered by Panely</span></span>
+      </div>
+      <h1>Payments API idempotency keys</h1>
+      <p class="subtitle">An independent multi-model review.</p>
+      <div class="meta-row">
+        <span class="chip"><b>Date</b> 2026-06-25</span>
+        <span class="chip"><b>Rounds</b> 2</span>
+        <span class="chip"><b>Board</b> Claude · Codex · Gemini</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+
+  <!-- ===================== VERDICT BANNER ===================== -->
+  
+  <div class="verdict block">
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
+    <p class="headline">DO NOT SHIP YET — unanimous</p>
+    <p class="note"></p>
+  </div>
+
+  <!-- ===================== MUST-RESOLVE (one line each) ===================== -->
+  <section class="qv-sec qv-blockers-sec">
+    <h2>Consensus blockers — must fix before ship</h2>
+    <ol class="qv-blockers">
+      
+      <li>
+        <span class="b-title">Concurrency window → double charge (no atomic reserve-before-charge)</span>
+        <div class="b-sub">Storing the response only after the charge completes leaves a race: two same-key requests arriving concurrently (retry storm, double-click, client-timeout-and-retry) both miss the…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">No key→payload binding (same key, different body served stale)</span>
+        <div class="b-sub">Nothing binds the key to the request. A client reusing a key with a different amount/recipient/currency gets the prior cached response — a silent under-charge or a replay of an…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">No per-tenant scoping → cross-tenant response leak</span>
+        <div class="b-sub">Keys are client-supplied strings with no stated namespace. Enabling a single shared keyspace for all clients means Client B sending a key Client A already used receives Client A&#x27;s…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Redis as sole system of record → non-durable idempotency</span>
+        <div class="b-sub">Redis is not durable by default; failover, restart without AOF, or maxmemory eviction can drop idempotency records early, after which a retry re-charges. The durable transactional…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Indeterminate downstream outcome + non-idempotent processor</span>
+        <div class="b-sub">API-layer idempotency cannot make a non-idempotent money movement exactly-once. A processor timeout leaves the charge state unknown; on retry you must neither replay a fabricated…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Caching of transient / indeterminate failures</span>
+        <div class="b-sub">An unqualified &#x27;cached response&#x27; pins every retry to a cached 5xx/timeout for 24h, turning a brief downstream glitch into a prolonged checkout outage — and caching an…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Big-bang rollout on the money path (no shadow/canary/kill switch)</span>
+        <div class="b-sub">Flipping a correctness-critical charge-path interceptor on for everyone at once is volatile: existing clients sending static/placeholder keys would have their checkout funnels…</div>
+      </li>
+      
+    </ol>
+  </section>
+
+  <!-- ===================== DISSENT (one line) ===================== -->
+  <div class="qv-dissent">
+    <span class="qv-dflag">Dissent on the record</span>
+    
+    <p class="qv-d"><span class="who">Gemini</span> — Returning a raw 409 to a duplicate in-flight request is dangerous for naive client SDKs: on a client-side timeout retry the SDK shows &#x27;Payment Failed&#x27;, the consumer retries on… <span class="qv-more">(+1 more in the full handoff)</span></p>
+    
+  </div>
+
+  <!-- ===================== NEXT STEPS ===================== -->
+  <section class="qv-sec qv-actions-sec">
+    <h2>Next steps</h2>
+    <ol class="qv-actions">
+      
+      <li>Write the contract first: scope (account_id, key); key format/length; what 24h expiry means to clients; same-key/different-payload behavior; Redis-down policy; which outcomes are cached.</li>
+      
+      <li>Add a durable idempotency record in the primary DB — unique on (account_id, endpoint, key) — storing request fingerprint, state (in_flight|completed|failed_terminal), and the response.</li>
+      
+      <li>Reserve-then-process: atomic durable insert of in_flight BEFORE charging; loser polls for the terminal result or returns a deterministic conflict.</li>
+      
+      <li class="qv-more-li">…3 more in the full handoff</li>
+    </ol>
+  </section>
+
+  </main>
+
+  <!-- ===================== FOOTER / COLOPHON (Panely / dark band) ===================== -->
+  
+  <footer class="colophon">
+    <div class="band-inner">
+      <div class="colophon-grid">
+        <div class="colophon-about">
+          <div class="footer-lockup">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="22" fill="#0a0e1a"/><circle cx="50" cy="50" r="30" fill="none" stroke="#3a5fd9" stroke-width="3" opacity="0.55"/><circle cx="50" cy="20" r="10" fill="#0a0e1a" stroke="#e2b658" stroke-width="4"/><circle cx="50" cy="20" r="4" fill="#e2b658"/><circle cx="76" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="76" cy="65" r="4" fill="#3d6bff"/><circle cx="24" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="24" cy="65" r="4" fill="#3d6bff"/><circle cx="50" cy="50" r="13" fill="#5b8cff"/><circle cx="50" cy="50" r="5.5" fill="#ffffff"/></svg>
+            <span>Advisory Board <span style="font-weight:400; color:var(--on-dark-soft); font-size:11.5px; letter-spacing:0.02em;">powered by Panely</span></span>
+          </div>
+          <p>Convene Claude, Codex, and Gemini on your own subscriptions — the ones you already pay for, no new accounts and no API keys — to review the same material and reach one clear verdict.</p>
+        </div>
+        <div class="colophon-cta">
+          <a class="cta" href="https://panely.ai">panely.ai</a>
+        </div>
+      </div>
+      <span class="prov">Board: Claude · Codex · Gemini · 2 rounds · 2026-06-25</span>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/examples/ratelimiter-readiness-review/final-consensus.html
+++ b/examples/ratelimiter-readiness-review/final-consensus.html
@@ -81,6 +81,11 @@
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
     font-weight: 700; margin: 0 0 6px; opacity: 0.85;
   }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
   .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
@@ -286,7 +291,7 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict caution">
-    <p class="label">Final verdict</p>
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
     <p class="headline">SHIP WITH CHANGES — unanimous</p>
     <p class="note"></p>
   </div>

--- a/examples/ratelimiter-readiness-review/handoff-data.json
+++ b/examples/ratelimiter-readiness-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "SHIP WITH CHANGES — unanimous",
   "verdict_class": "caution",
   "verdict_note": "",
+  "confidence": "high confidence",
   "blockers_heading": "Consensus blockers — must fix before ship",
   "disclaimer": "",
   "plan": "review packet",
@@ -110,33 +111,40 @@
   "blockers": [
     {
       "blocker_title": "Wall-clock source on the refill hot path",
-      "blocker_body": "All three seats agree the use of time.time() on the refill path is a correctness bug under the stated operating context: a backward clock step makes elapsed negative, so self._tokens + elapsed*rate subtracts tokens and the min() clamp only bounds the top, never zero. Result is spurious denials / a multi-second denial window after an NTP or operator clock correction — exactly the traffic conditions the limiter exists to handle. Fix: switch to time.monotonic() (injectable), and clamp elapsed = max(0.0, now - self._last)."
+      "blocker_body": "All three seats agree the use of time.time() on the refill path is a correctness bug under the stated operating context: a backward clock step makes elapsed negative, so self._tokens + elapsed*rate subtracts tokens and the min() clamp only bounds the top, never zero. Result is spurious denials / a multi-second denial window after an NTP or operator clock correction — exactly the traffic conditions the limiter exists to handle. Fix: switch to time.monotonic() (injectable), and clamp elapsed = max(0.0, now - self._last).",
+      "blocker_summary": "All three seats agree the use of time.time() on the refill path is a correctness bug under the stated operating context: a backward clock step makes elapsed negative, so…"
     },
     {
       "blocker_title": "allow(n) accepts invalid request costs",
-      "blocker_body": "All three seats flag that allow(n) performs no validation on n. A negative n (e.g. allow(-5)) executes self._tokens -= n, which mints tokens and returns True — a caller can refill the bucket by asking. Non-finite values have undefined behavior and n is never bounded against capacity. Fix: require finite, positive n and define behavior for n &gt; capacity."
+      "blocker_body": "All three seats flag that allow(n) performs no validation on n. A negative n (e.g. allow(-5)) executes self._tokens -= n, which mints tokens and returns True — a caller can refill the bucket by asking. Non-finite values have undefined behavior and n is never bounded against capacity. Fix: require finite, positive n and define behavior for n &gt; capacity.",
+      "blocker_summary": "All three seats flag that allow(n) performs no validation on n. A negative n (e.g. allow(-5)) executes self._tokens -= n, which mints tokens and returns True — a caller can refill…"
     },
     {
       "blocker_title": "Per-process / deployment enforcement semantics unresolved",
-      "blocker_body": "Claude and Codex flag that one bucket per worker process means the globally enforced rate is roughly rate × worker_count, so advertised limit ≠ enforced limit. Claude treats this as a must-decide operational caveat (acceptable as a soft abuse cap, not as a hard ceiling) rather than a code fix; Codex states that if a fixed per-client RPS must be enforced globally across processes/hosts this becomes a block unless moved to a shared limiter or upstream gateway. The seats did not settle whether &#x27;per-client&#x27; is global or local. Requires an explicit, recorded operator decision."
+      "blocker_body": "Claude and Codex flag that one bucket per worker process means the globally enforced rate is roughly rate × worker_count, so advertised limit ≠ enforced limit. Claude treats this as a must-decide operational caveat (acceptable as a soft abuse cap, not as a hard ceiling) rather than a code fix; Codex states that if a fixed per-client RPS must be enforced globally across processes/hosts this becomes a block unless moved to a shared limiter or upstream gateway. The seats did not settle whether &#x27;per-client&#x27; is global or local. Requires an explicit, recorded operator decision.",
+      "blocker_summary": "Claude and Codex flag that one bucket per worker process means the globally enforced rate is roughly rate × worker_count, so advertised limit ≠ enforced limit. Claude treats this…"
     },
     {
       "blocker_title": "Tests are timing-dependent and prove none of the failure modes",
-      "blocker_body": "Claude and Codex find the tests use time.sleep() and real wall-clock, making them flaky on loaded CI. No test injects a clock, exercises a backward clock jump, asserts the 0 ≤ _tokens ≤ capacity invariant, covers n ≤ 0, or exercises concurrent access — so they cannot deterministically reproduce the primary failure mode. The suite does pass clean — the command citation below re-runs it (exit 0, `OK`) — which is exactly the point: a green suite is a verified receipt that the tests pass, not evidence that the failure modes are covered. Fix: rewrite around a fake/injected clock and add the missing cases."
+      "blocker_body": "Claude and Codex find the tests use time.sleep() and real wall-clock, making them flaky on loaded CI. No test injects a clock, exercises a backward clock jump, asserts the 0 ≤ _tokens ≤ capacity invariant, covers n ≤ 0, or exercises concurrent access — so they cannot deterministically reproduce the primary failure mode. The suite does pass clean — the command citation below re-runs it (exit 0, `OK`) — which is exactly the point: a green suite is a verified receipt that the tests pass, not evidence that the failure modes are covered. Fix: rewrite around a fake/injected clock and add the missing cases.",
+      "blocker_summary": "Claude and Codex find the tests use time.sleep() and real wall-clock, making them flaky on loaded CI. No test injects a clock, exercises a backward clock jump, asserts the 0 ≤…"
     }
   ],
   "dissents": [
     {
       "dissent_who": "Claude",
-      "dissent_body": "Dissents from Gemini on two named points: (1) &#x27;migrate to an API Gateway / centralized store instead&#x27; is a recommendation to build a different system, not a defect in the artifact under review — per-process and centralized limiting are both legitimate, and a block must rest on an unfixable in-scope defect; (2) the GIL/lock-contention latency-spike rationale is overstated to the point of being wrong as a blocking reason — the critical section is ~four arithmetic ops with no I/O or allocation, sub-microsecond, and the GIL already serializes the workers, so the lock adds negligible marginal contention. If contention ever mattered, the fix is sharding buckets, not abandoning the design."
+      "dissent_body": "Dissents from Gemini on two named points: (1) &#x27;migrate to an API Gateway / centralized store instead&#x27; is a recommendation to build a different system, not a defect in the artifact under review — per-process and centralized limiting are both legitimate, and a block must rest on an unfixable in-scope defect; (2) the GIL/lock-contention latency-spike rationale is overstated to the point of being wrong as a blocking reason — the critical section is ~four arithmetic ops with no I/O or allocation, sub-microsecond, and the GIL already serializes the workers, so the lock adds negligible marginal contention. If contention ever mattered, the fix is sharding buckets, not abandoning the design.",
+      "dissent_summary": "Dissents from Gemini on two named points: (1) 'migrate to an API Gateway / centralized store instead' is a recommendation to build a different system, not a defect in the artifact…"
     },
     {
       "dissent_who": "Codex",
-      "dissent_body": "Dissents from Gemini: Python lock contention alone does not justify an unconditional block on the provided evidence. It is a real risk needing load testing, but the packet gives no peak RPS, thread count, latency SLO, or contention benchmark."
+      "dissent_body": "Dissents from Gemini: Python lock contention alone does not justify an unconditional block on the provided evidence. It is a real risk needing load testing, but the packet gives no peak RPS, thread count, latency SLO, or contention benchmark.",
+      "dissent_summary": "Dissents from Gemini: Python lock contention alone does not justify an unconditional block on the provided evidence. It is a real risk needing load testing, but the packet gives…"
     },
     {
       "dissent_who": "Gemini",
-      "dissent_body": "Dissents from Codex for focusing narrowly on code correctness while ignoring operational risk: deploying to the hot path of every public request without built-in observability, dry-run/shadow mode, and a fail-open circuit breaker is a critical operational risk regardless of clock correctness. Also dissents from Claude&#x27;s structural acceptance of per-process limits without operational remediation, insisting on explicit configuration scaling guidelines (e.g. dividing limits by active worker count) to prevent SLA drift."
+      "dissent_body": "Dissents from Codex for focusing narrowly on code correctness while ignoring operational risk: deploying to the hot path of every public request without built-in observability, dry-run/shadow mode, and a fail-open circuit breaker is a critical operational risk regardless of clock correctness. Also dissents from Claude&#x27;s structural acceptance of per-process limits without operational remediation, insisting on explicit configuration scaling guidelines (e.g. dividing limits by active worker count) to prevent SLA drift.",
+      "dissent_summary": "Dissents from Codex for focusing narrowly on code correctness while ignoring operational risk: deploying to the hot path of every public request without built-in observability,…"
     }
   ],
   "caveats": [
@@ -193,5 +201,24 @@
     {
       "action": "(Gemini) Add operational safeguards: dry-run/shadow mode emitting metrics while returning True, allow/reject telemetry tagged by client ID, a fail-open try/except around allow() in the caller, and a canary rollout via feature flag."
     }
-  ]
+  ],
+  "dissents_brief": [
+    {
+      "dissent_who": "Claude",
+      "dissent_summary": "Dissents from Gemini on two named points: (1) 'migrate to an API Gateway / centralized store instead' is a recommendation to build a different system, not a defect in the artifact…",
+      "dissent_more": "(+2 more in the full handoff)"
+    }
+  ],
+  "actions_brief": [
+    {
+      "action": "Replace time.time() with an injectable clock defaulting to time.monotonic() in __init__ and allow()."
+    },
+    {
+      "action": "Clamp elapsed = max(0.0, now - self._last) so refill math never goes negative; never move _last backward."
+    },
+    {
+      "action": "Validate n in allow(): require finite, positive values and define behavior for n &gt; capacity."
+    }
+  ],
+  "actions_more": "…5 more in the full handoff"
 }

--- a/examples/ratelimiter-readiness-review/quick-verdict.html
+++ b/examples/ratelimiter-readiness-review/quick-verdict.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>review packet</title>
+<style>
+  :root {
+    --maxw: 820px;
+    /* light "Boardroom" body */
+    --page: #faf8f3;
+    --surface: #ffffff;
+    --surface-soft: #faf7f0;
+    --vellum: #f3eee3;
+    --ink: #11192b;
+    --ink-soft: #3a4459;
+    --ink-faint: #6e768a;
+    --line: #e4ddce;
+    --line-strong: #d8cfb8;
+    /* brand accents (both themes) */
+    --accent: #2347ff;          /* cobalt — signature */
+    --accent-deep: #0f2bc2;
+    --accent-tint: #eaedff;
+    --gold: #a8843c;            /* secondary — the lead seat */
+    /* dark "Signal" bands */
+    --dark: #0a0e1a;
+    --dark-2: #111726;
+    --dark-line: #232b3e;
+    --on-dark: #fbfaf7;
+    --on-dark-soft: #b9c0d0;
+    --on-dark-faint: #8a93a8;
+    --accent-bright: #5b8cff;
+    --gold-bright: #e2b658;
+    /* verdict palettes (muted — counsel, not error toasts) */
+    --ship-bg: #e9f1ec;     --ship-edge: #2f6f57;   --ship-ink: #235540;
+    --caution-bg: #fbf1de;  --caution-edge: #b07a1e; --caution-ink: #7a5410;
+    --block-bg: #f7e9e9;    --block-edge: #9e3636;  --block-ink: #7a2525;
+    --font-sans: "Panely Grotesk","Söhne","Inter","Helvetica Neue",Helvetica,Arial,"Segoe UI",system-ui,sans-serif;
+    --font-mono: "Berkeley Mono","JetBrains Mono",ui-monospace,"Menlo","Consolas",monospace;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 17px;
+    line-height: 1.65;
+  }
+
+  /* ---- dark masthead band ---- */
+  header.masthead { background: var(--dark); color: var(--on-dark); padding: 30px 20px 28px; }
+  .band-inner { max-width: var(--maxw); margin: 0 auto; }
+  .brand-lockup { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+  .brand-mark { width: 46px; height: 46px; border-radius: 11px; overflow: hidden; flex: 0 0 auto; }
+  .brand-mark svg { display: block; width: 100%; height: 100%; }
+  .brand-name { display: flex; flex-direction: column; line-height: 1.1; }
+  .brand-name .p { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--on-dark); }
+  .brand-name .ab { font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-bright); margin-top: 4px; }
+  header.masthead h1 { font-size: 29px; line-height: 1.18; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; color: var(--on-dark); }
+  .subtitle { font-size: 16px; color: var(--on-dark-soft); margin: 0 0 18px; max-width: 60ch; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(255,255,255,0.05); border: 1px solid var(--dark-line);
+    border-radius: 999px; padding: 5px 13px; font-size: 13px; color: var(--on-dark-soft);
+  }
+  .chip b { font-weight: 600; color: var(--on-dark); }
+
+  /* ---- body column ---- */
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 30px 20px 56px; }
+
+  /* ---- verdict banner ---- */
+  .verdict {
+    border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
+    border: 1px solid transparent; border-left-width: 6px;
+  }
+  .verdict .label {
+    font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
+    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+  }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
+  .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
+  .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
+  .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
+  .verdict.caution { background: var(--caution-bg); border-color: var(--caution-edge); color: var(--caution-ink); }
+  .verdict.block   { background: var(--block-bg);   border-color: var(--block-edge);   color: var(--block-ink); }
+
+  /* ---- sections ---- */
+  .qv-sec { margin: 0 0 30px; }
+  h2 {
+    font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-faint); margin: 0 0 14px;
+    padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+
+  /* ---- compact blocker list (one line per item) ---- */
+  ol.qv-blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
+  ol.qv-blockers > li {
+    counter-increment: blk; position: relative;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 11px; padding: 14px 18px 14px 56px; margin: 0 0 10px;
+  }
+  ol.qv-blockers > li::before {
+    content: counter(blk); position: absolute; left: 14px; top: 13px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--block-bg); color: var(--block-ink);
+    font-size: 14px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  }
+  ol.qv-blockers .b-title { font-weight: 600; }
+  ol.qv-blockers .b-sub { font-size: 15px; color: var(--ink-soft); margin-top: 2px; }
+
+  /* ---- dissent line ---- */
+  .qv-dissent {
+    background: #fbf3ec; border: 1px dashed var(--caution-edge);
+    border-radius: 12px; padding: 14px 20px; margin: 0 0 30px;
+  }
+  .qv-dflag {
+    display: inline-block; font-size: 11.5px; font-weight: 700;
+    letter-spacing: 0.07em; text-transform: uppercase; color: var(--caution-ink);
+    background: var(--caution-bg); border-radius: 999px; padding: 3px 10px; margin-bottom: 8px;
+  }
+  .qv-d { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
+  .qv-d .who { font-weight: 700; color: var(--caution-ink); }
+  .qv-more { color: var(--ink-faint, #6b665c); font-size: 0.92em; }
+
+  /* ---- next steps ---- */
+  .qv-actions {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 12px; padding: 14px 20px 14px 38px; margin: 0; font-size: 15.5px;
+  }
+  ol.qv-actions li { margin: 6px 0; }
+  .qv-more-li { color: var(--ink-faint, #6b665c); list-style: none; font-size: 0.92em; }
+
+  /* ---- dark footer / colophon band ---- */
+  footer.colophon { background: var(--dark); color: var(--on-dark-soft); padding: 26px 20px 32px; }
+  footer.colophon .disclaimer {
+    display: block; margin: 0 0 16px; font-style: italic;
+    color: var(--on-dark-faint); font-size: 13.5px;
+  }
+  .colophon-grid { display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-start; justify-content: space-between; }
+  .colophon-about { flex: 1 1 320px; }
+  .footer-lockup { display: flex; align-items: center; gap: 9px; font-weight: 700; color: var(--on-dark); font-size: 14px; margin-bottom: 9px; }
+  .footer-lockup svg { width: 26px; height: 26px; display: block; }
+  .colophon-about p { margin: 0; font-size: 13.5px; line-height: 1.6; color: var(--on-dark-soft); max-width: 54ch; }
+  .colophon-cta { flex: 0 0 auto; }
+  .cta {
+    display: inline-block; background: var(--accent); color: #ffffff;
+    font-weight: 600; font-size: 14.5px; text-decoration: none;
+    padding: 10px 20px; border-radius: 9px;
+  }
+  .cta::after { content: " →"; }
+  footer.colophon .prov { display: block; margin-top: 12px; font-size: 11.5px; color: var(--on-dark-faint); font-family: var(--font-mono); }
+
+  /* ---- responsive ---- */
+  @media (max-width: 560px) {
+    body { font-size: 16px; }
+    .wrap { padding: 22px 15px 44px; }
+    header.masthead, footer.colophon { padding-left: 15px; padding-right: 15px; }
+    header.masthead h1 { font-size: 25px; }
+    .verdict .headline { font-size: 20px; }
+    ol.qv-blockers > li { padding-left: 50px; padding-right: 16px; }
+    .colophon-cta { width: 100%; }
+  }
+
+  /* ---- print / PDF (Print -> Save as PDF) ---- */
+  @media print {
+    body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    header.masthead, footer.colophon { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .wrap { max-width: none; }
+    .verdict, ol.qv-blockers > li, .qv-dissent, .qv-actions { break-inside: avoid; }
+    a { color: inherit; text-decoration: none; }
+  }
+</style>
+</head>
+<body>
+
+  <!-- ===================== MASTHEAD (Panely / dark band) ===================== -->
+  <header class="masthead">
+    <div class="band-inner">
+      <div class="brand-lockup">
+        <span class="brand-mark"><svg viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg"><defs><radialGradient id="bg" cx="50%" cy="38%" r="74%"><stop offset="0%" stop-color="#122046"/><stop offset="55%" stop-color="#0a1024"/><stop offset="100%" stop-color="#05070f"/></radialGradient><radialGradient id="vig" cx="50%" cy="50%" r="62%"><stop offset="60%" stop-color="#000000" stop-opacity="0"/><stop offset="100%" stop-color="#000000" stop-opacity="0.5"/></radialGradient><linearGradient id="cobalt" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a9c2ff"/><stop offset="52%" stop-color="#5b8cff"/><stop offset="100%" stop-color="#2347ff"/></linearGradient><linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffe6a3"/><stop offset="55%" stop-color="#e2b658"/><stop offset="100%" stop-color="#b9842e"/></linearGradient><radialGradient id="core" cx="50%" cy="42%" r="62%"><stop offset="0%" stop-color="#ffffff"/><stop offset="34%" stop-color="#dbe6ff"/><stop offset="70%" stop-color="#6f93ff"/><stop offset="100%" stop-color="#2347ff"/></radialGradient><radialGradient id="spark" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#eaf1ff"/><stop offset="100%" stop-color="#5b8cff"/></radialGradient><filter id="gM" x="-180%" y="-180%" width="460%" height="460%"><feGaussianBlur stdDeviation="14"/></filter><filter id="gL" x="-220%" y="-220%" width="540%" height="540%"><feGaussianBlur stdDeviation="32"/></filter></defs><rect width="1000" height="1000" fill="#05070f"/><rect width="1000" height="1000" fill="url(#bg)"/><circle cx="500" cy="500" r="220" fill="#3a5fff" opacity="0.12" filter="url(#gL)"/><circle cx="500" cy="500" r="312" fill="none" stroke="url(#cobalt)" stroke-width="3" opacity="0.7"/><circle cx="500" cy="500" r="210" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.32"/><circle cx="500" cy="500" r="120" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.22"/><g stroke="#4f7bff" stroke-width="2"><line x1="830" y1="500" x2="850" y2="500" opacity="0.4"/><line x1="500" y1="830" x2="500" y2="850" opacity="0.4"/><line x1="170" y1="500" x2="150" y2="500" opacity="0.4"/><line x1="500" y1="170" x2="500" y2="150" opacity="0.4"/><line x1="733.3" y1="733.3" x2="743.2" y2="743.2" opacity="0.16"/><line x1="266.7" y1="733.3" x2="256.8" y2="743.2" opacity="0.16"/><line x1="266.7" y1="266.7" x2="256.8" y2="256.8" opacity="0.16"/><line x1="733.3" y1="266.7" x2="743.2" y2="256.8" opacity="0.16"/></g><line x1="500" y1="250" x2="500" y2="188" stroke="#f7b500" stroke-width="3" opacity="0.45"/><circle cx="500" cy="188" r="46" fill="#e2b658" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="188" r="34" fill="#0a1430" stroke="url(#gold)" stroke-width="5"/><circle cx="500" cy="188" r="15" fill="url(#gold)"/><circle cx="770.2" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="344" r="15" fill="url(#spark)"/><circle cx="770.2" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="656" r="15" fill="url(#spark)"/><circle cx="500" cy="812" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="812" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="500" cy="812" r="15" fill="url(#spark)"/><circle cx="229.8" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="656" r="15" fill="url(#spark)"/><circle cx="229.8" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="344" r="15" fill="url(#spark)"/><circle cx="500" cy="500" r="74" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.5"/><circle cx="500" cy="500" r="144" fill="#3a5fff" opacity="0.16" filter="url(#gL)"/><circle cx="500" cy="500" r="77" fill="url(#core)" opacity="0.5" filter="url(#gM)"/><circle cx="500" cy="500" r="48" fill="url(#core)" stroke="#ffffff" stroke-width="3"/><circle cx="500" cy="489" r="13" fill="#ffffff" opacity="0.92"/><rect width="1000" height="1000" fill="url(#vig)"/></svg></span>
+        <span class="brand-name"><span class="p">Advisory Board</span><span class="ab" style="text-transform:none; letter-spacing:0.03em; font-weight:600; margin-top:3px;">powered by Panely</span></span>
+      </div>
+      <h1>review packet</h1>
+      <p class="subtitle">An independent multi-model review.</p>
+      <div class="meta-row">
+        <span class="chip"><b>Date</b> 2026-06-25</span>
+        <span class="chip"><b>Rounds</b> 3</span>
+        <span class="chip"><b>Board</b> Claude · Codex · Gemini</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+
+  <!-- ===================== VERDICT BANNER ===================== -->
+  
+  <div class="verdict caution">
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
+    <p class="headline">SHIP WITH CHANGES — unanimous</p>
+    <p class="note"></p>
+  </div>
+
+  <!-- ===================== MUST-RESOLVE (one line each) ===================== -->
+  <section class="qv-sec qv-blockers-sec">
+    <h2>Consensus blockers — must fix before ship</h2>
+    <ol class="qv-blockers">
+      
+      <li>
+        <span class="b-title">Wall-clock source on the refill hot path</span>
+        <div class="b-sub">All three seats agree the use of time.time() on the refill path is a correctness bug under the stated operating context: a backward clock step makes elapsed negative, so…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">allow(n) accepts invalid request costs</span>
+        <div class="b-sub">All three seats flag that allow(n) performs no validation on n. A negative n (e.g. allow(-5)) executes self._tokens -= n, which mints tokens and returns True — a caller can refill…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Per-process / deployment enforcement semantics unresolved</span>
+        <div class="b-sub">Claude and Codex flag that one bucket per worker process means the globally enforced rate is roughly rate × worker_count, so advertised limit ≠ enforced limit. Claude treats this…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Tests are timing-dependent and prove none of the failure modes</span>
+        <div class="b-sub">Claude and Codex find the tests use time.sleep() and real wall-clock, making them flaky on loaded CI. No test injects a clock, exercises a backward clock jump, asserts the 0 ≤…</div>
+      </li>
+      
+    </ol>
+  </section>
+
+  <!-- ===================== DISSENT (one line) ===================== -->
+  <div class="qv-dissent">
+    <span class="qv-dflag">Dissent on the record</span>
+    
+    <p class="qv-d"><span class="who">Claude</span> — Dissents from Gemini on two named points: (1) &#x27;migrate to an API Gateway / centralized store instead&#x27; is a recommendation to build a different system, not a defect in the artifact… <span class="qv-more">(+2 more in the full handoff)</span></p>
+    
+  </div>
+
+  <!-- ===================== NEXT STEPS ===================== -->
+  <section class="qv-sec qv-actions-sec">
+    <h2>Next steps</h2>
+    <ol class="qv-actions">
+      
+      <li>Replace time.time() with an injectable clock defaulting to time.monotonic() in __init__ and allow().</li>
+      
+      <li>Clamp elapsed = max(0.0, now - self._last) so refill math never goes negative; never move _last backward.</li>
+      
+      <li>Validate n in allow(): require finite, positive values and define behavior for n &gt; capacity.</li>
+      
+      <li class="qv-more-li">…5 more in the full handoff</li>
+    </ol>
+  </section>
+
+  </main>
+
+  <!-- ===================== FOOTER / COLOPHON (Panely / dark band) ===================== -->
+  
+  <footer class="colophon">
+    <div class="band-inner">
+      <div class="colophon-grid">
+        <div class="colophon-about">
+          <div class="footer-lockup">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="22" fill="#0a0e1a"/><circle cx="50" cy="50" r="30" fill="none" stroke="#3a5fd9" stroke-width="3" opacity="0.55"/><circle cx="50" cy="20" r="10" fill="#0a0e1a" stroke="#e2b658" stroke-width="4"/><circle cx="50" cy="20" r="4" fill="#e2b658"/><circle cx="76" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="76" cy="65" r="4" fill="#3d6bff"/><circle cx="24" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="24" cy="65" r="4" fill="#3d6bff"/><circle cx="50" cy="50" r="13" fill="#5b8cff"/><circle cx="50" cy="50" r="5.5" fill="#ffffff"/></svg>
+            <span>Advisory Board <span style="font-weight:400; color:var(--on-dark-soft); font-size:11.5px; letter-spacing:0.02em;">powered by Panely</span></span>
+          </div>
+          <p>Convene Claude, Codex, and Gemini on your own subscriptions — the ones you already pay for, no new accounts and no API keys — to review the same material and reach one clear verdict.</p>
+        </div>
+        <div class="colophon-cta">
+          <a class="cta" href="https://panely.ai">panely.ai</a>
+        </div>
+      </div>
+      <span class="prov">Board: Claude · Codex · Gemini · 3 rounds · 2026-06-25</span>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/examples/side-project-go-full-time-review/final-consensus.html
+++ b/examples/side-project-go-full-time-review/final-consensus.html
@@ -81,6 +81,11 @@
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
     font-weight: 700; margin: 0 0 6px; opacity: 0.85;
   }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
   .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
@@ -286,7 +291,7 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict caution">
-    <p class="label">Final verdict</p>
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
     <p class="headline">Go ahead, with conditions · unanimous</p>
     <p class="note">Workable, but address the flagged concerns before you go ahead.</p>
   </div>

--- a/examples/side-project-go-full-time-review/handoff-data.json
+++ b/examples/side-project-go-full-time-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "Go ahead, with conditions · unanimous",
   "verdict_class": "caution",
   "verdict_note": "Workable, but address the flagged concerns before you go ahead.",
+  "confidence": "high confidence",
   "blockers_heading": "What to resolve first",
   "disclaimer": "An advisory board sharpens your judgment; it doesn&#x27;t replace professional advice where your decision warrants it.",
   "plan": "Should I go full-time on my side project?",
@@ -89,37 +90,45 @@
   "blockers": [
     {
       "blocker_title": "Income case never closes: $12k MRR ≠ replacing a $165k salary",
-      "blocker_body": "All three seats converged in the final round that the financial model is a gating item, not background. Claude quantified that $12k MRR = ~$144k/yr gross revenue, and once payment fees, self-employment tax, lost 401k match, forgone equity, and especially self-paid family health insurance are stripped out, net personal economic value at the target is ~$100–110k versus ~$200k+ current total comp — a trade down to ~50% even if the plan fully succeeds. Codex now treats the same point as a gating item; Gemini conceded the health-insurance omission is catastrophic and pegs the true savings draw closer to ~$4,800/mo, roughly halving runway."
+      "blocker_body": "All three seats converged in the final round that the financial model is a gating item, not background. Claude quantified that $12k MRR = ~$144k/yr gross revenue, and once payment fees, self-employment tax, lost 401k match, forgone equity, and especially self-paid family health insurance are stripped out, net personal economic value at the target is ~$100–110k versus ~$200k+ current total comp — a trade down to ~50% even if the plan fully succeeds. Codex now treats the same point as a gating item; Gemini conceded the health-insurance omission is catastrophic and pegs the true savings draw closer to ~$4,800/mo, roughly halving runway.",
+      "blocker_summary": "All three seats converged in the final round that the financial model is a gating item, not background. Claude quantified that $12k MRR = ~$144k/yr gross revenue, and once payment…"
     },
     {
       "blocker_title": "Growth math is flawed: 8% MoM does not reach the $12k target",
-      "blocker_body": "The board found the founder is projecting unjustified acceleration. At the observed 8% MoM net rate, $4,200 reaches only ~$8,395 at month 9 and ~$10,577 at month 12. Hitting $12k by month 9 requires ~12.3% MoM (+54% faster) on a 2–3× larger base, after the non-repeating Reddit/Indie Hackers spikes are spent. Gemini and Codex both explicitly conceded this math in round 2."
+      "blocker_body": "The board found the founder is projecting unjustified acceleration. At the observed 8% MoM net rate, $4,200 reaches only ~$8,395 at month 9 and ~$10,577 at month 12. Hitting $12k by month 9 requires ~12.3% MoM (+54% faster) on a 2–3× larger base, after the non-repeating Reddit/Indie Hackers spikes are spent. Gemini and Codex both explicitly conceded this math in round 2.",
+      "blocker_summary": "The board found the founder is projecting unjustified acceleration. At the observed 8% MoM net rate, $4,200 reaches only ~$8,395 at month 9 and ~$10,577 at month 12. Hitting $12k…"
     },
     {
       "blocker_title": "Quit is triggered by the vesting date, not by evidence",
-      "blocker_body": "Claude and Codex both held that the vesting date is financially attractive but logically irrelevant to business readiness. The recommendation: take the vest regardless, but make quitting conditional on 3-month gates passing — not on the calendar. Claude called decoupling the trigger from the vest the single most important fix."
+      "blocker_body": "Claude and Codex both held that the vesting date is financially attractive but logically irrelevant to business readiness. The recommendation: take the vest regardless, but make quitting conditional on 3-month gates passing — not on the calendar. Claude called decoupling the trigger from the vest the single most important fix.",
+      "blocker_summary": "Claude and Codex both held that the vesting date is financially attractive but logically irrelevant to business readiness. The recommendation: take the vest regardless, but make…"
     },
     {
       "blocker_title": "Plan spends the scarcest resource (founder hours) on the non-bottleneck",
-      "blocker_body": "Claude, Codex, and Gemini agreed the plan is product-build heavy (Team plan, integrations marketplace, paid acquisition — three major tracks for a solo founder) when the binding constraint is distribution and economics, not engineering output. Claude framed the marginal return on 25 extra coding hours/week as near-zero if growth is distribution-bound; Codex and Gemini flagged the same stale &#x27;time = revenue&#x27; assumption."
+      "blocker_body": "Claude, Codex, and Gemini agreed the plan is product-build heavy (Team plan, integrations marketplace, paid acquisition — three major tracks for a solo founder) when the binding constraint is distribution and economics, not engineering output. Claude framed the marginal return on 25 extra coding hours/week as near-zero if growth is distribution-bound; Codex and Gemini flagged the same stale &#x27;time = revenue&#x27; assumption.",
+      "blocker_summary": "Claude, Codex, and Gemini agreed the plan is product-build heavy (Team plan, integrations marketplace, paid acquisition — three major tracks for a solo founder) when the binding…"
     },
     {
       "blocker_title": "5% churn at $15 ARPA makes paid acquisition structurally hard",
-      "blocker_body": "At a $15/mo plan, 5% monthly churn implies a ~20-month lifetime and ~$300 gross LTV, leaving little room for CAC. Codex and Claude set a CAC ceiling around $80–100; the board agreed retention/ARPA must improve before scaling spend. Gemini went further (see dissent), arguing no ad channel will deliver sub-$50 CAC for an inexperienced solo founder."
+      "blocker_body": "At a $15/mo plan, 5% monthly churn implies a ~20-month lifetime and ~$300 gross LTV, leaving little room for CAC. Codex and Claude set a CAC ceiling around $80–100; the board agreed retention/ARPA must improve before scaling spend. Gemini went further (see dissent), arguing no ad channel will deliver sub-$50 CAC for an inexperienced solo founder.",
+      "blocker_summary": "At a $15/mo plan, 5% monthly churn implies a ~20-month lifetime and ~$300 gross LTV, leaving little room for CAC. Codex and Claude set a CAC ceiling around $80–100; the board…"
     }
   ],
   "dissents": [
     {
       "dissent_who": "Gemini",
-      "dissent_body": "Dissents from Claude&#x27;s proposal to GATE paid acquisition on proven CAC payback: as the downside seat, Gemini argues paid acquisition should be completely BLOCKED, not gated. A $300 LTV with 5% churn means no realistic channel delivers sub-$50 CAC for an inexperienced solo founder, so any attempt simply incinerates the household safety net."
+      "dissent_body": "Dissents from Claude&#x27;s proposal to GATE paid acquisition on proven CAC payback: as the downside seat, Gemini argues paid acquisition should be completely BLOCKED, not gated. A $300 LTV with 5% churn means no realistic channel delivers sub-$50 CAC for an inexperienced solo founder, so any attempt simply incinerates the household safety net.",
+      "dissent_summary": "Dissents from Claude's proposal to GATE paid acquisition on proven CAC payback: as the downside seat, Gemini argues paid acquisition should be completely BLOCKED, not gated. A…"
     },
     {
       "dissent_who": "Claude",
-      "dissent_body": "Dissents from Gemini calling 5% monthly churn &#x27;toxic&#x27;: Claude holds it is mediocre-but-normal for freelancer SaaS (20-month lifetime), a ceiling on LTV rather than a disqualifier, and notes the 8% growth figure is already net of that churn."
+      "dissent_body": "Dissents from Gemini calling 5% monthly churn &#x27;toxic&#x27;: Claude holds it is mediocre-but-normal for freelancer SaaS (20-month lifetime), a ceiling on LTV rather than a disqualifier, and notes the 8% growth figure is already net of that churn.",
+      "dissent_summary": "Dissents from Gemini calling 5% monthly churn 'toxic': Claude holds it is mediocre-but-normal for freelancer SaaS (20-month lifetime), a ceiling on LTV rather than a disqualifier,…"
     },
     {
       "dissent_who": "Codex",
-      "dissent_body": "Dissents from Gemini&#x27;s &#x27;do not write a line of code&#x27;: Codex agrees not to speculatively build the Team plan or marketplace, but holds that small code work for pricing tests, instrumentation, onboarding, retention, and a manually sold Pro/Team stub is justified."
+      "dissent_body": "Dissents from Gemini&#x27;s &#x27;do not write a line of code&#x27;: Codex agrees not to speculatively build the Team plan or marketplace, but holds that small code work for pricing tests, instrumentation, onboarding, retention, and a manually sold Pro/Team stub is justified.",
+      "dissent_summary": "Dissents from Gemini's 'do not write a line of code': Codex agrees not to speculatively build the Team plan or marketplace, but holds that small code work for pricing tests,…"
     }
   ],
   "caveats": [
@@ -169,5 +178,24 @@
     {
       "action": "Establish a dual re-entry trigger (savings floor OR month-12 MRR &lt; $8k, whichever first) and a written partner agreement on runway and floor."
     }
-  ]
+  ],
+  "dissents_brief": [
+    {
+      "dissent_who": "Gemini",
+      "dissent_summary": "Dissents from Claude's proposal to GATE paid acquisition on proven CAC payback: as the downside seat, Gemini argues paid acquisition should be completely BLOCKED, not gated. A…",
+      "dissent_more": "(+2 more in the full handoff)"
+    }
+  ],
+  "actions_brief": [
+    {
+      "action": "Re-cost true burn: get an actual marketplace/COBRA family quote plus SE-tax delta, retirement/401k loss, and business costs; expect ~$8,000–8,500/mo, and agree a written non-spendable savings floor with the partner."
+    },
+    {
+      "action": "Pre-sell ARPA instead of building it: secure paid commitments/LOIs from existing customers for a higher tier ($49–99 Team) before writing the Team plan or marketplace."
+    },
+    {
+      "action": "Run a small capped paid-acquisition probe ($1–2k) on 1–2 channels to measure real CAC; continue only if payback is under ~6 months on gross margin."
+    }
+  ],
+  "actions_more": "…3 more in the full handoff"
 }

--- a/examples/side-project-go-full-time-review/quick-verdict.html
+++ b/examples/side-project-go-full-time-review/quick-verdict.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Should I go full-time on my side project?</title>
+<style>
+  :root {
+    --maxw: 820px;
+    /* light "Boardroom" body */
+    --page: #faf8f3;
+    --surface: #ffffff;
+    --surface-soft: #faf7f0;
+    --vellum: #f3eee3;
+    --ink: #11192b;
+    --ink-soft: #3a4459;
+    --ink-faint: #6e768a;
+    --line: #e4ddce;
+    --line-strong: #d8cfb8;
+    /* brand accents (both themes) */
+    --accent: #2347ff;          /* cobalt — signature */
+    --accent-deep: #0f2bc2;
+    --accent-tint: #eaedff;
+    --gold: #a8843c;            /* secondary — the lead seat */
+    /* dark "Signal" bands */
+    --dark: #0a0e1a;
+    --dark-2: #111726;
+    --dark-line: #232b3e;
+    --on-dark: #fbfaf7;
+    --on-dark-soft: #b9c0d0;
+    --on-dark-faint: #8a93a8;
+    --accent-bright: #5b8cff;
+    --gold-bright: #e2b658;
+    /* verdict palettes (muted — counsel, not error toasts) */
+    --ship-bg: #e9f1ec;     --ship-edge: #2f6f57;   --ship-ink: #235540;
+    --caution-bg: #fbf1de;  --caution-edge: #b07a1e; --caution-ink: #7a5410;
+    --block-bg: #f7e9e9;    --block-edge: #9e3636;  --block-ink: #7a2525;
+    --font-sans: "Panely Grotesk","Söhne","Inter","Helvetica Neue",Helvetica,Arial,"Segoe UI",system-ui,sans-serif;
+    --font-mono: "Berkeley Mono","JetBrains Mono",ui-monospace,"Menlo","Consolas",monospace;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 17px;
+    line-height: 1.65;
+  }
+
+  /* ---- dark masthead band ---- */
+  header.masthead { background: var(--dark); color: var(--on-dark); padding: 30px 20px 28px; }
+  .band-inner { max-width: var(--maxw); margin: 0 auto; }
+  .brand-lockup { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+  .brand-mark { width: 46px; height: 46px; border-radius: 11px; overflow: hidden; flex: 0 0 auto; }
+  .brand-mark svg { display: block; width: 100%; height: 100%; }
+  .brand-name { display: flex; flex-direction: column; line-height: 1.1; }
+  .brand-name .p { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--on-dark); }
+  .brand-name .ab { font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-bright); margin-top: 4px; }
+  header.masthead h1 { font-size: 29px; line-height: 1.18; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; color: var(--on-dark); }
+  .subtitle { font-size: 16px; color: var(--on-dark-soft); margin: 0 0 18px; max-width: 60ch; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(255,255,255,0.05); border: 1px solid var(--dark-line);
+    border-radius: 999px; padding: 5px 13px; font-size: 13px; color: var(--on-dark-soft);
+  }
+  .chip b { font-weight: 600; color: var(--on-dark); }
+
+  /* ---- body column ---- */
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 30px 20px 56px; }
+
+  /* ---- verdict banner ---- */
+  .verdict {
+    border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
+    border: 1px solid transparent; border-left-width: 6px;
+  }
+  .verdict .label {
+    font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
+    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+  }
+  .verdict .conf-badge {
+    display: inline-block; margin-left: 9px; font-size: 10.5px; letter-spacing: 0.05em;
+    font-weight: 700; padding: 1px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.07); vertical-align: 1.5px;
+  }
+  .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
+  .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
+  .verdict.ship    { background: var(--ship-bg);    border-color: var(--ship-edge);    color: var(--ship-ink); }
+  .verdict.caution { background: var(--caution-bg); border-color: var(--caution-edge); color: var(--caution-ink); }
+  .verdict.block   { background: var(--block-bg);   border-color: var(--block-edge);   color: var(--block-ink); }
+
+  /* ---- sections ---- */
+  .qv-sec { margin: 0 0 30px; }
+  h2 {
+    font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-faint); margin: 0 0 14px;
+    padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+
+  /* ---- compact blocker list (one line per item) ---- */
+  ol.qv-blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
+  ol.qv-blockers > li {
+    counter-increment: blk; position: relative;
+    background: var(--surface); border: 1px solid var(--line-strong);
+    border-radius: 11px; padding: 14px 18px 14px 56px; margin: 0 0 10px;
+  }
+  ol.qv-blockers > li::before {
+    content: counter(blk); position: absolute; left: 14px; top: 13px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--block-bg); color: var(--block-ink);
+    font-size: 14px; font-weight: 700; display: flex; align-items: center; justify-content: center;
+  }
+  ol.qv-blockers .b-title { font-weight: 600; }
+  ol.qv-blockers .b-sub { font-size: 15px; color: var(--ink-soft); margin-top: 2px; }
+
+  /* ---- dissent line ---- */
+  .qv-dissent {
+    background: #fbf3ec; border: 1px dashed var(--caution-edge);
+    border-radius: 12px; padding: 14px 20px; margin: 0 0 30px;
+  }
+  .qv-dflag {
+    display: inline-block; font-size: 11.5px; font-weight: 700;
+    letter-spacing: 0.07em; text-transform: uppercase; color: var(--caution-ink);
+    background: var(--caution-bg); border-radius: 999px; padding: 3px 10px; margin-bottom: 8px;
+  }
+  .qv-d { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
+  .qv-d .who { font-weight: 700; color: var(--caution-ink); }
+  .qv-more { color: var(--ink-faint, #6b665c); font-size: 0.92em; }
+
+  /* ---- next steps ---- */
+  .qv-actions {
+    background: var(--surface-soft); border: 1px solid var(--line);
+    border-radius: 12px; padding: 14px 20px 14px 38px; margin: 0; font-size: 15.5px;
+  }
+  ol.qv-actions li { margin: 6px 0; }
+  .qv-more-li { color: var(--ink-faint, #6b665c); list-style: none; font-size: 0.92em; }
+
+  /* ---- dark footer / colophon band ---- */
+  footer.colophon { background: var(--dark); color: var(--on-dark-soft); padding: 26px 20px 32px; }
+  footer.colophon .disclaimer {
+    display: block; margin: 0 0 16px; font-style: italic;
+    color: var(--on-dark-faint); font-size: 13.5px;
+  }
+  .colophon-grid { display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-start; justify-content: space-between; }
+  .colophon-about { flex: 1 1 320px; }
+  .footer-lockup { display: flex; align-items: center; gap: 9px; font-weight: 700; color: var(--on-dark); font-size: 14px; margin-bottom: 9px; }
+  .footer-lockup svg { width: 26px; height: 26px; display: block; }
+  .colophon-about p { margin: 0; font-size: 13.5px; line-height: 1.6; color: var(--on-dark-soft); max-width: 54ch; }
+  .colophon-cta { flex: 0 0 auto; }
+  .cta {
+    display: inline-block; background: var(--accent); color: #ffffff;
+    font-weight: 600; font-size: 14.5px; text-decoration: none;
+    padding: 10px 20px; border-radius: 9px;
+  }
+  .cta::after { content: " →"; }
+  footer.colophon .prov { display: block; margin-top: 12px; font-size: 11.5px; color: var(--on-dark-faint); font-family: var(--font-mono); }
+
+  /* ---- responsive ---- */
+  @media (max-width: 560px) {
+    body { font-size: 16px; }
+    .wrap { padding: 22px 15px 44px; }
+    header.masthead, footer.colophon { padding-left: 15px; padding-right: 15px; }
+    header.masthead h1 { font-size: 25px; }
+    .verdict .headline { font-size: 20px; }
+    ol.qv-blockers > li { padding-left: 50px; padding-right: 16px; }
+    .colophon-cta { width: 100%; }
+  }
+
+  /* ---- print / PDF (Print -> Save as PDF) ---- */
+  @media print {
+    body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    header.masthead, footer.colophon { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .wrap { max-width: none; }
+    .verdict, ol.qv-blockers > li, .qv-dissent, .qv-actions { break-inside: avoid; }
+    a { color: inherit; text-decoration: none; }
+  }
+</style>
+</head>
+<body>
+
+  <!-- ===================== MASTHEAD (Panely / dark band) ===================== -->
+  <header class="masthead">
+    <div class="band-inner">
+      <div class="brand-lockup">
+        <span class="brand-mark"><svg viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg"><defs><radialGradient id="bg" cx="50%" cy="38%" r="74%"><stop offset="0%" stop-color="#122046"/><stop offset="55%" stop-color="#0a1024"/><stop offset="100%" stop-color="#05070f"/></radialGradient><radialGradient id="vig" cx="50%" cy="50%" r="62%"><stop offset="60%" stop-color="#000000" stop-opacity="0"/><stop offset="100%" stop-color="#000000" stop-opacity="0.5"/></radialGradient><linearGradient id="cobalt" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#a9c2ff"/><stop offset="52%" stop-color="#5b8cff"/><stop offset="100%" stop-color="#2347ff"/></linearGradient><linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#ffe6a3"/><stop offset="55%" stop-color="#e2b658"/><stop offset="100%" stop-color="#b9842e"/></linearGradient><radialGradient id="core" cx="50%" cy="42%" r="62%"><stop offset="0%" stop-color="#ffffff"/><stop offset="34%" stop-color="#dbe6ff"/><stop offset="70%" stop-color="#6f93ff"/><stop offset="100%" stop-color="#2347ff"/></radialGradient><radialGradient id="spark" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#eaf1ff"/><stop offset="100%" stop-color="#5b8cff"/></radialGradient><filter id="gM" x="-180%" y="-180%" width="460%" height="460%"><feGaussianBlur stdDeviation="14"/></filter><filter id="gL" x="-220%" y="-220%" width="540%" height="540%"><feGaussianBlur stdDeviation="32"/></filter></defs><rect width="1000" height="1000" fill="#05070f"/><rect width="1000" height="1000" fill="url(#bg)"/><circle cx="500" cy="500" r="220" fill="#3a5fff" opacity="0.12" filter="url(#gL)"/><circle cx="500" cy="500" r="312" fill="none" stroke="url(#cobalt)" stroke-width="3" opacity="0.7"/><circle cx="500" cy="500" r="210" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.32"/><circle cx="500" cy="500" r="120" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.22"/><g stroke="#4f7bff" stroke-width="2"><line x1="830" y1="500" x2="850" y2="500" opacity="0.4"/><line x1="500" y1="830" x2="500" y2="850" opacity="0.4"/><line x1="170" y1="500" x2="150" y2="500" opacity="0.4"/><line x1="500" y1="170" x2="500" y2="150" opacity="0.4"/><line x1="733.3" y1="733.3" x2="743.2" y2="743.2" opacity="0.16"/><line x1="266.7" y1="733.3" x2="256.8" y2="743.2" opacity="0.16"/><line x1="266.7" y1="266.7" x2="256.8" y2="256.8" opacity="0.16"/><line x1="733.3" y1="266.7" x2="743.2" y2="256.8" opacity="0.16"/></g><line x1="500" y1="250" x2="500" y2="188" stroke="#f7b500" stroke-width="3" opacity="0.45"/><circle cx="500" cy="188" r="46" fill="#e2b658" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="188" r="34" fill="#0a1430" stroke="url(#gold)" stroke-width="5"/><circle cx="500" cy="188" r="15" fill="url(#gold)"/><circle cx="770.2" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="344" r="15" fill="url(#spark)"/><circle cx="770.2" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="770.2" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="770.2" cy="656" r="15" fill="url(#spark)"/><circle cx="500" cy="812" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="500" cy="812" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="500" cy="812" r="15" fill="url(#spark)"/><circle cx="229.8" cy="656" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="656" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="656" r="15" fill="url(#spark)"/><circle cx="229.8" cy="344" r="46" fill="#2f54e6" opacity="0.30" filter="url(#gM)"/><circle cx="229.8" cy="344" r="34" fill="#0a1430" stroke="url(#cobalt)" stroke-width="5"/><circle cx="229.8" cy="344" r="15" fill="url(#spark)"/><circle cx="500" cy="500" r="74" fill="none" stroke="#4f7bff" stroke-width="2" opacity="0.5"/><circle cx="500" cy="500" r="144" fill="#3a5fff" opacity="0.16" filter="url(#gL)"/><circle cx="500" cy="500" r="77" fill="url(#core)" opacity="0.5" filter="url(#gM)"/><circle cx="500" cy="500" r="48" fill="url(#core)" stroke="#ffffff" stroke-width="3"/><circle cx="500" cy="489" r="13" fill="#ffffff" opacity="0.92"/><rect width="1000" height="1000" fill="url(#vig)"/></svg></span>
+        <span class="brand-name"><span class="p">Advisory Board</span><span class="ab" style="text-transform:none; letter-spacing:0.03em; font-weight:600; margin-top:3px;">powered by Panely</span></span>
+      </div>
+      <h1>Should I go full-time on my side project?</h1>
+      <p class="subtitle">An independent multi-model review.</p>
+      <div class="meta-row">
+        <span class="chip"><b>Date</b> 2026-06-26</span>
+        <span class="chip"><b>Rounds</b> 2</span>
+        <span class="chip"><b>Board</b> Claude · Codex · Gemini</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+
+  <!-- ===================== VERDICT BANNER ===================== -->
+  
+  <div class="verdict caution">
+    <p class="label">Final verdict<span class="conf-badge">high confidence</span></p>
+    <p class="headline">Go ahead, with conditions · unanimous</p>
+    <p class="note">Workable, but address the flagged concerns before you go ahead.</p>
+  </div>
+
+  <!-- ===================== MUST-RESOLVE (one line each) ===================== -->
+  <section class="qv-sec qv-blockers-sec">
+    <h2>What to resolve first</h2>
+    <ol class="qv-blockers">
+      
+      <li>
+        <span class="b-title">Income case never closes: $12k MRR ≠ replacing a $165k salary</span>
+        <div class="b-sub">All three seats converged in the final round that the financial model is a gating item, not background. Claude quantified that $12k MRR = ~$144k/yr gross revenue, and once payment…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Growth math is flawed: 8% MoM does not reach the $12k target</span>
+        <div class="b-sub">The board found the founder is projecting unjustified acceleration. At the observed 8% MoM net rate, $4,200 reaches only ~$8,395 at month 9 and ~$10,577 at month 12. Hitting $12k…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Quit is triggered by the vesting date, not by evidence</span>
+        <div class="b-sub">Claude and Codex both held that the vesting date is financially attractive but logically irrelevant to business readiness. The recommendation: take the vest regardless, but make…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">Plan spends the scarcest resource (founder hours) on the non-bottleneck</span>
+        <div class="b-sub">Claude, Codex, and Gemini agreed the plan is product-build heavy (Team plan, integrations marketplace, paid acquisition — three major tracks for a solo founder) when the binding…</div>
+      </li>
+      
+      <li>
+        <span class="b-title">5% churn at $15 ARPA makes paid acquisition structurally hard</span>
+        <div class="b-sub">At a $15/mo plan, 5% monthly churn implies a ~20-month lifetime and ~$300 gross LTV, leaving little room for CAC. Codex and Claude set a CAC ceiling around $80–100; the board…</div>
+      </li>
+      
+    </ol>
+  </section>
+
+  <!-- ===================== DISSENT (one line) ===================== -->
+  <div class="qv-dissent">
+    <span class="qv-dflag">Dissent on the record</span>
+    
+    <p class="qv-d"><span class="who">Gemini</span> — Dissents from Claude&#x27;s proposal to GATE paid acquisition on proven CAC payback: as the downside seat, Gemini argues paid acquisition should be completely BLOCKED, not gated. A… <span class="qv-more">(+2 more in the full handoff)</span></p>
+    
+  </div>
+
+  <!-- ===================== NEXT STEPS ===================== -->
+  <section class="qv-sec qv-actions-sec">
+    <h2>Next steps</h2>
+    <ol class="qv-actions">
+      
+      <li>Re-cost true burn: get an actual marketplace/COBRA family quote plus SE-tax delta, retirement/401k loss, and business costs; expect ~$8,000–8,500/mo, and agree a written non-spendable savings floor with the partner.</li>
+      
+      <li>Pre-sell ARPA instead of building it: secure paid commitments/LOIs from existing customers for a higher tier ($49–99 Team) before writing the Team plan or marketplace.</li>
+      
+      <li>Run a small capped paid-acquisition probe ($1–2k) on 1–2 channels to measure real CAC; continue only if payback is under ~6 months on gross margin.</li>
+      
+      <li class="qv-more-li">…3 more in the full handoff</li>
+    </ol>
+  </section>
+
+  </main>
+
+  <!-- ===================== FOOTER / COLOPHON (Panely / dark band) ===================== -->
+  
+  <footer class="colophon">
+    <div class="band-inner">
+      <span class="disclaimer">An advisory board sharpens your judgment; it doesn&#x27;t replace professional advice where your decision warrants it.</span>
+      <div class="colophon-grid">
+        <div class="colophon-about">
+          <div class="footer-lockup">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="22" fill="#0a0e1a"/><circle cx="50" cy="50" r="30" fill="none" stroke="#3a5fd9" stroke-width="3" opacity="0.55"/><circle cx="50" cy="20" r="10" fill="#0a0e1a" stroke="#e2b658" stroke-width="4"/><circle cx="50" cy="20" r="4" fill="#e2b658"/><circle cx="76" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="76" cy="65" r="4" fill="#3d6bff"/><circle cx="24" cy="65" r="10" fill="#0a0e1a" stroke="#3d6bff" stroke-width="4"/><circle cx="24" cy="65" r="4" fill="#3d6bff"/><circle cx="50" cy="50" r="13" fill="#5b8cff"/><circle cx="50" cy="50" r="5.5" fill="#ffffff"/></svg>
+            <span>Advisory Board <span style="font-weight:400; color:var(--on-dark-soft); font-size:11.5px; letter-spacing:0.02em;">powered by Panely</span></span>
+          </div>
+          <p>Convene Claude, Codex, and Gemini on your own subscriptions — the ones you already pay for, no new accounts and no API keys — to review the same material and reach one clear verdict.</p>
+        </div>
+        <div class="colophon-cta">
+          <a class="cta" href="https://panely.ai">panely.ai</a>
+        </div>
+      </div>
+      <span class="prov">Board: Claude · Codex · Gemini · 2 rounds · 2026-06-26</span>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/skills/advisory-board/references/quick-verdict-template.html
+++ b/skills/advisory-board/references/quick-verdict-template.html
@@ -1,63 +1,55 @@
 <!DOCTYPE html>
 <!--
   ============================================================================
-  PANELY ADVISORY BOARD — HANDOFF TEMPLATE
+  PANELY ADVISORY BOARD — QUICK-VERDICT (SKIM-BRIEF) TEMPLATE
   ============================================================================
-  A SELF-CONTAINED HTML template for rendering a finished multi-model advisory
-  board review into a clean, human-readable, Panely-branded handoff page.
+  A SELF-CONTAINED, one-screen HTML brief: the verdict, the must-resolve items
+  as one-liners, a one-line dissent flag, and the next steps. The full handoff
+  (handoff-template.html) keeps the round-by-round board reviews, the couldn't-
+  verify bucket, and the open questions; this is the skim view of the same data.
 
-  Brand: a light, readable body (the "Boardroom" light theme) bookended by dark
-  ("Signal") masthead and footer bands carrying the Panely Advisory Board mark,
-  lockup, the subscriptions line, and the panely.ai call-to-action. Brand kit:
-  ~/Desktop/panely-brand-kit (cobalt #2347FF signature accent, gold #E2B658
-  secondary / lead seat; muted verdict colors).
+  Brand: identical to the full handoff — a light, readable body ("Boardroom")
+  bookended by dark ("Signal") masthead and footer bands carrying the Panely
+  Advisory Board mark, lockup, the subscriptions line, and the panely.ai CTA.
 
   OUTPUT CONTRACT (read first)
   ----------------------------
   The file you produce MUST:
     - contain ZERO "{{...}}" placeholders and ZERO authoring comments (the
-      BEGIN/END and OPTIONAL notes below) — strip every one. The "====="
-      section dividers may stay.
-    - be a faithful VIEW of final-consensus.md — the Markdown handoff is the
-      source of truth; the HTML must not contradict it.
+      BEGIN/END notes below) — strip every one. The "=====" dividers may stay.
+    - be a faithful, condensed VIEW of final-consensus.md / the full handoff —
+      it must not contradict them; it only carries less.
     - stay fully self-contained: inline CSS + inline SVG only, no external
       fonts, CDNs, JS, <link>, or <script src>. It MUST render offline.
-    - HTML-escape every injected string ( & -> &amp;  < -> &lt;  > -> &gt; );
-      wrap inline code in <code>...</code>.
+    - HTML-escape every injected string ( & -> &amp;  < -> &lt;  > -> &gt; ).
 
-  TWO KINDS OF PLACEHOLDER
-  ------------------------
-  1. SINGLE TOKEN  — "{{TOKEN}}" appearing once. Replace it in place with text.
-  2. REPEATABLE BLOCK — markup between "BEGIN X" / "END X" comments. Duplicate
-     the whole block once per item and fill its tokens. If there are zero
-     items, delete the sample block (don't leave an empty shell).
-
-  Repeatable blocks here: SEAT CARD (per seat) > ROUND (per round, nested in a
-  seat) ; BLOCKER (per consensus blocker) ; DISSENT (per dissenting point) ;
-  CAVEAT (per couldn't-verify item) ; QUESTION (per open question) ;
-  ACTION (per next action).
+  REPEATABLE BLOCKS (duplicate per item; delete the sample if zero):
+    BLOCKER (per consensus must-resolve item) ; DISSENT BRIEF (the FIRST dissenter only —
+    the brief trims; the full handoff carries them all) ; ACTION BRIEF (the TOP 3 next
+    steps only — the brief caps; the full handoff carries them all).
 
   SINGLE TOKENS
   -------------
-  {{TITLE}}          Page + banner title (what the board was asked).
-  {{SUBTITLE}}       One-line description of what was reviewed.
-  {{DATE}}           Review date, e.g. "2026-06-24".
-  {{BOARD}}          Board roster: models + lenses (HTML allowed).
-  {{ROUNDS}}         Number of rounds, e.g. "2".
-  {{VERDICT}}        Final verdict headline. Software: "<label> — <stance>" (e.g.
-                     "DO NOT SHIP YET — unanimous"). Other lenses lead with a plain
-                     should-I/shouldn't-I directive (e.g. "Go ahead, with conditions ·
-                     unanimous"), or the board's authored decision verbatim.
-  {{VERDICT_CLASS}}  One of: ship | caution | block  (colors the banner).
-  {{CONFIDENCE}}     OPTIONAL banner pill, e.g. "high confidence". Empty -> pill dropped.
-  {{VERDICT_NOTE}}   One-line explanation under the verdict headline.
-  {{BLOCKERS_HEADING}}  Consensus-section header, lens-aware: "Consensus blockers —
-                     must fix before ship" (software) or "What to resolve first" (else).
-  {{DISCLAIMER}}     OPTIONAL lens-aware professional-advice caveat (subtle footer
-                     line). Empty for a software-lens board — leave blank and the
-                     line is dropped.
-  {{PLAN}}           What was reviewed (HTML allowed; use <p>).
-  {{METADATA}}       Footer provenance (board, rounds, date).
+  {{TITLE}}            Page + masthead title (what the board was asked).
+  {{SUBTITLE}}         One-line description of what was reviewed.
+  {{DATE}}             Review date, e.g. "2026-06-24".
+  {{BOARD}}            Board roster (HTML allowed).
+  {{ROUNDS}}           Number of rounds, e.g. "2".
+  {{VERDICT}}          Final verdict headline (same as the full handoff).
+  {{VERDICT_CLASS}}    One of: ship | caution | block  (colors the banner).
+  {{CONFIDENCE}}       OPTIONAL banner pill, e.g. "high confidence". Empty -> pill dropped.
+  {{VERDICT_NOTE}}     One-line explanation under the verdict headline.
+  {{BLOCKERS_HEADING}} Lens-aware must-resolve header.
+  {{BLOCKER_TITLE}}    A must-resolve item's title.
+  {{BLOCKER_SUMMARY}}  That item, collapsed to one plain line (may be empty).
+  {{DISSENT_FLAG}}     Dissent-section flag, e.g. "Dissent on the record".
+  {{DISSENT_WHO}}      The dissenting seat (or "Minority report").
+  {{DISSENT_SUMMARY}}  That dissent, collapsed to one plain line.
+  {{DISSENT_MORE}}     OPTIONAL "(+N more in the full handoff)" pointer. Empty -> dropped.
+  {{ACTION}}           A next step (top 3 only in the brief).
+  {{ACTIONS_MORE}}     OPTIONAL "…N more in the full handoff" pointer. Empty -> dropped.
+  {{DISCLAIMER}}       OPTIONAL lens-aware professional-advice caveat (footer).
+  {{METADATA}}         Footer provenance (board, rounds, date).
   ============================================================================
 -->
 <html lang="en">
@@ -153,137 +145,50 @@
   .verdict.block   { background: var(--block-bg);   border-color: var(--block-edge);   color: var(--block-ink); }
 
   /* ---- sections ---- */
-  section { margin: 0 0 34px; }
+  .qv-sec { margin: 0 0 30px; }
   h2 {
     font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
     font-weight: 700; color: var(--ink-faint); margin: 0 0 14px;
     padding-bottom: 8px; border-bottom: 1px solid var(--line);
   }
 
-  /* ---- plan callout ---- */
-  .plan {
-    background: var(--surface-soft); border: 1px solid var(--line);
-    border-left: 4px solid var(--accent); border-radius: 0 10px 10px 0;
-    padding: 16px 20px;
-  }
-  .plan p { margin: 0 0 10px; } .plan p:last-child { margin: 0; }
-
-  /* ---- seat cards ---- */
-  .seat {
-    background: var(--surface); border: 1px solid var(--line-strong);
-    border-radius: 12px; padding: 20px 22px; margin: 0 0 18px;
-  }
-  .seat-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 12px; margin-bottom: 4px; }
-  .seat-name { font-size: 19px; font-weight: 700; margin: 0; }
-  .seat-lens {
-    font-size: 12.5px; font-weight: 600; color: var(--accent);
-    background: var(--accent-tint); border-radius: 999px; padding: 3px 11px;
-  }
-  .seat-model { font-size: 13px; color: var(--ink-faint); font-family: var(--font-mono); }
-  .seat-status {
-    font-size: 11.5px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
-    border-radius: 999px; padding: 3px 10px;
-  }
-  .seat-status.ran      { background: var(--vellum);     color: var(--ink-faint); }
-  .seat-status.degraded { background: var(--caution-bg); color: var(--caution-ink); }
-  .seat-status.dropped  { background: var(--block-bg);   color: var(--block-ink); }
-  .round { margin-top: 16px; padding-top: 16px; border-top: 1px dashed var(--line); }
-  .round:first-of-type { margin-top: 12px; }
-  .round-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 8px; }
-  .round-tag { font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); }
-  /* per-round verdict pill */
-  .vpill { font-size: 12px; font-weight: 700; border-radius: 999px; padding: 3px 11px; line-height: 1.4; }
-  .vpill.ship    { background: var(--ship-bg);    color: var(--ship-ink); }
-  .vpill.caution { background: var(--caution-bg); color: var(--caution-ink); }
-  .vpill.block   { background: var(--block-bg);   color: var(--block-ink); }
-  .vpill.moved::after { content: " ↓"; }
-  .conf {
-    font-size: 11.5px; font-weight: 600; color: var(--ink-faint);
-    background: var(--surface-soft); border: 1px solid var(--line);
-    border-radius: 999px; padding: 2px 9px;
-  }
-
-  .review-body { font-size: 15.5px; color: var(--ink); }
-  .review-body strong { font-weight: 600; }
-  .review-body em { font-style: italic; }
-  .review-body a { color: var(--accent); text-decoration: underline; }
-  .review-body ul, .review-body ol { margin: 6px 0; padding-left: 22px; }
-  .review-body li { margin: 5px 0; }
-  .review-body p { margin: 6px 0; }
-  .review-body p.r-title { font-weight: 600; margin-top: 12px; }
-  .review-body blockquote {
-    margin: 8px 0; padding: 2px 0 2px 14px;
-    border-left: 3px solid var(--line-strong); color: var(--ink-soft);
-  }
-  .review-body pre {
-    background: var(--surface-soft); border: 1px solid var(--line);
-    border-radius: 8px; padding: 10px 12px; margin: 8px 0;
-    overflow-x: auto; font-size: 13px; line-height: 1.5;
-  }
-  .review-body pre code { background: none; border: 0; padding: 0; font-size: inherit; }
-  code {
-    font-family: var(--font-mono);
-    font-size: 0.86em; background: var(--vellum); border: 1px solid var(--line);
-    border-radius: 5px; padding: 1px 5px;
-  }
-
-  /* highlight callout (e.g. a seat that changed its verdict) */
-  .highlight {
-    background: #fff6e3; border: 1px solid #ecd9a3; border-radius: 10px;
-    padding: 12px 16px; margin: 14px 0 0; font-size: 14.5px; color: #6f5212;
-  }
-  .highlight b { color: #5a4209; }
-
-  /* ---- numbered blocker checklist ---- */
-  ol.blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
-  ol.blockers > li {
+  /* ---- compact blocker list (one line per item) ---- */
+  ol.qv-blockers { list-style: none; counter-reset: blk; margin: 0; padding: 0; }
+  ol.qv-blockers > li {
     counter-increment: blk; position: relative;
     background: var(--surface); border: 1px solid var(--line-strong);
-    border-radius: 11px; padding: 15px 18px 15px 56px; margin: 0 0 11px;
+    border-radius: 11px; padding: 14px 18px 14px 56px; margin: 0 0 10px;
   }
-  ol.blockers > li::before {
-    content: counter(blk); position: absolute; left: 14px; top: 14px;
+  ol.qv-blockers > li::before {
+    content: counter(blk); position: absolute; left: 14px; top: 13px;
     width: 28px; height: 28px; border-radius: 50%;
     background: var(--block-bg); color: var(--block-ink);
     font-size: 14px; font-weight: 700; display: flex; align-items: center; justify-content: center;
   }
-  ol.blockers .b-title { font-weight: 600; }
-  ol.blockers .b-body { font-size: 15px; color: var(--ink-soft); margin-top: 3px; }
+  ol.qv-blockers .b-title { font-weight: 600; }
+  ol.qv-blockers .b-sub { font-size: 15px; color: var(--ink-soft); margin-top: 2px; }
 
-  /* ---- dissent (visually distinct) ---- */
-  .dissent {
+  /* ---- dissent line ---- */
+  .qv-dissent {
     background: #fbf3ec; border: 1px dashed var(--caution-edge);
-    border-radius: 12px; padding: 16px 20px;
+    border-radius: 12px; padding: 14px 20px; margin: 0 0 30px;
   }
-  .dissent .d-flag {
+  .qv-dflag {
     display: inline-block; font-size: 11.5px; font-weight: 700;
     letter-spacing: 0.07em; text-transform: uppercase; color: var(--caution-ink);
     background: var(--caution-bg); border-radius: 999px; padding: 3px 10px; margin-bottom: 8px;
   }
-  .dissent p { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
-  .dissent .who { font-weight: 700; color: var(--caution-ink); }
+  .qv-d { margin: 6px 0; font-size: 15.5px; color: #5e4a31; }
+  .qv-d .who { font-weight: 700; color: var(--caution-ink); }
+  .qv-more { color: var(--ink-faint, #6b665c); font-size: 0.92em; }
 
-  /* ---- what the board couldn't verify (epistemic caveats) ---- */
-  .caveats {
+  /* ---- next steps ---- */
+  .qv-actions {
     background: var(--surface-soft); border: 1px solid var(--line);
-    border-left: 4px solid var(--ink-faint); border-radius: 0 12px 12px 0;
-    padding: 16px 20px;
+    border-radius: 12px; padding: 14px 20px 14px 38px; margin: 0; font-size: 15.5px;
   }
-  .caveats ul { margin: 0; padding-left: 22px; }
-  .caveats li { margin: 7px 0; font-size: 15.5px; }
-  .caveats .c-claim { font-weight: 600; }
-  .caveats .c-change { color: var(--ink-soft); }
-
-  /* ---- simple lists ---- */
-  ul.plain { margin: 0; padding-left: 22px; }
-  ul.plain li { margin: 7px 0; font-size: 15.5px; }
-
-  .actions {
-    background: var(--surface-soft); border: 1px solid var(--line);
-    border-radius: 12px; padding: 16px 20px; font-size: 15.5px;
-  }
-  .actions ol { margin: 0; padding-left: 20px; }
-  .actions li { margin: 6px 0; }
+  ol.qv-actions li { margin: 6px 0; }
+  .qv-more-li { color: var(--ink-faint, #6b665c); list-style: none; font-size: 0.92em; }
 
   /* ---- dark footer / colophon band ---- */
   footer.colophon { background: var(--dark); color: var(--on-dark-soft); padding: 26px 20px 32px; }
@@ -312,8 +217,7 @@
     header.masthead, footer.colophon { padding-left: 15px; padding-right: 15px; }
     header.masthead h1 { font-size: 25px; }
     .verdict .headline { font-size: 20px; }
-    .seat, ol.blockers > li { padding-left: 16px; padding-right: 16px; }
-    ol.blockers > li { padding-left: 50px; }
+    ol.qv-blockers > li { padding-left: 50px; padding-right: 16px; }
     .colophon-cta { width: 100%; }
   }
 
@@ -322,7 +226,7 @@
     body { background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
     header.masthead, footer.colophon { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
     .wrap { max-width: none; }
-    .verdict, .plan, .seat, .round, ol.blockers > li, .dissent, .actions { break-inside: avoid; }
+    .verdict, ol.qv-blockers > li, .qv-dissent, .qv-actions { break-inside: avoid; }
     a { color: inherit; text-decoration: none; }
   }
 </style>
@@ -356,120 +260,36 @@
     <p class="note">{{VERDICT_NOTE}}</p>
   </div>
 
-  <!-- ===================== PLAN UNDER REVIEW ===================== -->
-  <section>
-    <h2>What was reviewed</h2>
-    <div class="plan">
-      {{PLAN}}
-    </div>
-  </section>
-
-  <!-- ===================== SEAT REVIEWS ===================== -->
-  <section>
-    <h2>Board reviews — round by round</h2>
-
-    <!-- BEGIN SEAT CARD (duplicate per seat) -->
-    <article class="seat">
-      <div class="seat-head">
-        <h3 class="seat-name">{{SEAT_NAME}}</h3>
-        <span class="seat-lens">{{SEAT_LENS}}</span>
-        <span class="seat-model">{{SEAT_MODEL}}</span>
-        <!-- OPTIONAL seat status: class ran | degraded | dropped. Show only for a degraded or dropped seat; delete for a clean run. -->
-        <span class="seat-status {{SEAT_STATUS_CLASS}}">{{SEAT_STATUS}}</span>
-      </div>
-
-      <!-- BEGIN ROUND (duplicate per round) -->
-      <div class="round">
-        <div class="round-head">
-          <span class="round-tag">{{ROUND_LABEL}}</span>
-          <!-- vpill class: ship | caution | block ; add "moved" to show a ↓ when the verdict shifted -->
-          <span class="vpill {{ROUND_VERDICT_CLASS}}">{{ROUND_VERDICT}}</span>
-          <!-- OPTIONAL confidence chip: low | medium | high. Delete if confidence wasn't tracked. -->
-          <span class="conf">confidence: {{ROUND_CONFIDENCE}}</span>
-        </div>
-        <div class="review-body">
-          <!-- {{ROUND_REVIEW}}: this seat's findings, authored as raw Markdown and
-               converted to HTML by render_handoff.py (_md) — headings -> <p class="r-title">,
-               **bold**/*italic*, -/1. lists, `code`/```fences```. -->
-          {{ROUND_REVIEW}}
-        </div>
-      </div>
-      <!-- END ROUND -->
-
-      <!-- OPTIONAL per-seat highlight (e.g. a verdict change). Delete if unused. -->
-      <div class="highlight">{{SEAT_HIGHLIGHT}}</div>
-
-    </article>
-    <!-- END SEAT CARD -->
-
-  </section>
-
-  <!-- ===================== CONSENSUS BLOCKERS ===================== -->
-  <section>
+  <!-- ===================== MUST-RESOLVE (one line each) ===================== -->
+  <section class="qv-sec qv-blockers-sec">
     <h2>{{BLOCKERS_HEADING}}</h2>
-    <ol class="blockers">
+    <ol class="qv-blockers">
       <!-- BEGIN BLOCKER (duplicate per blocker; the number is added automatically) -->
       <li>
         <span class="b-title">{{BLOCKER_TITLE}}</span>
-        <div class="b-body">{{BLOCKER_BODY}}</div>
+        <div class="b-sub">{{BLOCKER_SUMMARY}}</div>
       </li>
       <!-- END BLOCKER -->
     </ol>
   </section>
 
-  <!-- ===================== DISSENT / MINORITY REPORT ===================== -->
-  <!-- Records disagreement that survived the debate. If the board was UNANIMOUS, this
-       holds the minority report — the strongest case against the verdict (see
-       references/epistemics.md); set {{DISSENT_FLAG}} to "Minority report". Delete the
-       section only if there is genuinely neither dissent nor a minority report. -->
-  <section>
-    <h2>Dissent &amp; minority report</h2>
-    <div class="dissent">
-      <span class="d-flag">{{DISSENT_FLAG}}</span>
-      <!-- BEGIN DISSENT (duplicate per point; name the seat in .who, or use "Minority report") -->
-      <p><span class="who">{{DISSENT_WHO}}:</span> {{DISSENT_BODY}}</p>
-      <!-- END DISSENT -->
-    </div>
-  </section>
+  <!-- ===================== DISSENT (one line) ===================== -->
+  <div class="qv-dissent">
+    <span class="qv-dflag">{{DISSENT_FLAG}}</span>
+    <!-- BEGIN DISSENT BRIEF (the first dissenter only; {{DISSENT_MORE}} = "+N more" pointer) -->
+    <p class="qv-d"><span class="who">{{DISSENT_WHO}}</span> — {{DISSENT_SUMMARY}} <span class="qv-more">{{DISSENT_MORE}}</span></p>
+    <!-- END DISSENT BRIEF -->
+  </div>
 
-  <!-- ===================== WHAT THE BOARD COULDN'T VERIFY ===================== -->
-  <!-- Claims the board relied on but did NOT check, and shared blind spots: facts every
-       seat assumed, things outside what any seat could see (live data, prod config, the
-       real code when only a plan was reviewed), and what would flip the verdict if false.
-       Guards against a confident, unanimous, wrong call (see references/epistemics.md).
-       Delete this section only if the board verified everything load-bearing — rare; say
-       so in the verdict note instead of dropping it silently. -->
-  <section>
-    <h2>What the board couldn't verify</h2>
-    <div class="caveats">
-      <ul>
-        <!-- BEGIN CAVEAT (duplicate per couldn't-verify item) -->
-        <li><span class="c-claim">{{CAVEAT_CLAIM}}</span> — <span class="c-change">{{CAVEAT_IMPACT}}</span></li>
-        <!-- END CAVEAT -->
-      </ul>
-    </div>
-  </section>
-
-  <!-- ===================== OPEN QUESTIONS ===================== -->
-  <section>
-    <h2>Open questions</h2>
-    <ul class="plain">
-      <!-- BEGIN QUESTION (duplicate per open question) -->
-      <li>{{QUESTION}}</li>
-      <!-- END QUESTION -->
-    </ul>
-  </section>
-
-  <!-- ===================== NEXT ACTIONS ===================== -->
-  <section>
-    <h2>Next actions</h2>
-    <div class="actions">
-      <ol>
-        <!-- BEGIN ACTION (duplicate per next action) -->
-        <li>{{ACTION}}</li>
-        <!-- END ACTION -->
-      </ol>
-    </div>
+  <!-- ===================== NEXT STEPS ===================== -->
+  <section class="qv-sec qv-actions-sec">
+    <h2>Next steps</h2>
+    <ol class="qv-actions">
+      <!-- BEGIN ACTION BRIEF (the top 3 next steps only) -->
+      <li>{{ACTION}}</li>
+      <!-- END ACTION BRIEF -->
+      <li class="qv-more-li">{{ACTIONS_MORE}}</li>
+    </ol>
   </section>
 
   </main>

--- a/skills/advisory-board/scripts/render_handoff.py
+++ b/skills/advisory-board/scripts/render_handoff.py
@@ -67,9 +67,11 @@ BLOCK_KEYS = {
     "ROUND": "rounds",
     "BLOCKER": "blockers",
     "DISSENT": "dissents",
+    "DISSENT BRIEF": "dissents_brief",
     "CAVEAT": "caveats",
     "QUESTION": "questions",
     "ACTION": "actions",
+    "ACTION BRIEF": "actions_brief",
 }
 
 # Tokens whose values are authored HTML fragments and pass through unescaped.
@@ -86,6 +88,31 @@ def drop_empty_optionals(out: str) -> str:
     out = re.sub(r'\s*<div class="highlight">\s*</div>', "", out)
     out = re.sub(r'\s*<span class="conf">confidence:\s*</span>', "", out)
     out = re.sub(r'\s*<span class="disclaimer">\s*</span>', "", out)
+    # Drop the verdict-banner confidence pill when there's no confidence. Shared by both
+    # the full handoff and the brief (same banner markup); no-op when the pill is filled.
+    out = re.sub(r'<span class="conf-badge">\s*</span>', "", out)
+    # --- quick-verdict (qv-*) drops. All scoped to qv-* classes, so they are NO-OPS
+    #     for the full handoff template (which has no qv-* markup). After render_item,
+    #     an empty repeatable block leaves its <ol>…</ol>/<span>…</span> empty — that
+    #     is the shape these match. ---
+    # Drop the brief's "+N more" / "…N more" pointers when they rendered empty. The
+    # qv-more-li drop MUST run BEFORE the empty-actions-section drop below, so a zero-
+    # action brief leaves a truly empty <ol> for that rule to match (and the whole
+    # section drops). qv-more is the inline dissent pointer span.
+    out = re.sub(r'\s*<li class="qv-more-li">\s*</li>', "", out)
+    out = re.sub(r'\s*<span class="qv-more">\s*</span>', "", out)
+    # Drop an empty dissent block: only an empty qv-dflag and no qv-d items left.
+    out = re.sub(
+        r'\s*<div class="qv-dissent">\s*<span class="qv-dflag">\s*</span>\s*</div>',
+        "", out, flags=re.DOTALL)
+    # Drop an empty blockers section (the qv-blockers <ol> rendered empty).
+    out = re.sub(
+        r'\s*<section class="qv-sec qv-blockers-sec">.*?<ol class="qv-blockers">\s*</ol>.*?</section>',
+        "", out, flags=re.DOTALL)
+    # Drop an empty actions section (the qv-actions <ol> rendered empty).
+    out = re.sub(
+        r'\s*<section class="qv-sec qv-actions-sec">.*?<ol class="qv-actions">\s*</ol>.*?</section>',
+        "", out, flags=re.DOTALL)
     return out
 
 
@@ -135,6 +162,14 @@ def default_template() -> str:
     return os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "..", "references", "handoff-template.html",
+    )
+
+
+def quick_verdict_template() -> str:
+    """The slim "quick-verdict" (skim-brief) template — same handoff-data, fewer slots."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..", "references", "quick-verdict-template.html",
     )
 
 

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -269,6 +269,32 @@ def _plain(text: str) -> str:
     return _nb(text)
 
 
+def _oneliner(text: str, limit: int = 180) -> str:
+    """Collapse a blocker/dissent body to ONE plain-text line for the quick-verdict brief.
+
+    Strips leading list markers and inline markdown (per-line leading "-"/"•" bullets, and
+    the `* ` backtick `#` `>` characters), collapses all whitespace/newlines to single
+    spaces, and trims. If the result is longer than `limit`, it is cut at the last word
+    boundary <= limit and an ellipsis is appended. Returns "" for empty/whitespace input."""
+    if not text or not str(text).strip():
+        return ""
+    lines = []
+    for line in str(text).splitlines():
+        # Drop a leading bullet marker ("-", "•", "*") and surrounding space per line.
+        line = re.sub(r"^\s*[-•*]\s+", "", line)
+        lines.append(line)
+    joined = " ".join(lines)
+    # Strip the remaining inline-markdown punctuation (emphasis, code, headings, quotes).
+    joined = re.sub(r"[*`#>]", "", joined)
+    collapsed = re.sub(r"\s+", " ", joined).strip()
+    if len(collapsed) <= limit:
+        return collapsed
+    cut = collapsed[:limit]
+    if " " in cut:
+        cut = cut[:cut.rfind(" ")]
+    return cut.rstrip() + "…"
+
+
 def _round_review(run_dir, seat_name: str, round_no: int, verdict: str) -> str:
     """The seat's round review as raw MARKDOWN. render_handoff.py owns the single
     Markdown->HTML conversion (its _md_review), so this must NOT pre-render HTML — a
@@ -303,8 +329,16 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     # the absent-preset default). Empty string when absent so the template slot resolves
     # to nothing and the footer line is dropped.
     disclaimer = lens_disclaimer(lens_preset)
+    # The board's confidence, rendered as a small banner pill ("high confidence"). Empty
+    # when absent so the pill is dropped. Same value feeds both the full and brief banners.
+    confidence = data.get("confidence")
+    confidence_str = f"{confidence} confidence" if confidence else ""
     board_str = " · ".join(s.get("seat", "?") for s in data.get("board", []))
     rounds_str = str(data.get("rounds", ""))
+    # The brief trims dissent to the first dissenter + a "+N more" pointer, and caps next
+    # steps at the top 3 + a "…N more" pointer; the full handoff keeps the complete lists.
+    dissent = data.get("dissent") or []
+    actions = data.get("next_actions") or []
     # Footer provenance, in human terms — no internal file/script names. (The old
     # "Rendered from verdict.json by scripts/render_verdict.py" was a developer string
     # that leaked onto the page; same for the subtitle below.)
@@ -325,6 +359,7 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         "verdict": _plain(headline),
         "verdict_class": _VERDICT_CLASS.get(verdict, ""),
         "verdict_note": _raw(verdict_note) if verdict_note else "",
+        "confidence": _plain(confidence_str),
         # Lens-aware section header for the consensus must-resolve items.
         "blockers_heading": _plain(blockers_heading(lens_preset, "html")),
         "disclaimer": _raw(disclaimer) if disclaimer else "",
@@ -332,14 +367,32 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         "metadata": _raw(metadata),
         "dissent_flag": "Dissent on the record" if data.get("dissent") else "",
         "seats": [],
+        # blocker_summary / dissent_summary are the one-line plain-text forms the
+        # quick-verdict brief renders; the full handoff keeps using blocker_body /
+        # dissent_body (the full prose). Both are non-RAW (the renderer escapes them).
         "blockers": [{"blocker_title": _plain(b.get("title", "blocker")),
-                      "blocker_body": _raw(b.get("body", ""))} for b in data.get("blockers", [])],
+                      "blocker_body": _raw(b.get("body", "")),
+                      "blocker_summary": _plain(_oneliner(b.get("body", "")))}
+                     for b in data.get("blockers", [])],
         "dissents": [{"dissent_who": _plain(d.get("who", "-")),
-                      "dissent_body": _raw(d.get("body", ""))} for d in data.get("dissent", [])],
+                      "dissent_body": _raw(d.get("body", "")),
+                      "dissent_summary": _plain(_oneliner(d.get("body", "")))}
+                     for d in data.get("dissent", [])],
         "caveats": [{"caveat_claim": _raw(line), "caveat_impact": ""}
                     for line in _couldnt_verify_lines(data)],
         "questions": [{"question": _raw(q)} for q in data.get("open_questions", [])],
         "actions": [{"action": _raw(a)} for a in data.get("next_actions", [])],
+        # Brief-only trims. The full handoff uses dissents[]/actions[] (complete); the
+        # quick-verdict template uses these capped variants + their "more" pointers.
+        "dissents_brief": ([{
+            "dissent_who": _plain(dissent[0].get("who", "-")),
+            "dissent_summary": _plain(_oneliner(dissent[0].get("body", ""))),
+            "dissent_more": _plain(f"(+{len(dissent) - 1} more in the full handoff)")
+                            if len(dissent) > 1 else "",
+        }] if dissent else []),
+        "actions_brief": [{"action": _raw(a)} for a in actions[:3]],
+        "actions_more": _plain(f"…{len(actions) - 3} more in the full handoff")
+                        if len(actions) > 3 else "",
     }
     for seat in data.get("board", []):
         name = seat.get("seat", "?")
@@ -369,10 +422,16 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     return hd
 
 
-def _render_html(hd: dict) -> str:
+def _render_html(hd: dict, shape: str = "full-handoff") -> str:
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     import render_handoff  # sibling script
-    with open(render_handoff.default_template(), encoding="utf-8") as handle:
+    # Same handoff-data dict feeds both views; only the template differs. The
+    # quick-verdict template uses the slim subset of tokens/blocks (verdict banner,
+    # one-line blockers, dissent line, actions) — no seats/rounds/caveats/questions.
+    template_path = (render_handoff.quick_verdict_template()
+                     if shape == "quick-verdict"
+                     else render_handoff.default_template())
+    with open(template_path, encoding="utf-8") as handle:
         template = handle.read()
     return render_handoff.render(hd, template)
 
@@ -384,6 +443,8 @@ def main(argv=None) -> int:
     parser.add_argument("--check", action="store_true", help="print Markdown to stdout; write nothing")
     parser.add_argument("--handoff-data", dest="handoff_data", help="also write a derived handoff-data.json here")
     parser.add_argument("--html", help="also write final-consensus.html here (via render_handoff.py)")
+    parser.add_argument("--shape", choices=("full-handoff", "quick-verdict"), default="full-handoff",
+                        help="HTML shape for --html: the full handoff (default) or the slim quick-verdict brief")
     parser.add_argument("--run", dest="run_dir", help="a run dir; pulls per-round prose from its round-N/<seat>.md")
     args = parser.parse_args(argv)
 
@@ -405,7 +466,7 @@ def main(argv=None) -> int:
                 handle.write("\n")
             print(f"wrote {args.handoff_data}")
         if args.html:
-            out_html = _render_html(hd)
+            out_html = _render_html(hd, args.shape)
             with open(args.html, "w", encoding="utf-8") as handle:
                 handle.write(out_html)
             print(f"wrote {args.html} ({len(out_html)} bytes)")

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3555,7 +3555,8 @@ class TestLensAwareFraming(unittest.TestCase):
     software board (and the absent/None default) stays byte-identical."""
 
     # --- the shared module: directive lead / section heading --------------- #
-    # (The "Final verdict" eyebrow is hardcoded in the template, same for every lens.)
+    # (The "Final verdict" eyebrow is hardcoded in the template, same for every lens;
+    #  it now also carries an optional confidence pill — see TestConfidencePill.)
 
     def test_lead_software_and_absent_are_none(self):
         # A software board's SHIP/… label is already a directive — no extra lead.
@@ -3648,7 +3649,7 @@ class TestLensAwareFraming(unittest.TestCase):
 
     def test_html_non_software_banner_and_heading(self):
         html_out = self._html(self._caution())
-        self.assertIn('<p class="label">Final verdict</p>', html_out)   # eyebrow unchanged
+        self.assertIn('<p class="label">Final verdict', html_out)       # eyebrow (now carries the conf pill)
         self.assertIn("Go ahead, with conditions ·", html_out)          # directive headline
         self.assertIn("<h2>What to resolve first</h2>", html_out)       # lens-aware section
         self.assertNotIn("must fix before ship", html_out)
@@ -3659,7 +3660,7 @@ class TestLensAwareFraming(unittest.TestCase):
                         lens_preset="software-architecture",
                         blockers=[{"title": "x", "body": "y"}])
         html_out = self._html(data)
-        self.assertIn('<p class="label">Final verdict</p>', html_out)
+        self.assertIn('<p class="label">Final verdict', html_out)
         self.assertIn("DO NOT SHIP YET — unanimous", html_out)
         self.assertIn("<h2>Consensus blockers — must fix before ship</h2>", html_out)
         self.assertNotIn("What to resolve first", html_out)
@@ -3670,6 +3671,215 @@ class TestLensAwareFraming(unittest.TestCase):
         sw = rv.build_handoff_data(_verdict("block", "block", "block",
                                             lens_preset="software-architecture"))
         self.assertEqual(sw["blockers_heading"], "Consensus blockers — must fix before ship")
+
+    # --- confidence pill in the full-handoff banner ------------------------- #
+
+    def test_full_handoff_banner_shows_confidence_pill(self):
+        # _verdict sets confidence="high"; the pill rides the eyebrow on the full handoff.
+        html_out = self._html(self._caution())
+        self.assertIn('<span class="conf-badge">high confidence</span>', html_out)
+        self.assertEqual(rv.build_handoff_data(self._caution())["confidence"], "high confidence")
+
+    def test_full_handoff_drops_pill_without_confidence(self):
+        data = self._caution()
+        del data["confidence"]
+        html_out = self._html(data)
+        self.assertNotIn('<span class="conf-badge">', html_out)
+        self.assertIn('<p class="label">Final verdict</p>', html_out)
+        self.assertEqual(rv.build_handoff_data(data)["confidence"], "")
+
+
+class TestQuickVerdictShape(unittest.TestCase):
+    """v1.8.x: the "quick-verdict" (skim-brief) HTML shape — the verdict banner, the
+    must-resolve items as one-liners, a one-line dissent flag, and the next steps. Same
+    handoff-data feeds it as the full handoff; it just carries less (no round-by-round
+    board reviews, no couldn't-verify bucket, no open questions). Mirrors
+    TestLensAwareFraming: render via render_handoff against the quick-verdict template."""
+
+    def _qv(self, data):
+        import render_handoff as rh
+        return rh.render(rv.build_handoff_data(data),
+                         open(rh.quick_verdict_template()).read())
+
+    def _caution(self, **extra):
+        return _verdict("caution", "caution", "caution", title="Should I do X?",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "Runway", "body": "The numbers don't close."}],
+                        dissent=[{"who": "Codex", "body": "I'd wait another quarter."}],
+                        next_actions=["Build 6 months of runway", "Land 2 anchor clients"],
+                        **extra)
+
+    # --- _oneliner ---------------------------------------------------------- #
+
+    def test_oneliner_empty(self):
+        self.assertEqual(rv._oneliner(""), "")
+        self.assertEqual(rv._oneliner("   \n  "), "")
+
+    def test_oneliner_strips_markdown_and_collapses(self):
+        out = rv._oneliner("- The numbers do **not**\n  close at current `burn`. # heading\n> quote")
+        self.assertEqual(out, "The numbers do not close at current burn. heading quote")
+
+    def test_oneliner_truncates_at_word_boundary(self):
+        out = rv._oneliner("alpha beta gamma delta epsilon", limit=12)
+        self.assertTrue(out.endswith("…"))
+        self.assertLessEqual(len(out) - 1, 12)   # the cut text (sans ellipsis) is within the limit
+        self.assertNotIn("gamma", out)           # cut mid-stream, not at a partial word
+
+    # --- renders + KEEPS ---------------------------------------------------- #
+
+    def test_qv_renders_clean(self):
+        # No SystemExit (assert_fully_resolved) and no leftover token.
+        out = self._qv(self._caution())
+        self.assertNotIn("{{", out)
+
+    def test_qv_keeps_lens_aware_banner_heading_blocker_dissent_action(self):
+        out = self._qv(self._caution())
+        self.assertIn("Go ahead, with conditions ·", out)        # lens-aware headline
+        self.assertIn("<h2>What to resolve first</h2>", out)      # lens-aware must-resolve heading
+        self.assertIn("Runway", out)                             # a blocker title
+        self.assertIn("Dissent on the record", out)              # the dissent flag
+        self.assertIn("Build 6 months of runway", out)           # an action line
+        self.assertIn('<p class="label">Final verdict', out)      # brand eyebrow (carries the conf pill)
+
+    # --- DROPS the heavy full-handoff sections ------------------------------ #
+
+    def test_qv_drops_heavy_sections(self):
+        out = self._qv(self._caution())
+        self.assertNotIn("Board reviews — round by round", out)
+        self.assertNotIn("Round 1 verdict", out)                 # no seat round_review prose
+        self.assertNotIn("What the board couldn't verify", out)
+        self.assertNotIn("Open questions", out)
+
+    # --- lens-aware software fixture ---------------------------------------- #
+
+    def test_qv_software_banner_and_heading(self):
+        data = _verdict("block", "block", "block", title="Cache layer",
+                        lens_preset="software-architecture",
+                        blockers=[{"title": "x", "body": "y"}])
+        out = self._qv(data)
+        self.assertIn("DO NOT SHIP YET", out)
+        self.assertIn("<h2>Consensus blockers — must fix before ship</h2>", out)
+
+    # --- empty handling ----------------------------------------------------- #
+
+    def test_qv_ship_with_no_blockers_drops_blockers_section(self):
+        data = _verdict("ship", "ship", "ship", title="Launch?",
+                        lens_preset="business-decision",
+                        next_actions=["Ship it"])
+        out = self._qv(data)
+        self.assertNotIn('<ol class="qv-blockers"></ol>', out)
+        self.assertNotIn('qv-blockers-sec', out)
+
+    def test_qv_no_dissent_drops_dissent_div(self):
+        data = _verdict("ship", "ship", "ship", title="Launch?",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "B", "body": "b"}],
+                        next_actions=["Ship it"])
+        out = self._qv(data)
+        self.assertNotIn('<div class="qv-dissent">', out)
+        self.assertNotIn('<span class="qv-dflag">', out)
+
+    # --- dissent trim (brief only) ------------------------------------------ #
+
+    def _trim_fixture(self, *, dissent, next_actions):
+        # A business-decision caution fixture with caller-set dissent / next_actions counts
+        # (the _caution helper hardcodes both, so the trim/cap tests build directly).
+        return _verdict("caution", "caution", "caution", title="Should I do X?",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "Runway", "body": "The numbers don't close."}],
+                        dissent=dissent, next_actions=next_actions)
+
+    def test_qv_dissent_trims_to_first_plus_more(self):
+        data = self._trim_fixture(dissent=[
+            {"who": "Claude", "body": "First dissenter view."},
+            {"who": "Codex", "body": "ZZ-second-dissenter-body."},
+            {"who": "Gemini", "body": "Third one too."}],
+            next_actions=["a1"])
+        out = self._qv(data)
+        # the rendered dissent block (not the CSS) — slice on the markup div.
+        i = out.index('<div class="qv-dissent">')
+        block = out[i:out.index("</div>", i)]
+        self.assertIn("Claude", block)                       # first dissenter present
+        self.assertIn("First dissenter view.", block)
+        self.assertNotIn("ZZ-second-dissenter-body.", out)   # a LATER dissenter's body absent
+        self.assertNotIn("Gemini", block)                    # a LATER dissenter absent
+        self.assertIn("(+2 more in the full handoff)", out)  # the "+N more" pointer
+
+    def test_qv_single_dissent_has_no_more_pointer(self):
+        out = self._qv(self._caution())  # exactly one dissenter
+        self.assertIn("Codex", out)
+        self.assertNotIn("more in the full handoff", out)
+
+    # --- next-steps cap at 3 (brief only) ----------------------------------- #
+
+    def test_qv_actions_cap_at_three_plus_more(self):
+        data = self._trim_fixture(dissent=[{"who": "Codex", "body": "d"}], next_actions=[
+            "Step one", "Step two", "Step three", "ZZ-fourth-step", "Step five"])
+        out = self._qv(data)
+        sec = out[out.index('qv-actions-sec'):]
+        self.assertIn("Step one", out)
+        self.assertIn("Step three", out)
+        self.assertNotIn("ZZ-fourth-step", out)              # the 4th action is absent
+        self.assertEqual(sec.count("<li"), 4)                # exactly 3 actions + the more-li
+        self.assertIn("…2 more in the full handoff", out)    # the "…N more" pointer
+
+    def test_qv_three_or_fewer_actions_has_no_more_li(self):
+        data = self._trim_fixture(dissent=[{"who": "Codex", "body": "d"}],
+                                  next_actions=["Only one", "Only two"])
+        out = self._qv(data)
+        self.assertNotIn('<li class="qv-more-li">', out)     # the markup li, not the CSS class
+        self.assertNotIn("more in the full handoff", out)
+
+    def test_qv_zero_actions_drops_actions_section(self):
+        data = _verdict("ship", "ship", "ship", title="Launch?",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "B", "body": "b"}])  # no next_actions
+        out = self._qv(data)
+        self.assertNotIn("qv-actions-sec", out)
+        self.assertNotIn('<ol class="qv-actions">', out)
+
+    # --- confidence pill (both templates) ----------------------------------- #
+
+    def test_qv_confidence_pill_present_and_dropped(self):
+        out = self._qv(self._caution())  # _verdict sets confidence="high"
+        self.assertIn('<span class="conf-badge">high confidence</span>', out)
+        # a no-confidence fixture drops the pill (leaving the bare eyebrow).
+        nc = self._caution()
+        del nc["confidence"]
+        out = self._qv(nc)
+        self.assertNotIn('<span class="conf-badge">', out)
+        self.assertIn('<p class="label">Final verdict</p>', out)
+
+    # --- --shape flag ------------------------------------------------------- #
+
+    def test_shape_flag_writes_slim_vs_full(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        vpath = os.path.join(d, "verdict.json")
+        with open(vpath, "w") as fh:
+            json.dump(self._caution(), fh)
+        slim = os.path.join(d, "quick-verdict.html")
+        full = os.path.join(d, "final-consensus.html")
+        md = os.path.join(d, "out.md")
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rv.main([vpath, "-o", md, "--html", slim, "--shape", "quick-verdict"])
+            rv.main([vpath, "-o", md, "--html", full])  # default shape = full-handoff
+
+        slim_html = open(slim).read()
+        full_html = open(full).read()
+        self.assertNotIn("Board reviews — round by round", slim_html)
+        self.assertIn("Board reviews — round by round", full_html)
+
+    # --- brace safety ------------------------------------------------------- #
+
+    def test_qv_brace_safe_blocker_title(self):
+        data = _verdict("caution", "caution", title="Plan",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "use {{X}} here", "body": "b"}])
+        out = self._qv(data)  # must not raise SystemExit on a literal {{X}}
+        self.assertNotIn("{{X}}", out)
 
 
 class TestM5ChainDelegation(EnvMixin):


### PR DESCRIPTION
## What & why

Adds the **quick-verdict (skim-brief)** output shape — the artifact-flexibility plan's *hero artifact*: a concise, forwardable HTML view of the same `verdict.json` for the public example gallery. ~**19 KB vs the full handoff's ~73 KB**.

Built **against the merged plan** (a sub-agent read `design/run-board-artifact-flexibility.md` first): the brief is a baseline-bundle artifact, not the deferred audience flex-axis, so building it now is in-scope; it honors the plan's invariants (lens-aware labels, dissent + blockers + confidence prominent).

### The brief contains
brand masthead · the lens-aware verdict banner · blocker **titles + one-line summaries** · a **trimmed dissent** (first dissenter + "(+N more in the full handoff)") · the **top 3 next steps** + "…N more" · disclaimer/`panely.ai` footer. It drops the per-round seat prose, evidence trails, full dissent bodies, "couldn't verify", and open questions (those stay in the full handoff).

### Mechanism
A new slim `references/quick-verdict-template.html` rendered through the **existing hardened engine**, selected with `render_verdict.py --shape quick-verdict`. `build_handoff_data` is shared (the brief references a subset of the same data). Three `qv-*`-scoped drop rules remove empty sections; they're no-ops on the full template. The inert run `--output` flag is left unwired (follow-up); `implementation-sequence` is out of scope.

### Also: confidence pill
The board's **confidence** now shows as a small pill in the verdict banner (e.g. `high confidence`), in **both** the full handoff and the brief — it was previously Markdown-only (plan invariant: confidence prominent in every tier). This is the one intentional change to the full-handoff HTML.

## Verification
- **643 tests pass** (new `TestQuickVerdictShape` + extended lens-aware tests).
- Software full-handoff **Markdown byte-identical**; software full-handoff **HTML changed only by the confidence pill**.
- Section drops (blockers/dissent/actions) exercised across ship/caution/block, empty, and split-board shapes — no leftover tokens.
- Copy chosen via a design panel; **two adversarial reviews** (0 confirmed bugs; the one surfaced gap — confidence missing from the banner — is fixed here).
- Examples gained `quick-verdict.html` **alongside** `final-consensus.*` (full record kept, not replaced).

Follow-ups: document `--shape` in SKILL.md/output-formats and curate the README "See It In Action" gallery to lead with the brief (a presentation discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)