### PR TITLE
advisory-board: render board confidence in the full-handoff HTML (D11)

### DIFF
--- a/design/run-board-artifact-flexibility.html
+++ b/design/run-board-artifact-flexibility.html
@@ -706,7 +706,7 @@ footer.colophon code { background: var(--surface-2); }
         
         <div class="testing">
           <p class="t-label">Testing strategy</p>
-          <div class="t-body"><p>golden renders of all core artifacts from one fixture. Golden assertion that dissent, blockers, and confidence are INVARIANT (D11) — the same minority report, blockers, and confidence string appear in the brief and the record across every audience and reading level, not merely present in one of them; and that the dropped seat in the ragged fixture surfaces in the brief and record bodies.</p></div>
+          <div class="t-body"><p>golden renders of all core artifacts from one fixture. Golden assertion that dissent, blockers, and confidence are INVARIANT (D11) — the same minority report, blockers, and confidence string appear in the brief and the record across every audience and reading level, not merely present in one of them; and that the dropped seat in the ragged fixture surfaces in the brief and record bodies. - PARTIAL (2026-06-27): the <strong>confidence</strong> half of this invariant has landed for the artifacts that exist today — the board confidence now renders as a verdict-banner pill in the HTML record (<code>build_handoff_data</code> → <code>references/handoff-template.html</code> <code>.vconf</code>), and <code>TestConfidenceIsProminentInEveryTier</code> (tests/test_run_board.py) pins it across lenses + the Markdown record + the short formats (tldr/pr/slack). The skim-brief / quick-verdict tier does NOT exist yet, so this box stays open: when that tier is built it MUST carry the same confidence/dissent/blockers golden assertion (the test note flags this).</p></div>
         </div>
         
         

--- a/design/run-board-artifact-flexibility.md
+++ b/design/run-board-artifact-flexibility.md
@@ -99,6 +99,7 @@ status: todo
 - [ ] The brief and the record render blockers + minority dissent PROMINENTLY (D11) — never confined to the atlas/transcript, never smoothed away by the plain-language/reading-level layer (D2/D10).
 - [ ] Every serious artifact renders dropped/degraded seats visibly (from the per-seat `dropped` field) — a 3→2 board never renders as a clean unanimous board.
 Testing: golden renders of all core artifacts from one fixture. Golden assertion that dissent, blockers, and confidence are INVARIANT (D11) — the same minority report, blockers, and confidence string appear in the brief and the record across every audience and reading level, not merely present in one of them; and that the dropped seat in the ragged fixture surfaces in the brief and record bodies.
+  - PARTIAL (2026-06-27): the **confidence** half of this invariant has landed for the artifacts that exist today — the board confidence now renders as a verdict-banner pill in the HTML record (`build_handoff_data` → `references/handoff-template.html` `.vconf`), and `TestConfidenceIsProminentInEveryTier` (tests/test_run_board.py) pins it across lenses + the Markdown record + the short formats (tldr/pr/slack). The skim-brief / quick-verdict tier does NOT exist yet, so this box stays open: when that tier is built it MUST carry the same confidence/dissent/blockers golden assertion (the test note flags this).
 Gate: `python3 -m unittest discover -s tests -t tests`
 
 ### Phase 7 — Derived share formats (after the core)

--- a/examples/payments-idempotency-review/final-consensus.html
+++ b/examples/payments-idempotency-review/final-consensus.html
@@ -77,9 +77,21 @@
     border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
     border: 1px solid transparent; border-left-width: 6px;
   }
+  .verdict .verdict-top {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; margin: 0 0 6px;
+  }
   .verdict .label {
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
-    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+    font-weight: 700; margin: 0; opacity: 0.85;
+  }
+  /* Board confidence pill — inherits the banner's ink via currentColor so it reads
+     ship/caution/block alongside the verdict. */
+  .verdict .vconf {
+    flex: 0 0 auto; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border: 1px solid currentColor; border-radius: 999px;
+    padding: 2px 10px; opacity: 0.8; white-space: nowrap;
   }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
@@ -286,7 +298,11 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict block">
-    <p class="label">Final verdict</p>
+    <div class="verdict-top">
+      <p class="label">Final verdict</p>
+      
+      <span class="vconf">high confidence</span>
+    </div>
     <p class="headline">DO NOT SHIP YET — unanimous</p>
     <p class="note"></p>
   </div>

--- a/examples/payments-idempotency-review/handoff-data.json
+++ b/examples/payments-idempotency-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "DO NOT SHIP YET — unanimous",
   "verdict_class": "block",
   "verdict_note": "",
+  "confidence": "high confidence",
   "blockers_heading": "Consensus blockers — must fix before ship",
   "disclaimer": "",
   "plan": "Payments API idempotency keys",

--- a/examples/ratelimiter-readiness-review/final-consensus.html
+++ b/examples/ratelimiter-readiness-review/final-consensus.html
@@ -77,9 +77,21 @@
     border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
     border: 1px solid transparent; border-left-width: 6px;
   }
+  .verdict .verdict-top {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; margin: 0 0 6px;
+  }
   .verdict .label {
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
-    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+    font-weight: 700; margin: 0; opacity: 0.85;
+  }
+  /* Board confidence pill — inherits the banner's ink via currentColor so it reads
+     ship/caution/block alongside the verdict. */
+  .verdict .vconf {
+    flex: 0 0 auto; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border: 1px solid currentColor; border-radius: 999px;
+    padding: 2px 10px; opacity: 0.8; white-space: nowrap;
   }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
@@ -286,7 +298,11 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict caution">
-    <p class="label">Final verdict</p>
+    <div class="verdict-top">
+      <p class="label">Final verdict</p>
+      
+      <span class="vconf">high confidence</span>
+    </div>
     <p class="headline">SHIP WITH CHANGES — unanimous</p>
     <p class="note"></p>
   </div>

--- a/examples/ratelimiter-readiness-review/handoff-data.json
+++ b/examples/ratelimiter-readiness-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "SHIP WITH CHANGES — unanimous",
   "verdict_class": "caution",
   "verdict_note": "",
+  "confidence": "high confidence",
   "blockers_heading": "Consensus blockers — must fix before ship",
   "disclaimer": "",
   "plan": "review packet",

--- a/examples/side-project-go-full-time-review/final-consensus.html
+++ b/examples/side-project-go-full-time-review/final-consensus.html
@@ -77,9 +77,21 @@
     border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
     border: 1px solid transparent; border-left-width: 6px;
   }
+  .verdict .verdict-top {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; margin: 0 0 6px;
+  }
   .verdict .label {
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
-    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+    font-weight: 700; margin: 0; opacity: 0.85;
+  }
+  /* Board confidence pill — inherits the banner's ink via currentColor so it reads
+     ship/caution/block alongside the verdict. */
+  .verdict .vconf {
+    flex: 0 0 auto; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border: 1px solid currentColor; border-radius: 999px;
+    padding: 2px 10px; opacity: 0.8; white-space: nowrap;
   }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
@@ -286,7 +298,11 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   
   <div class="verdict caution">
-    <p class="label">Final verdict</p>
+    <div class="verdict-top">
+      <p class="label">Final verdict</p>
+      
+      <span class="vconf">high confidence</span>
+    </div>
     <p class="headline">Go ahead, with conditions · unanimous</p>
     <p class="note">Workable, but address the flagged concerns before you go ahead.</p>
   </div>

--- a/examples/side-project-go-full-time-review/handoff-data.json
+++ b/examples/side-project-go-full-time-review/handoff-data.json
@@ -7,6 +7,7 @@
   "verdict": "Go ahead, with conditions · unanimous",
   "verdict_class": "caution",
   "verdict_note": "Workable, but address the flagged concerns before you go ahead.",
+  "confidence": "high confidence",
   "blockers_heading": "What to resolve first",
   "disclaimer": "An advisory board sharpens your judgment; it doesn&#x27;t replace professional advice where your decision warrants it.",
   "plan": "Should I go full-time on my side project?",

--- a/skills/advisory-board/references/handoff-template.html
+++ b/skills/advisory-board/references/handoff-template.html
@@ -50,6 +50,10 @@
                      unanimous"), or the board's authored decision verbatim.
   {{VERDICT_CLASS}}  One of: ship | caution | block  (colors the banner).
   {{VERDICT_NOTE}}   One-line explanation under the verdict headline.
+  {{CONFIDENCE}}     Board confidence in the call, e.g. "high confidence" — shown as a
+                     pill on the verdict-banner eyebrow row (D11: confidence is prominent
+                     in every tier). OPTIONAL: empty when confidence wasn't tracked, and
+                     the pill is dropped.
   {{BLOCKERS_HEADING}}  Consensus-section header, lens-aware: "Consensus blockers —
                      must fix before ship" (software) or "What to resolve first" (else).
   {{DISCLAIMER}}     OPTIONAL lens-aware professional-advice caveat (subtle footer
@@ -136,9 +140,21 @@
     border-radius: 12px; padding: 22px 24px; margin: 4px 0 32px;
     border: 1px solid transparent; border-left-width: 6px;
   }
+  .verdict .verdict-top {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; margin: 0 0 6px;
+  }
   .verdict .label {
     font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase;
-    font-weight: 700; margin: 0 0 6px; opacity: 0.85;
+    font-weight: 700; margin: 0; opacity: 0.85;
+  }
+  /* Board confidence pill — inherits the banner's ink via currentColor so it reads
+     ship/caution/block alongside the verdict. */
+  .verdict .vconf {
+    flex: 0 0 auto; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border: 1px solid currentColor; border-radius: 999px;
+    padding: 2px 10px; opacity: 0.8; white-space: nowrap;
   }
   .verdict .headline { font-size: 23px; font-weight: 700; margin: 0; line-height: 1.25; }
   .verdict .note { margin: 10px 0 0; font-size: 15.5px; line-height: 1.55; }
@@ -345,7 +361,11 @@
   <!-- ===================== VERDICT BANNER ===================== -->
   <!-- {{VERDICT_CLASS}} = ship | caution | block  (controls color) -->
   <div class="verdict {{VERDICT_CLASS}}">
-    <p class="label">Final verdict</p>
+    <div class="verdict-top">
+      <p class="label">Final verdict</p>
+      <!-- OPTIONAL board-confidence pill (D11). Dropped when {{CONFIDENCE}} is empty. -->
+      <span class="vconf">{{CONFIDENCE}}</span>
+    </div>
     <p class="headline">{{VERDICT}}</p>
     <p class="note">{{VERDICT_NOTE}}</p>
   </div>

--- a/skills/advisory-board/scripts/render_handoff.py
+++ b/skills/advisory-board/scripts/render_handoff.py
@@ -18,8 +18,8 @@ Standard library only; no third-party dependencies.
 handoff-data.json shape (keys mirror the template's {{TOKENS}}, lowercased):
 
   Top level (scalars):  title, subtitle, date, board, rounds, verdict,
-                        verdict_class, verdict_note, blockers_heading, disclaimer,
-                        plan, metadata, dissent_flag
+                        verdict_class, verdict_note, confidence, blockers_heading,
+                        disclaimer, plan, metadata, dissent_flag
   Lists of objects:     seats[], blockers[], dissents[], caveats[],
                         questions[], actions[]
     seats[]:   seat_name, seat_lens, seat_model, seat_status, seat_status_class,
@@ -85,6 +85,7 @@ def drop_empty_optionals(out: str) -> str:
     out = re.sub(r'\s*<span class="seat-status\s*">\s*</span>', "", out)
     out = re.sub(r'\s*<div class="highlight">\s*</div>', "", out)
     out = re.sub(r'\s*<span class="conf">confidence:\s*</span>', "", out)
+    out = re.sub(r'\s*<span class="vconf">\s*</span>', "", out)
     out = re.sub(r'\s*<span class="disclaimer">\s*</span>', "", out)
     return out
 

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -299,6 +299,11 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     headline = f"{lead} · {_stance(data)}" if lead else f"{label} — {_stance(data)}"
     # An explicit verdict_note (authored) wins; else the plain lens note.
     verdict_note = data.get("verdict_note") or note
+    # Board confidence rides on the verdict banner as a pill (D11: confidence is prominent
+    # in every artifact tier, not just the Markdown verdict line). The raw token
+    # (high|medium|low) is preserved verbatim inside a plain "<level> confidence" string;
+    # empty when the board didn't track it, so the pill is dropped (render_handoff).
+    confidence = str(data.get("confidence") or "").strip()
     # The subtle, lens-aware professional-advice caveat (None for a software lens and
     # the absent-preset default). Empty string when absent so the template slot resolves
     # to nothing and the footer line is dropped.
@@ -325,6 +330,7 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
         "verdict": _plain(headline),
         "verdict_class": _VERDICT_CLASS.get(verdict, ""),
         "verdict_note": _raw(verdict_note) if verdict_note else "",
+        "confidence": _plain(f"{confidence} confidence") if confidence else "",
         # Lens-aware section header for the consensus must-resolve items.
         "blockers_heading": _plain(blockers_heading(lens_preset, "html")),
         "disclaimer": _raw(disclaimer) if disclaimer else "",

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3672,6 +3672,63 @@ class TestLensAwareFraming(unittest.TestCase):
         self.assertEqual(sw["blockers_heading"], "Consensus blockers — must fix before ship")
 
 
+class TestConfidenceIsProminentInEveryTier(unittest.TestCase):
+    """D11 invariant: the board's confidence renders PROMINENTLY in every artifact tier,
+    regardless of audience/lens, and is never smoothed away by the plain-language layer.
+
+    The verdict.json `confidence` was already surfaced in the Markdown verdict line, but
+    `build_handoff_data` used to drop it before the HTML — so the full-handoff *record*
+    showed no board-level confidence at all. These golden assertions pin it back in.
+
+    NOTE: the full handoff is currently the only rendered HTML tier. When a skim-brief /
+    quick-verdict tier is added, it MUST carry the same golden assertion — D11 line 101:
+    "the same minority report, blockers, and confidence string appear in the brief and
+    the record." The brief cannot satisfy that until the record does (here)."""
+
+    def _html(self, data):
+        import render_handoff as rh
+        with open(rh.default_template()) as fh:
+            template = fh.read()
+        return rh.render(rv.build_handoff_data(data), template)
+
+    def test_build_handoff_data_threads_confidence(self):
+        # The raw token (high|medium|low) is preserved verbatim inside a plain
+        # "<level> confidence" string — D11's machine token is not smoothed away.
+        for level in ("high", "medium", "low"):
+            hd = rv.build_handoff_data(_verdict("ship", "ship", "ship", confidence=level))
+            self.assertEqual(hd["confidence"], f"{level} confidence")
+
+    def test_full_handoff_html_shows_confidence_for_every_lens(self):
+        # The confidence string survives into the rendered record under a software, a
+        # non-software, a legal, and an absent lens — the invariant is audience-independent.
+        for lens in ("software-architecture", "business-decision", "legal-contract", None):
+            data = _verdict("caution", "caution", "caution", title="T",
+                            lens_preset=lens, confidence="medium")
+            html_out = self._html(data)
+            self.assertIn('class="vconf"', html_out)         # the prominent banner pill
+            self.assertIn("medium confidence", html_out)     # the human string
+
+    def test_confidence_string_is_invariant_across_tiers(self):
+        # D11 line 101: "the same … confidence string appear[s] in the brief and the
+        # record." The skim/quick-verdict tier doesn't exist yet, but the de-facto skim
+        # surfaces today are the short formats (tldr/pr/slack) — pin that they, the
+        # Markdown record, and the HTML record all carry the SAME "low confidence" string.
+        data = _verdict("block", "block", "block", confidence="low")
+        self.assertIn("(low confidence)", rv.render_markdown(data))   # Markdown record
+        self.assertIn("low confidence", self._html(data))             # HTML record (pill)
+        for short in (fo.as_tldr(data), fo.as_pr(data), fo.as_slack(data)):
+            self.assertIn("low confidence", short)                    # skim surfaces
+
+    def test_confidence_pill_dropped_when_untracked(self):
+        # A verdict.json with no confidence renders no empty pill (clean drop, not blank) —
+        # the eyebrow itself is untouched, preserving the software byte-for-byte path.
+        data = {"verdict": "ship", "title": "Legacy", "board": [{"seat": "Claude"}], "rounds": 1}
+        self.assertEqual(rv.build_handoff_data(data)["confidence"], "")
+        html_out = self._html(data)
+        self.assertNotIn('<span class="vconf">', html_out)
+        self.assertIn('<p class="label">Final verdict</p>', html_out)
+
+
 class TestM5ChainDelegation(EnvMixin):
     def _stage(self):
         d = tempfile.mkdtemp()


### PR DESCRIPTION
## What & why

The board's `confidence` (from `verdict.json`) was carried in the Markdown verdict line and the short formats, but **dropped before the HTML record** — `build_handoff_data` never threaded it, and the handoff template had no board-level confidence element (only an unused per-round chip). Plan invariant **D11** requires confidence to be PROMINENT in *every* artifact tier; the rendered record (`final-consensus.html`) showed none. This closes that gap for the tier that exists today (the full-handoff record).

> Note: the task that motivated this referenced a `quick-verdict` template/examples/test that **don't exist** in the repo (the skim-brief tier is an inert `--output` choice + a planned design item). So this fixes the real, present D11 gap in the artifact that ships. Building the quick-verdict tier is tracked as follow-up.

## Changes
- **`render_verdict.py`** — `build_handoff_data` threads `confidence` into handoff-data as `"<level> confidence"` (raw `high|medium|low` preserved verbatim; `""` when untracked).
- **`handoff-template.html`** — a confidence pill on the verdict-banner eyebrow row, border keyed to the banner ink via `currentColor` (reads ship/caution/block). Wrapped in `.verdict-top` so `<p class="label">Final verdict</p>` stays byte-identical (two existing tests depend on it).
- **`render_handoff.py`** — drop rule so an untracked-confidence run renders no empty pill. Software-lens / absent-confidence path unchanged.
- **tests** — `TestConfidenceIsProminentInEveryTier`: the confidence string is invariant across software/business/legal/absent lenses and across the Markdown record, HTML record, and short formats (tldr/pr/slack), and drops cleanly when untracked.
- Regenerated the 3 committed examples (only diff is the chip) + the design-doc HTML view; added a Phase-6 breadcrumb.

## Verification
- **628 tests pass.**
- Byte-diff confirmed: regenerating the examples produces only the confidence chip.
- Two adversarial reviewers (regression + design-completeness) found no blocking bugs; their cheap suggestions are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
