### PR TITLE
advisory-board: drop confidence clause cleanly when untracked (MD + short formats)

### DIFF
--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -45,7 +45,11 @@ def verdict_line(data: dict) -> str:
     # doesn't become a shouted "STOP AND RETHINK".
     if data.get("decision") or is_software_lens(lens_preset):
         label = label.upper()
-    return f"{label} ({data.get('confidence', '?')} confidence, {stance})"
+    # Drop the confidence clause when untracked (matching the HTML clean-drop), keeping the
+    # stance — never emit a literal "? confidence".
+    confidence = data.get("confidence")
+    inner = f"{confidence} confidence, {stance}" if confidence else stance
+    return f"{label} ({inner})"
 
 
 def _disclaimer(data: dict):

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -131,7 +131,11 @@ def render_markdown(data: dict) -> str:
     out.append("")
 
     label, note = human_label(data.get("verdict"), data.get("lens_preset"), data.get("decision"))
-    out.append(f"## Verdict: {label} — {_stance(data)} ({data.get('confidence', '?')} confidence)")
+    # The confidence clause is dropped entirely when confidence is untracked — matching the
+    # HTML handoff's clean-drop of the pill — rather than emitting a literal "? confidence".
+    confidence = data.get("confidence")
+    conf_clause = f" ({confidence} confidence)" if confidence else ""
+    out.append(f"## Verdict: {label} — {_stance(data)}{conf_clause}")
     # Lead with the plain should-I/shouldn't-I answer on a non-software lens. The heading
     # keeps the calibrated label (the machine-friendly anchor); this bold line answers
     # the reader's actual question. Suppressed when the board authored its own

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3689,6 +3689,57 @@ class TestLensAwareFraming(unittest.TestCase):
         self.assertEqual(rv.build_handoff_data(data)["confidence"], "")
 
 
+class TestConfidenceIsProminentInEveryTier(unittest.TestCase):
+    """Plan invariant: the board confidence is shown wherever a tier carries a verdict
+    line — and when it is *untracked* every tier drops the clause cleanly, never emitting
+    a literal "? confidence" (the HTML handoff already drops its pill cleanly; this keeps
+    Markdown and the short formats consistent with it)."""
+
+    def _tracked(self, **extra):
+        return _verdict("caution", "caution", "caution", title="Should I do X?",
+                        lens_preset="business-decision",
+                        blockers=[{"title": "Money", "body": "Numbers don't close."}],
+                        **extra)
+
+    def _untracked(self, **extra):
+        data = self._tracked(**extra)
+        del data["confidence"]  # _verdict seeds confidence="high"; model the absent case
+        return data
+
+    # --- tracked: confidence rides every tier ------------------------------ #
+
+    def test_markdown_shows_confidence_when_tracked(self):
+        self.assertIn("(high confidence)", rv.render_markdown(self._tracked()))
+
+    def test_short_formats_show_confidence_when_tracked(self):
+        line = fo.verdict_line(self._tracked())
+        self.assertIn("high confidence", line)
+        self.assertIn("split board", line)  # stance still rides alongside
+        for text in (fo.as_tldr(self._tracked()), fo.as_pr(self._tracked()),
+                     fo.as_slack(self._tracked())):
+            self.assertIn("high confidence", text)
+
+    # --- untracked: the clause is dropped cleanly in every tier ------------ #
+
+    def test_markdown_drops_confidence_clause_when_untracked(self):
+        md = rv.render_markdown(self._untracked())
+        self.assertNotIn("confidence", md)
+        self.assertNotIn("? confidence", md)
+        verdict_line = next(ln for ln in md.splitlines() if ln.startswith("## Verdict:"))
+        self.assertNotIn("(", verdict_line)  # no trailing "(... confidence)" parenthetical
+
+    def test_short_formats_drop_confidence_clause_when_untracked(self):
+        line = fo.verdict_line(self._untracked())
+        self.assertNotIn("confidence", line)
+        self.assertNotIn("?", line)
+        self.assertIn("split board", line)        # stance survives the drop
+        self.assertEqual(line.count("("), 1)      # only the (stance) parenthetical remains
+        for text in (fo.as_tldr(self._untracked()), fo.as_pr(self._untracked()),
+                     fo.as_slack(self._untracked())):
+            self.assertNotIn("confidence", text)
+            self.assertNotIn("? confidence", text)
+
+
 class TestQuickVerdictShape(unittest.TestCase):
     """v1.8.x: the "quick-verdict" (skim-brief) HTML shape — the verdict banner, the
     must-resolve items as one-liners, a one-line dissent flag, and the next steps. Same


### PR DESCRIPTION
## What

When a `verdict.json` has **no `confidence` field**, the artifact tiers rendered the absent case inconsistently:

- The **HTML full-handoff** already drops the confidence pill cleanly (the D11 fix).
- The **Markdown** verdict line still printed a literal `(? confidence)`.
- The **short formats** (tldr/pr/slack) via `verdict_line()` likewise emitted `? confidence`.

This makes Markdown + the short formats match the HTML's clean-drop: omit the confidence clause entirely when it's untracked, rather than render a placeholder.

## Changes

- `scripts/render_verdict.py` — `render_markdown`: only append `(… confidence)` when confidence is present.
- `scripts/format_output.py` — `verdict_line`: drop the `X confidence,` portion when absent, **keep the `(stance)`** (so a short line stays `LABEL (split board)`, never `LABEL (? confidence, split board)`).
- `tests/test_run_board.py` — new `TestConfidenceIsProminentInEveryTier`: confidence still rides every tier when tracked, and is dropped cleanly across Markdown + short formats when untracked (no `? confidence` leak; stance survives).

Behavior when present is unchanged. `board_verdict.py`'s internal CLI summary was deliberately left alone — it runs only on `validate()`'d data where `confidence` is required, so it can't hit the absent case.

## Verification

- Two-skeptic adversarial review (completeness sweep + correctness/edge-case): 0 real bugs.
- `cd skills/advisory-board && python3 -m unittest discover -s tests -t tests` → **647 OK** (up from 643).

🤖 Generated with [Claude Code](https://claude.com/claude-code)