### PR TITLE
advisory-board: document --shape + stop the brief render from littering final-consensus.md

### DIFF
--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -125,7 +125,7 @@ Write:
 - `round-1/<seat>.md` (and `round-2/`, `round-3/` as rounds run)
 - `board-packet-round-2.md` (and `board-packet-round-3.md` when needed)
 - `final-consensus.md` — the handoff in Markdown
-- `final-consensus.html` — a self-contained, human-readable view of the handoff. Render it deterministically with `scripts/render_handoff.py` from a `handoff-data.json` (recommended — guarantees no leftover placeholders or template drift), or fill `references/handoff-template.html` by hand
+- `final-consensus.html` — a self-contained, human-readable view of the handoff. Render it deterministically with `scripts/render_handoff.py` from a `handoff-data.json` (recommended — guarantees no leftover placeholders or template drift), or fill `references/handoff-template.html` by hand. Choose the **shape** with `scripts/render_verdict.py --html … --shape full-handoff` (default — the complete record) or `--shape quick-verdict` (a slim skim brief to lead with); see `references/output-formats.md`
 - `verdict.json` — the machine-readable verdict (`references/verdict-schema.md`); gate or reformat it with `scripts/`
 - `run-metadata.md` — provenance: commands, the model that actually answered per seat, auth mode (no secrets), per-seat status (ran / degraded / dropped), timings, and source paths. Use `references/run-metadata-template.md`.
 

--- a/skills/advisory-board/references/output-formats.md
+++ b/skills/advisory-board/references/output-formats.md
@@ -2,6 +2,19 @@
 
 The Markdown + HTML handoff is the default deliverable. From the same run you can derive lighter formats for where the decision actually gets read — without re-running the board.
 
+## HTML shapes (`--shape`)
+
+`scripts/render_verdict.py` renders the self-contained HTML handoff from `verdict.json`. The same `verdict.json` gives you two shapes — pick by how the reader will use it:
+
+| Shape | Command | For |
+| ----- | ------- | --- |
+| `full-handoff` (default) | `render_verdict.py verdict.json --run <run-dir> -o final-consensus.md --handoff-data handoff-data.json --html final-consensus.html` | The complete record — verdict banner, consensus blockers, per-round seat reviews, dissent, what the board couldn't verify, open questions, next steps. The deliverable you archive. |
+| `quick-verdict` | `render_verdict.py verdict.json --run <run-dir> --html quick-verdict.html --shape quick-verdict` | A skim brief, roughly a quarter the size — masthead, verdict banner, blocker one-liners, trimmed dissent, top next steps. The teaser you lead with; link the full handoff from it. |
+
+Both render from the same `verdict.json` (plus the optional `--run <run-dir>` for per-round prose), so the two shapes never disagree. `--shape` defaults to `full-handoff` and only affects the `--html` output.
+
+> The intake menu (SKILL.md "Upfront Choices") also lists an **implementation sequence** framing. That isn't a distinct `--shape` yet — selecting it renders the full handoff for now.
+
 ## Derived from `verdict.json` (deterministic)
 
 `scripts/format_output.py` turns `verdict.json` (see `references/verdict-schema.md`) into:

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -443,7 +443,9 @@ def _render_html(hd: dict, shape: str = "full-handoff") -> str:
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="Render final-consensus.md / handoff-data.json / HTML from verdict.json.")
     parser.add_argument("path", help="path to verdict.json")
-    parser.add_argument("-o", "--out", default="final-consensus.md", help="Markdown output path (default: final-consensus.md)")
+    parser.add_argument("-o", "--out", default=None,
+                        help="Markdown output path. Written when given, or — when no --html/--handoff-data is "
+                             "requested — defaults to final-consensus.md. Pass --html alone to render only the HTML.")
     parser.add_argument("--check", action="store_true", help="print Markdown to stdout; write nothing")
     parser.add_argument("--handoff-data", dest="handoff_data", help="also write a derived handoff-data.json here")
     parser.add_argument("--html", help="also write final-consensus.html here (via render_handoff.py)")
@@ -455,12 +457,17 @@ def main(argv=None) -> int:
     data = load(args.path)
     markdown = render_markdown(data)
 
+    # The Markdown is the implicit default deliverable: write it when --out is given, or
+    # when no other output (--html / --handoff-data) was requested. Asking only for the
+    # HTML brief (e.g. --html quick-verdict.html --shape quick-verdict) no longer litters
+    # a stray final-consensus.md.
     if args.check:
         sys.stdout.write(markdown)
-    else:
-        with open(args.out, "w", encoding="utf-8") as handle:
+    elif args.out is not None or not (args.html or args.handoff_data):
+        out_path = args.out or "final-consensus.md"
+        with open(out_path, "w", encoding="utf-8") as handle:
             handle.write(markdown)
-        print(f"wrote {args.out} ({len(markdown)} bytes)")
+        print(f"wrote {out_path} ({len(markdown)} bytes)")
 
     if args.handoff_data or args.html:
         hd = build_handoff_data(data, run_dir=args.run_dir)

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3923,6 +3923,35 @@ class TestQuickVerdictShape(unittest.TestCase):
         self.assertNotIn("Board reviews — round by round", slim_html)
         self.assertIn("Board reviews — round by round", full_html)
 
+    def test_html_only_writes_no_stray_markdown(self):
+        # Rendering just the brief (--html, no -o) must NOT litter a default
+        # final-consensus.md — you get only the HTML you asked for.
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        vpath = os.path.join(d, "verdict.json")
+        with open(vpath, "w") as fh:
+            json.dump(self._caution(), fh)
+        slim = os.path.join(d, "quick-verdict.html")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rv.main([vpath, "--html", slim, "--shape", "quick-verdict"])
+        self.assertTrue(os.path.exists(slim))
+        self.assertFalse(os.path.exists(os.path.join(d, "final-consensus.md")))
+
+    def test_markdown_is_default_deliverable_when_no_other_output(self):
+        # With no --html/--handoff-data and no -o, the Markdown still lands at the
+        # default path (the implicit default deliverable is preserved).
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        vpath = os.path.join(d, "verdict.json")
+        with open(vpath, "w") as fh:
+            json.dump(self._caution(), fh)
+        cwd = os.getcwd()
+        os.chdir(d)
+        self.addCleanup(lambda: os.chdir(cwd))
+        with contextlib.redirect_stdout(io.StringIO()):
+            rv.main([vpath])
+        self.assertTrue(os.path.exists(os.path.join(d, "final-consensus.md")))
+
     # --- brace safety ------------------------------------------------------- #
 
     def test_qv_brace_safe_blocker_title(self):


### PR DESCRIPTION
## What

Two tightly-coupled cleanups around the `quick-verdict` brief that shipped in v1.8.0:

**1. Document `--shape`.** The brief became a real renderable artifact (`render_verdict.py --shape quick-verdict`), but nothing documented it.
- `references/output-formats.md` — new **HTML shapes (`--shape`)** section: `full-handoff` (default) vs `quick-verdict`, the exact commands, and an honest note that the intake menu's *implementation sequence* framing isn't a distinct shape yet (it renders the full handoff).
- `SKILL.md` — the `final-consensus.html` artifact line now points at `--shape`.

**2. Stop the brief command from littering `final-consensus.md`.** `--out` defaulted to `final-consensus.md` and the Markdown was *always* written — so `render_verdict.py verdict.json --html quick-verdict.html --shape quick-verdict` left a stray `final-consensus.md`. (The handoff had documented a manual "delete the stray" workaround.)
- `render_verdict.py` — `--out` now defaults to `None`; the Markdown is written when `--out` is given **or** when no `--html`/`--handoff-data` was requested (the implicit default deliverable is preserved). Rendering only the HTML no longer writes a stray.

## Why it's safe

- The run flow always passes `-o` explicitly (`_conductor/cli.py:379,457`), so no caller relied on `--html` implicitly producing the markdown.
- Existing `--shape` tests already pass `-o` explicitly; none depended on the old always-write behavior.

## Tests

- New: brief-only render writes **no** stray markdown; the no-flag default **still** writes `final-consensus.md`.
- `cd skills/advisory-board && python3 -m unittest discover -s tests -t tests` → **649 OK**.
- Verified live: the relocation gallery run rendered full + brief with no stray file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)