### PR TITLE
advisory-board: default the Claude seat to Fable 5 at max effort

### DIFF
--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -44,7 +44,7 @@ If the user says "use defaults", stop asking the *optional* setup questions and 
 
 Target the strongest reasoning model each provider offers:
 
-- Claude seat: `claude-opus-4-8` at the highest available reasoning/effort.
+- Claude seat: `claude-fable-5` (Anthropic's most capable model) at max effort — `--effort max`. Fable 5 is a premium tier (priced above Opus) and max effort means longer, costlier runs; swap it with `--model claude=<id>` if cost matters more than depth.
 - Codex seat: `gpt-5.5` with `model_reasoning_effort="xhigh"` (or the highest Codex reasoning setting available).
 - Gemini seat: Google's latest frontier reasoning model via the Gemini CLI (currently Gemini 3.1 Pro) with `thinkingLevel: HIGH` (or the highest available).
 
@@ -157,10 +157,10 @@ Prefer read-only modes. Confirm every flag against the installed CLI (`<cli> --h
 Claude seat:
 
 ```
-claude -p "<seat prompt>" --model claude-opus-4-8 --permission-mode plan
+claude -p "<seat prompt>" --model claude-fable-5 --effort max --permission-mode plan
 ```
 
-`-p` runs non-interactively; `--permission-mode plan` keeps it read-only. Use the strongest reasoning/effort the build exposes (Claude Code defaults to `xhigh`). On long analytic prompts, `--permission-mode plan` can make the seat return a plan-style *summary* (and even claim it wrote a file) instead of the full review — so append the `{{CLAUDE_OUTPUT_OVERRIDE}}` block from `references/prompt-templates.md` verbatim to the Claude seat's prompt, and treat a short or plan-shaped artifact as a degraded seat to re-run.
+`-p` runs non-interactively; `--permission-mode plan` keeps it read-only. `--effort max` runs the deepest reasoning the build exposes (the flag accepts `low|medium|high|xhigh|max`; on Fable 5 thinking is always-on and effort scales how hard it thinks). On long analytic prompts, `--permission-mode plan` can make the seat return a plan-style *summary* (and even claim it wrote a file) instead of the full review — so append the `{{CLAUDE_OUTPUT_OVERRIDE}}` block from `references/prompt-templates.md` verbatim to the Claude seat's prompt, and treat a short or plan-shaped artifact as a degraded seat to re-run.
 
 Codex seat:
 

--- a/skills/advisory-board/references/run-metadata-template.md
+++ b/skills/advisory-board/references/run-metadata-template.md
@@ -13,7 +13,7 @@ Lens preset: <preset, or "custom">
 
 | Seat   | Lens          | Model requested | Model that answered | Reasoning/effort | Auth mode    | Status            |
 | ------ | ------------- | --------------- | ------------------- | ---------------- | ------------ | ----------------- |
-| Claude | architecture  | claude-opus-4-8 | <id returned>       | xhigh            | subscription | ran               |
+| Claude | architecture  | claude-fable-5  | <id returned>       | max              | subscription | ran               |
 | Codex  | impl/testing  | gpt-5.5         | <id returned>       | xhigh            | subscription | ran               |
 | Gemini | product/ops   | <model>         | <id returned>       | HIGH             | subscription | dropped @ round 2 |
 

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -21,7 +21,7 @@ via `scripts/render_handoff.py`. It drives tooling — most usefully a **CI / la
   "board": [
     {
       "seat": "Claude",
-      "model": "claude-opus-4-8",
+      "model": "claude-fable-5",
       "lens": "architecture",
       "round_verdicts": ["block", "block"],
       "dropped": false

--- a/skills/advisory-board/scripts/_conductor/config.py
+++ b/skills/advisory-board/scripts/_conductor/config.py
@@ -181,11 +181,13 @@ def assign_seat_ids(seat_specs: list) -> list:
 
 
 def resolve_board(seat_specs: list, lens_preset: str, model_overrides: dict,
-                  lens_overrides: Optional[dict] = None) -> list:
+                  lens_overrides: Optional[dict] = None,
+                  reasoning_overrides: Optional[dict] = None) -> list:
     lenses = LENS_PRESETS.get(lens_preset)
     if lenses is None:
         die(f"unknown lens preset {lens_preset!r}; choose from {', '.join(sorted(LENS_PRESETS))}")
     lens_overrides = lens_overrides or {}
+    reasoning_overrides = reasoning_overrides or {}
     ids = assign_seat_ids(seat_specs)
     # Uniqueness guard — replaces today's SILENT collapse of two same-named seats with a
     # loud failure. Only reachable when a user aliases two seats identically (auto-numbering
@@ -219,7 +221,9 @@ def resolve_board(seat_specs: list, lens_preset: str, model_overrides: dict,
             # so `--model claude=…` still works for a single-Claude board.
             model=model_overrides.get(sid, adapter.default_model),
             lens=lens,
-            reasoning=adapter.default_reasoning,
+            # Reasoning has no CLI flag today; the only per-seat source is a recipe
+            # (recorded reasoning restored on --from-recipe), else the registry default.
+            reasoning=reasoning_overrides.get(sid, adapter.default_reasoning),
         ))
     return board
 
@@ -241,6 +245,7 @@ def resolve_config(args) -> RunConfig:
         base = None
 
     lens_overrides: dict = {}
+    reasoning_overrides: dict = {}
     if base is not None and not getattr(args, "source", None):
         source = load_source(base["source_ref"])
         # Reconstruct the exact board from the recipe. Each entry's "seat" is the seat id
@@ -259,6 +264,8 @@ def resolve_config(args) -> RunConfig:
             model_overrides.setdefault(sid, entry["model"])
             if entry.get("lens"):
                 lens_overrides.setdefault(sid, entry["lens"])
+            if entry.get("reasoning"):
+                reasoning_overrides.setdefault(sid, entry["reasoning"])
         lens_preset = base.get("lens", DEFAULT_LENS)
     else:
         if not getattr(args, "source", None):
@@ -268,7 +275,8 @@ def resolve_config(args) -> RunConfig:
         board_preset, lens_overrides = parse_lens_args(getattr(args, "lens", None))
         lens_preset = board_preset or (base or {}).get("lens", DEFAULT_LENS)
 
-    board = resolve_board(seat_specs, lens_preset, model_overrides, lens_overrides)
+    board = resolve_board(seat_specs, lens_preset, model_overrides, lens_overrides,
+                          reasoning_overrides)
 
     mode = getattr(args, "mode", None) or (base or {}).get("mode") or "gate"
     if mode not in ("gate", "advisory"):

--- a/skills/advisory-board/scripts/_conductor/registry.py
+++ b/skills/advisory-board/scripts/_conductor/registry.py
@@ -148,13 +148,18 @@ def parse_model_answered(stdout: str, stderr: str) -> Optional[str]:
 # until M3+, and a silently-ignored flag is a worse footgun than its absence.
 
 
-def claude_argv(model, prompt, *, reasoning="xhigh", workdir=None, network=False, grounded=False):
+def claude_argv(model, prompt, *, reasoning="max", workdir=None, network=False, grounded=False):
     # claude -p reads the prompt from stdin; plan mode is read-only. fs scoping is
     # the subprocess cwd (applied at spawn), since claude has no dir-scoping flag.
     # `grounded` is accepted for a uniform signature: claude reads the repo via its
     # cwd (the snapshot, set at spawn) with no flag to change, so its argv is the
     # same grounded or not.
-    argv = ["claude", "-p", "--model", model, "--permission-mode", "plan"]
+    # --effort sets the session's reasoning depth (levels low|medium|high|xhigh|max,
+    # verified on claude 2.1.191). The board forwards the seat's reasoning here so the
+    # Claude seat actually runs at its configured effort (default "max"). On Fable 5
+    # thinking is always-on and effort scales how hard it thinks.
+    argv = ["claude", "-p", "--model", model, "--effort", reasoning,
+            "--permission-mode", "plan"]
     if not network:
         # Cut the seat's network reach in gate mode. Note: NOT --bare, which would
         # force ANTHROPIC_API_KEY auth and break subscription/OAuth login.
@@ -389,9 +394,12 @@ def model_not_found(result: "SpawnResult", *, include_stdout: bool = False) -> b
 REGISTRY: dict = {
     "claude": SeatAdapter(
         name="claude",
-        default_model="claude-opus-4-8",
+        # Fable 5 is Anthropic's most capable model; the board runs it at max effort
+        # (on Fable 5 thinking is always-on, so effort scales how hard it thinks).
+        # Pinned inline per the model-id policy; Anthropic ids are stable.
+        default_model="claude-fable-5",
         provider="Anthropic",
-        default_reasoning="xhigh",
+        default_reasoning="max",   # forwarded via --effort; deepest level the CLI exposes
         build_argv=claude_argv,
         version_argv=claude_version,
         prompt_on_stdin=True,
@@ -406,7 +414,7 @@ REGISTRY: dict = {
         install_argv=claude_install_argv,
         auth_hint="run `claude` once and sign in (Claude subscription, or set ANTHROPIC_API_KEY)",
         pkg_label="npm @anthropic-ai/claude-code",
-        flags_verified_version="2.1.177",
+        flags_verified_version="2.1.191",   # --model/--effort/--permission-mode plan verified here
         fallback_models=(),   # Anthropic ids are stable; pin the current one, no guesses
     ),
     "codex": SeatAdapter(

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -106,19 +106,31 @@ class TestRegistry(unittest.TestCase):
 
     def test_claude_gate_isolation_flags(self):
         a = rb.REGISTRY["claude"]
-        argv = a.build_argv("claude-opus-4-8", "PROMPT", reasoning="xhigh", network=False)
+        argv = a.build_argv("claude-fable-5", "PROMPT", reasoning="xhigh", network=False)
         self.assertIn("--permission-mode", argv)
         self.assertIn("plan", argv)
         self.assertIn("--disallowed-tools", argv)
         self.assertIn("WebSearch", argv)
         self.assertIn("WebFetch", argv)
-        self.assertIn("claude-opus-4-8", argv)
+        self.assertIn("claude-fable-5", argv)
+        self.assertEqual(argv[argv.index("--effort") + 1], "xhigh")  # reasoning forwarded
         self.assertNotIn("--bare", argv)  # --bare would break subscription auth
+
+    def test_claude_default_model_and_max_effort(self):
+        # The Claude seat runs Fable 5 at max effort, forwarded via the claude CLI's
+        # --effort flag (the deepest level it exposes).
+        a = rb.REGISTRY["claude"]
+        self.assertEqual(a.default_model, "claude-fable-5")
+        self.assertEqual(a.default_reasoning, "max")
+        argv = a.build_argv(a.default_model, "PROMPT", reasoning=a.default_reasoning, network=False)
+        self.assertEqual(argv[argv.index("--effort") + 1], "max")
+        self.assertIn("claude-fable-5", argv)
 
     def test_claude_advisory_allows_network(self):
         a = rb.REGISTRY["claude"]
-        argv = a.build_argv("claude-opus-4-8", "PROMPT", network=True)
+        argv = a.build_argv("claude-fable-5", "PROMPT", network=True)
         self.assertNotIn("--disallowed-tools", argv)
+        self.assertIn("--effort", argv)  # effort is forwarded in advisory mode too
 
     def test_codex_gate_isolation_flags(self):
         a = rb.REGISTRY["codex"]
@@ -262,7 +274,7 @@ class TestConfig(EnvMixin):
         c = _config(model=["codex=gpt-5.6"])
         models = {s.name: s.model for s in c.board}
         self.assertEqual(models["codex"], "gpt-5.6")
-        self.assertEqual(models["claude"], "claude-opus-4-8")
+        self.assertEqual(models["claude"], "claude-fable-5")
 
     def test_board_subset(self):
         c = _config(board="claude,gemini")
@@ -447,6 +459,22 @@ class TestSeatComposition(unittest.TestCase):
         self.assertEqual(by_id["risk"].model, "claude-opus-4-7")      # per-seat model reproduced
         self.assertEqual(by_id["econ"].name, "claude")                # provider restored from registry
         self.assertEqual(by_id["exec"].name, "codex")
+
+    def test_recipe_restores_recorded_reasoning(self):
+        # Reasoning is part of the reproducibility contract: a recipe recorded at one
+        # effort must replay at that effort even if the registry default later changes
+        # (regression guard — replay used to re-pull reasoning from the live registry).
+        c = resolve_config(_args(source=SAMPLE, board="claude,codex"))
+        recipe = rb.config_to_recipe(c)
+        for entry in recipe["board"]:
+            if entry["seat"] == "claude":
+                entry["reasoning"] = "high"   # a non-default effort, pinned in the recipe
+        path = os.path.join(tempfile.mkdtemp(prefix="board-rz-"), "run-recipe.yaml")
+        with open(path, "w") as fh:
+            fh.write(rb.dump_recipe(recipe))
+        restored = rb.resolve_config(_args(source=None, from_recipe=path))
+        by_id = {s.id: s for s in restored.board}
+        self.assertEqual(by_id["claude"].reasoning, "high")   # recorded value, not the registry default
 
     def test_recipe_round_trips_auto_numbered_duplicates(self):
         restored = self._round_trip(board="claude,claude,codex")
@@ -777,7 +805,7 @@ class TestRunFlow(EnvMixin):
             raw = fh.read()
         self.assertIn("packet-hash", raw)
         self.assertIn("source-hash", raw)
-        self.assertIn("model-answered  : claude-opus-4-8", raw)
+        self.assertIn("model-answered  : claude-fable-5", raw)
 
     def test_preflight_gates_before_egress(self):
         # Two seats down -> NO-GO -> must stop BEFORE writing any egress manifest,
@@ -1687,7 +1715,7 @@ class TestRound1FanOut(EnvMixin):
         self.assertTrue(all(r.usable for r in results))
         self.assertTrue(all(r.attempts == 1 for r in results))
         answered = {r.seat: r.model_answered for r in results}
-        self.assertEqual(answered["claude"], "claude-opus-4-8")
+        self.assertEqual(answered["claude"], "claude-fable-5")
         self.assertEqual(answered["codex"], "gpt-5.5")
         self.assertEqual(answered["gemini"], "gemini-3.5-flash")
 


### PR DESCRIPTION
## What

Defaults the **Claude seat** to **Fable 5** (`claude-fable-5`, Anthropic's most capable model) and runs it at **max effort**, forwarded to the CLI via the `--effort` flag (levels `low|medium|high|xhigh|max`, verified on `claude` 2.1.191).

Previously the Claude seat computed a `reasoning` value but **never passed it** to the CLI, so it silently ran at the CLI's own default. It now forwards the seat's reasoning; the default is `max`. On Fable 5 thinking is always-on and effort scales how hard it thinks.

## Scope of "max reasoning if available"

Applied to the **Claude seat only** — it is the one CLI that exposes a real `max` effort level:

- **Codex** stays at `xhigh` (its ceiling; `model_reasoning_effort=max` returns a hard 400 — confirmed live).
- **Gemini / Antigravity / Ollama** expose no effort knob — unchanged.

## Reproducibility fix (surfaced by this change)

`--from-recipe` restored per-seat `model` and `lens` but not `reasoning`, so replay re-pulled reasoning from the live registry. With the default moving `xhigh → max`, an old recipe (recorded at `xhigh`) would have silently replayed at `max`. `resolve_board` now accepts reasoning overrides and the recipe-replay path restores recorded reasoning. A new round-trip test guards it.

## Verification

- **676 tests OK** — added `test_claude_default_model_and_max_effort` and `test_recipe_restores_recorded_reasoning`.
- Two adversarial reviews (parallel skeptics): regressions + live-CLI semantics. The exact `claude_argv` output — `claude -p --model claude-fable-5 --effort max --permission-mode plan --disallowed-tools WebSearch WebFetch` — returns `PONG`, exit 0, empty stderr on `claude` 2.1.191.

## Notes

- **Cost**: Fable 5 is a premium tier (priced above Opus); max effort + always-on thinking → longer, costlier runs. `SKILL.md` notes this and the `--model claude=<id>` override.
- **CLI dependency**: `--effort` is now emitted on every Claude-seat call (incl. the preflight smoke ping). A `claude` CLI too old to have `--effort` fails that seat in preflight (fail-fast, caught by the existing ≥2-seats gate). `flags_verified_version` bumped `2.1.177 → 2.1.191`.
- CHANGELOG / version / release tag intentionally **not** touched here (outward-facing; the changelog is already behind the release tags at v1.7.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
