### PR TITLE
advisory-board: cost & time transparency — capture + preflight estimate (v1.11)

### DIFF
--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -41,6 +41,28 @@ reserved for an explicit production-ready call. The verdict-JSON schema is versi
   on the bundled sample source). No user material egresses — probes and smoke-pings only, and the
   output says so. Exits non-zero when no board is viable, so scripts can branch on it.
   (`scripts/_conductor/doctor.py`; probe logic stays in `preflight.py`/`toolchain.py`.)
+- **Per-seat token capture (v1.11 #3a).** `SeatRoundResult` gains nullable
+  `tokens_in`/`tokens_out`/`tokens_total`, filled by per-adapter `parse_usage`
+  parsers in `registry.py` that read ONLY what each CLI unambiguously reports
+  about its own usage (grounded live 2026-07-01): codex's trailing
+  `tokens used` stderr footer (a combined total — no in/out split), and
+  claude's `--output-format json` result envelope (plain `-p` text mode — the
+  board's argv today — prints no usage, so the seat honestly reports unknown).
+  gemini / antigravity / ollama print nothing and stay unknown. Never guessed.
+- **Preflight cost/time estimate.** A dated list-price table
+  (`constants.MODEL_PRICING_USD_PER_MTOK`) plus a pure `estimate_run()`
+  (source bytes × seats × rounds × cross-reading → token band, cost band,
+  rough minutes), surfaced as an `=== estimate ===` block in `run --dry-run`
+  and pointed at by SKILL.md's flag-a-large-run guidance. Best-effort and
+  labeled an ESTIMATE — never a gate; unverified prices render as unknown,
+  not $0.
+- **"If known" cost/time rendering.** When any seat CLI reported usage:
+  per-seat token lines and a `## Cost & time (best effort)` section in
+  `run-metadata.md`, three trailing token columns in `run-metadata.tsv`, and a
+  seat-reported totals segment in the `final-consensus.html` footer (read from
+  the run dir's TSV). With no usage reported — every mocked/default run today —
+  all three artifacts stay **byte-identical** to the pre-feature baseline
+  (guarded by tests).
 
 ## [v1.10.0] - 2026-07-01 — Claude seat on Fable 5 at max effort
 

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -24,7 +24,7 @@ Hard rules, collected here so they are never missed (each is elaborated in conte
 - Run read-only unless the user explicitly asks for edits.
 - Rounds: 2. Cross-reading: summaries. Final artifact: full handoff (Markdown plus a self-contained HTML view).
 - Write run artifacts to a timestamped `/tmp/advisory-board-*` folder by default. Writing them into the reviewed project is itself a write, even on a read-only review: do that only when the user asks or agrees, prefer a dedicated `advisory-board/<timestamp>/` (or `docs/advisory-board/<timestamp>/`) folder, and never write into a tracked git tree without naming the location first.
-- Quick pass: 1 round with `summaries`. High-stakes: 3 rounds with `full` cross-reading. Three frontier models at high reasoning across several rounds can take minutes and meaningful tokens — flag a large run to the user before launching it.
+- Quick pass: 1 round with `summaries`. High-stakes: 3 rounds with `full` cross-reading. Three frontier models at high reasoning across several rounds can take minutes and meaningful tokens — flag a large run to the user before launching it, with numbers: `run_board.py run … --dry-run` prints a best-effort token/cost/time **estimate** for the exact run shape (an estimate, never a gate; subscription-backed CLIs may bill nothing per token). After the run, `run-metadata.md` records what each seat CLI actually reported, where known.
 
 ## Upfront Choices
 
@@ -128,7 +128,7 @@ Write:
 - `final-consensus.md` — the handoff in Markdown
 - `final-consensus.html` — a self-contained, human-readable view of the handoff. Render it deterministically with `scripts/render_handoff.py` from a `handoff-data.json` (recommended — guarantees no leftover placeholders or template drift), or fill `references/handoff-template.html` by hand. Choose the **shape** with `scripts/render_verdict.py --html … --shape full-handoff` (default — the complete record), `--shape quick-verdict` (a slim skim brief to lead with), or `--shape implementation-sequence` (the sequence-first view for whoever executes: every next action in order with owners where named, backed by the blockers and their evidence — md + HTML); see `references/output-formats.md`
 - `verdict.json` — the machine-readable verdict (`references/verdict-schema.md`); gate or reformat it with `scripts/`
-- `run-metadata.md` — provenance: commands, the model that actually answered per seat, auth mode (no secrets), per-seat status (ran / degraded / dropped), timings, and source paths. Use `references/run-metadata-template.md`.
+- `run-metadata.md` — provenance: commands, the model that actually answered per seat, auth mode (no secrets), per-seat status (ran / degraded / dropped), timings, and source paths. Use `references/run-metadata-template.md`. When a seat CLI reports its own token usage, the conductor also records per-seat tokens and a best-effort cost/time line ("if known" — most CLIs report nothing, and nothing is ever guessed).
 
 When a seat is degraded or dropped, show it on its HTML seat card (status pill) and in `verdict.json` (`dropped: true`) — never let a smaller board look like a full one. Derive lighter shares (TL;DR, PR comment, Slack, print/PDF) per `references/output-formats.md`.
 

--- a/skills/advisory-board/scripts/_conductor/artifacts.py
+++ b/skills/advisory-board/scripts/_conductor/artifacts.py
@@ -6,7 +6,11 @@ import json
 import os
 from typing import Optional
 
-from _conductor.constants import SENSITIVITY_SCHEMA
+from _conductor.constants import (
+    PRICING_AS_OF,
+    SENSITIVITY_SCHEMA,
+    price_band_usd,
+)
 from _conductor.config import (
     RunConfig,
     SeatConfig,
@@ -31,12 +35,39 @@ __all__ = [
     "render_run_card",
     "render_sensitivity_json",
     "render_artifact_tree",
+    "seat_tokens_label",
+    "render_cost_time_section",
     "render_run_metadata",
     "RUN_METADATA_TSV_COLUMNS",
+    "RUN_METADATA_TSV_TOKEN_COLUMNS",
     "render_run_metadata_tsv",
     "write_pre_spawn_artifacts",
     "_write",
 ]
+
+
+def _has_tokens(r) -> bool:
+    """True when the seat CLI reported ANY usage for this seat-round."""
+    return r.tokens_in is not None or r.tokens_out is not None or r.tokens_total is not None
+
+
+def _tokens_total_or_none(r):
+    """The seat-round's combined token count when derivable, else None."""
+    if r.tokens_total is not None:
+        return r.tokens_total
+    if r.tokens_in is not None and r.tokens_out is not None:
+        return r.tokens_in + r.tokens_out
+    return None
+
+
+def seat_tokens_label(r) -> str:
+    """Human label for one seat-round's reported tokens ("unknown" when none)."""
+    if r.tokens_in is not None and r.tokens_out is not None:
+        total = _tokens_total_or_none(r)
+        return f"in {r.tokens_in:,} · out {r.tokens_out:,} · total {total:,}"
+    if r.tokens_total is not None:
+        return f"total {r.tokens_total:,} (combined count; the CLI reports no in/out split)"
+    return "unknown (the CLI reported no usage — not assumed)"
 
 
 def seat_network_status(seat: SeatConfig, config: RunConfig) -> str:
@@ -235,6 +266,57 @@ def render_synthesizer_section(synth) -> list:
     return lines
 
 
+def render_cost_time_section(rounds: list) -> list:
+    """The v1.11 cost/time trace for run-metadata.md — [] unless a seat REPORTED tokens.
+
+    Emitting nothing when every seat-round is unknown keeps a tokenless run's
+    run-metadata.md byte-identical to the pre-feature baseline (the standing
+    invariant). When any CLI did report usage: the known token sum, a list-price
+    cost band for the priceable part, and the measured wall clock — all labeled
+    best-effort/estimate, never a gate.
+    """
+    results = [r for round_results in (rounds or []) for r in round_results]
+    reported = [r for r in results if _has_tokens(r)]
+    if not reported:
+        return []
+    known_totals = [t for t in (_tokens_total_or_none(r) for r in reported) if t is not None]
+    tokens_sum = sum(known_totals)
+    cost_low = cost_high = 0.0
+    priced_any = False
+    for r in reported:
+        band = price_band_usd(r.model_requested, r.tokens_in, r.tokens_out, r.tokens_total)
+        if band is not None:
+            cost_low += band[0]
+            cost_high += band[1]
+            priced_any = True
+    # Parallel fan-out: each round's wall clock is its slowest seat's elapsed time.
+    wall_s = sum(max((r.elapsed_s for r in round_results), default=0.0)
+                 for round_results in (rounds or []))
+    rest = ("; the rest reported nothing and are counted as unknown, never guessed"
+            if len(known_totals) < len(results) else " (every seat-round reported; "
+            "unreported usage is counted as unknown, never guessed)")
+    lines = [
+        "",
+        "## Cost & time (best effort)",
+        "",
+        f"- Tokens reported by the seat CLIs: {tokens_sum:,} across "
+        f"{len(known_totals)} of {len(results)} seat-round(s){rest}.",
+    ]
+    if priced_any:
+        lines.append(
+            f"- Estimated cost of the reported tokens: ~${cost_low:.2f}–${cost_high:.2f} "
+            f"at list prices dated {PRICING_AS_OF} (an ESTIMATE — subscription-backed "
+            "CLIs may bill nothing per token; unknown/unpriced seat-rounds excluded).")
+    else:
+        lines.append(
+            "- Cost: unknown — no verified list price for the reporting seats' models "
+            "(see constants.MODEL_PRICING_USD_PER_MTOK).")
+    lines.append(
+        f"- Wall clock (measured): {wall_s / 60:.1f} min across {len(rounds or [])} round(s) "
+        "— seats fan out in parallel, so each round costs its slowest seat.")
+    return lines
+
+
 def render_run_metadata(config: RunConfig, preflight: list, approval: EgressApproval,
                         rounds: Optional[list] = None, convergence: Optional[dict] = None,
                         synthesizer=None) -> str:
@@ -306,6 +388,14 @@ def render_run_metadata(config: RunConfig, preflight: list, approval: EgressAppr
                 f"| {r.seat:<6} | {r.status:<8} | {answered} | {r.attempts} "
                 f"| {r.elapsed_s:.1f}s | {r.failure_class or '-'} |"
             )
+        # Per-seat token capture (v1.11 #3a) — rendered ONLY when a CLI actually
+        # reported usage this round, so a tokenless run (all seats unknown) keeps
+        # this file byte-identical to the pre-feature baseline.
+        token_rows = [r for r in round_results if _has_tokens(r)]
+        if token_rows:
+            lines += ["", "Tokens as reported by the seat CLIs (if known; capture is best-effort):"]
+            for r in token_rows:
+                lines.append(f"- {r.seat}: {seat_tokens_label(r)}")
         # Post-hoc egress accounting (R4): the pre-spawn scope hash bounds what a seat
         # COULD read; this records which in-scope paths each usable reply actually
         # referenced. Best-effort substring match — over-, not under-counts.
@@ -331,6 +421,9 @@ def render_run_metadata(config: RunConfig, preflight: list, approval: EgressAppr
         lines += render_convergence_section(convergence)
     if synthesizer is not None:
         lines += render_synthesizer_section(synthesizer)
+    # Cost & time (v1.11 #3a) — empty (and therefore absent) unless a seat CLI
+    # actually reported token usage, keeping tokenless runs byte-identical.
+    lines += render_cost_time_section(rounds)
     lines += [
         "",
         "## Notes",
@@ -374,23 +467,41 @@ RUN_METADATA_TSV_COLUMNS = (
     "prompt_sha256", "packet_sha256",
 )
 
+# Trailing token columns (v1.11 #3a), appended ONLY when at least one seat-round
+# actually reported usage. A tokenless run keeps the original header and rows
+# byte-identical to the pre-feature baseline (and existing consumers that read
+# the packet hash as the LAST column keep working); "-" marks an unknown cell.
+RUN_METADATA_TSV_TOKEN_COLUMNS = ("tokens_in", "tokens_out", "tokens_total")
+
 
 def render_run_metadata_tsv(rounds: list) -> str:
     """The diffable, machine-readable provenance companion to run-metadata.md
     (§12): one row per seat per round, including the parsed `VERDICT:` token (M1)
     so the movement trace is reproducible from the TSV. Tabs are stripped from any
-    field so the TSV can't be corrupted by a stray tab in a model id."""
+    field so the TSV can't be corrupted by a stray tab in a model id. When any
+    seat CLI reported token usage, three trailing columns (tokens_in, tokens_out,
+    tokens_total) are appended — see RUN_METADATA_TSV_TOKEN_COLUMNS."""
     def cell(v) -> str:
         return str(v).replace("\t", " ").replace("\n", " ")
-    out = ["\t".join(RUN_METADATA_TSV_COLUMNS)]
+    results = [r for round_results in (rounds or []) for r in round_results]
+    with_tokens = any(_has_tokens(r) for r in results)
+    columns = RUN_METADATA_TSV_COLUMNS + (RUN_METADATA_TSV_TOKEN_COLUMNS if with_tokens else ())
+    out = ["\t".join(columns)]
     for round_results in (rounds or []):
         for r in round_results:
-            out.append("\t".join(cell(v) for v in (
+            values = [
                 r.round_no, r.seat, r.provider, r.model_requested,
                 r.model_answered or "unknown", r.status, r.verdict or "-",
                 r.failure_class or "-", r.attempts, f"{r.elapsed_s:.2f}", r.exit_code,
                 "yes" if r.timed_out else "no", r.prompt_hash, r.round_packet_hash,
-            )))
+            ]
+            if with_tokens:
+                values += [
+                    r.tokens_in if r.tokens_in is not None else "-",
+                    r.tokens_out if r.tokens_out is not None else "-",
+                    r.tokens_total if r.tokens_total is not None else "-",
+                ]
+            out.append("\t".join(cell(v) for v in values))
     return "\n".join(out) + "\n"
 
 

--- a/skills/advisory-board/scripts/_conductor/cli.py
+++ b/skills/advisory-board/scripts/_conductor/cli.py
@@ -16,6 +16,8 @@ from _conductor.constants import (
     EXIT_USAGE,
     SMOKE_PROMPT,
     die,
+    estimate_run,
+    render_estimate,
 )
 from _conductor.registry import REGISTRY
 from _conductor.convergence import (
@@ -238,6 +240,19 @@ def _execute_run(config, args) -> int:
         print()
         print("=== artifact tree it WOULD create ===")
         print(render_artifact_tree(config))
+        print()
+        # The preflight cost/time estimate (v1.11 #3a) — the "know before you
+        # convene" number SKILL.md's large-run flag points at. Pure function of
+        # the run shape (deterministic), best-effort, and never a gate.
+        print("=== estimate (best effort — never a gate) ===")
+        est_rounds = config.max_rounds if config.rounds == "auto" else int(config.rounds)
+        est = estimate_run(config.source.nbytes, [s.model for s in config.board],
+                           est_rounds, config.cross_reading)
+        for line in render_estimate(est):
+            print(f"  {line}")
+        if config.rounds == "auto":
+            print(f"  (--rounds auto: sized at the --max-rounds ceiling of {config.max_rounds}; "
+                  "the convergence stop-rule may finish earlier and cheaper)")
         print()
         print(f"[dry-run] no preflight, no packet written, no egress, no spawn. "
               f"content hash = sha256:{content_hash}")

--- a/skills/advisory-board/scripts/_conductor/constants.py
+++ b/skills/advisory-board/scripts/_conductor/constants.py
@@ -24,6 +24,11 @@ __all__ = [
     "FAILURE_INVALID",
     "FAILURE_NOOUTPUT",
     "FAILURE_MODEL",
+    "MODEL_PRICING_USD_PER_MTOK",
+    "PRICING_AS_OF",
+    "price_band_usd",
+    "estimate_run",
+    "render_estimate",
     "die",
     "now_date",
     "now_stamp",
@@ -100,6 +105,147 @@ FAILURE_AUTH = "AuthFailure"
 FAILURE_INVALID = "InvalidOutput"
 FAILURE_NOOUTPUT = "NoOutput"
 FAILURE_MODEL = "ModelNotFound"   # pinned model id did not resolve on the installed CLI
+
+
+# --------------------------------------------------------------------------- #
+# Cost & time transparency (v1.11 #3a): list prices + the preflight estimator.
+# Everything here is BEST-EFFORT and labeled an estimate — never a gate (§ roadmap
+# "always best-effort, never a gate"). Actual spend depends on caching, discounts,
+# and each provider's subscription vs API billing; the board's default posture is
+# subscription CLIs, where per-token dollars may not be billed at all.
+# --------------------------------------------------------------------------- #
+
+# Published list prices in USD per MILLION tokens, keyed by the model ids the
+# REGISTRY pins (registry.py — frontier ids stay inline per the model-id policy).
+# Table dated 2026-07-01, checked against the providers' published prices that
+# day. Prices move; re-check before trusting a large-run estimate. A `None`
+# entry means "not verified" — the estimator then reports that seat's cost as
+# unknown rather than inventing a number (never $0, never a guess). The local
+# ollama seat is genuinely $0 (no external egress, no metered billing).
+PRICING_AS_OF = "2026-07-01"
+MODEL_PRICING_USD_PER_MTOK = {
+    # (input $/MTok, output $/MTok) — uncached list rates; cache reads are cheaper
+    "claude-fable-5": (10.00, 50.00),          # Anthropic
+    "gpt-5.5": (5.00, 30.00),                  # OpenAI
+    "gemini-3.5-flash": (1.50, 9.00),          # Google
+    "Gemini 3.5 Flash (High)": (1.50, 9.00),   # antigravity display name — same model family
+    "llama3.3": (0.00, 0.00),                  # local seat — no per-token cost at all
+}
+
+
+def price_band_usd(model: str, tokens_in: "Optional[int]" = None,
+                   tokens_out: "Optional[int]" = None,
+                   tokens_total: "Optional[int]" = None) -> "Optional[tuple]":
+    """(low, high) USD estimate for one seat's REPORTED tokens, or None.
+
+    None when the model has no verified table entry or nothing was reported.
+    A known in/out split prices exactly at list (low == high); a total-only
+    count (codex) is banded between all-input and all-output pricing. Either
+    way it is an estimate — list prices, no caching/discount/subscription math.
+    """
+    prices = MODEL_PRICING_USD_PER_MTOK.get(model)
+    if not prices or prices[0] is None or prices[1] is None:
+        return None
+    p_in, p_out = prices
+    if tokens_in is not None and tokens_out is not None:
+        cost = (tokens_in * p_in + tokens_out * p_out) / 1_000_000
+        return (cost, cost)
+    if tokens_total is not None:
+        lo, hi = sorted((p_in, p_out))
+        return (tokens_total * lo / 1_000_000, tokens_total * hi / 1_000_000)
+    return None
+
+
+# Rough estimator constants — deliberately coarse (order-of-magnitude bands, not
+# precision): ~4 bytes/token for English/markdown, a fixed allowance for the round
+# template + lens framing, and an output band covering a typical 7-section review.
+_EST_BYTES_PER_TOKEN = 4
+_EST_PROMPT_OVERHEAD_TOKENS = 1_200
+_EST_REVIEW_OUT_TOKENS = (800, 2_600)      # (low, high) per seat per round
+_EST_SUMMARY_TOKENS = 400                  # per peer review under --cross-reading summaries
+_EST_MINUTES_PER_ROUND = (1.0, 5.0)        # frontier seats at high reasoning, parallel fan-out
+
+
+def estimate_run(source_bytes: int, models: list, rounds: int, cross_reading: str) -> dict:
+    """Pure preflight estimate: token band + cost band + rough minutes.
+
+    Inputs are the run's shape only (source size, the per-seat model ids, the
+    round count, the cross-reading mode) — no I/O, no clock, fully deterministic.
+    The returned numbers are labeled estimates wherever they are rendered; they
+    inform the human before launch and never gate anything.
+    """
+    seats = len(models)
+    rounds = max(1, int(rounds))
+    source_tokens = max(1, source_bytes // _EST_BYTES_PER_TOKEN)
+    out_lo, out_hi = _EST_REVIEW_OUT_TOKENS
+
+    # Cross-reading adds each peer's round-(N-1) review to every round-2+ packet.
+    peers = max(0, seats - 1)
+    if cross_reading == "full":
+        cross_lo, cross_hi = peers * out_lo, peers * out_hi
+    elif cross_reading == "none":
+        cross_lo = cross_hi = 0
+    else:   # summaries (the default)
+        cross_lo = cross_hi = peers * _EST_SUMMARY_TOKENS
+
+    base_in = source_tokens + _EST_PROMPT_OVERHEAD_TOKENS
+    per_seat_in_lo = base_in * rounds + cross_lo * (rounds - 1)
+    per_seat_in_hi = base_in * rounds + cross_hi * (rounds - 1)
+    per_seat_out_lo, per_seat_out_hi = out_lo * rounds, out_hi * rounds
+
+    tokens_low = seats * (per_seat_in_lo + per_seat_out_lo)
+    tokens_high = seats * (per_seat_in_hi + per_seat_out_hi)
+
+    cost_low = cost_high = 0.0
+    priced_any = False
+    unpriced = []
+    for model in models:
+        prices = MODEL_PRICING_USD_PER_MTOK.get(model)
+        if not prices or prices[0] is None or prices[1] is None:
+            if model not in unpriced:
+                unpriced.append(model)
+            continue
+        p_in, p_out = prices
+        cost_low += (per_seat_in_lo * p_in + per_seat_out_lo * p_out) / 1_000_000
+        cost_high += (per_seat_in_hi * p_in + per_seat_out_hi * p_out) / 1_000_000
+        priced_any = True
+
+    m_lo, m_hi = _EST_MINUTES_PER_ROUND
+    return {
+        "seats": seats,
+        "rounds": rounds,
+        "cross_reading": cross_reading,
+        "tokens_low": tokens_low,
+        "tokens_high": tokens_high,
+        "cost_low_usd": cost_low if priced_any else None,
+        "cost_high_usd": cost_high if priced_any else None,
+        "cost_is_partial": priced_any and bool(unpriced),
+        "unpriced_models": unpriced,
+        "minutes_low": rounds * m_lo,
+        "minutes_high": rounds * m_hi,
+    }
+
+
+def render_estimate(est: dict) -> list:
+    """Human lines for an estimate_run() result — explicit estimate wording."""
+    lines = [
+        f"tokens  : ~{est['tokens_low']:,}–{est['tokens_high']:,} across the board "
+        f"({est['seats']} seat(s) × {est['rounds']} round(s), cross-reading: {est['cross_reading']})",
+    ]
+    if est["cost_low_usd"] is None:
+        lines.append("cost    : unknown — no verified list price for "
+                     f"{', '.join(est['unpriced_models'])} (see constants.MODEL_PRICING_USD_PER_MTOK)")
+    else:
+        partial = ""
+        if est["cost_is_partial"]:
+            partial = f"  (excludes unpriced: {', '.join(est['unpriced_models'])})"
+        lines.append(f"cost    : ~${est['cost_low_usd']:.2f}–${est['cost_high_usd']:.2f} "
+                     f"at list prices dated {PRICING_AS_OF}{partial}")
+    lines.append(f"time    : roughly {est['minutes_low']:.0f}–{est['minutes_high']:.0f} minutes "
+                 "(seats run in parallel; deep reasoning rounds vary widely)")
+    lines.append("These are ESTIMATES, not measurements or a gate — subscription-backed CLIs "
+                 "may bill nothing per token; actuals land in run-metadata after the run.")
+    return lines
 
 
 def die(message: str, code: int = EXIT_USAGE) -> "NoReturn":  # type: ignore[name-defined]

--- a/skills/advisory-board/scripts/_conductor/registry.py
+++ b/skills/advisory-board/scripts/_conductor/registry.py
@@ -15,6 +15,9 @@ __all__ = [
     "_MODEL_BANNER_RE",
     "_PROMPT_ECHO_MARKER",
     "parse_model_answered",
+    "_usage_unknown",
+    "claude_usage",
+    "codex_usage",
     "claude_argv",
     "claude_version",
     "codex_argv",
@@ -69,6 +72,16 @@ __all__ = [
 # 2026-06-25; re-verify before a large run, they move fast.
 
 
+def _usage_unknown(stdout: str, stderr: str) -> tuple:
+    """Deliberately-unknown token-usage parser: (tokens_in, tokens_out, tokens_total).
+
+    Returns (None, None, None) — "unknown, flag it" — never a guessed count. The
+    default for every seat whose CLI does not print its own usage in the captured
+    output (mirrors _model_answered_none below: honest absence over fabrication).
+    """
+    return (None, None, None)
+
+
 @dataclass(frozen=True)
 class SeatAdapter:
     name: str
@@ -84,6 +97,11 @@ class SeatAdapter:
     isolates_network: bool               # can gate mode actually REMOVE this seat's network via a flag?
     model_answered: Callable[[str, str], Optional[str]]  # (stdout, stderr) -> real model id | None
     timeout_s: int = 900                 # hard cap; §13 default is 15 min (overridden per call)
+    # (stdout, stderr) -> (tokens_in, tokens_out, tokens_total), each Optional[int].
+    # Best-effort token capture (v1.11 #3a): parse ONLY what the CLI unambiguously
+    # reports about ITS OWN usage — a miss is (None, None, None) ("unknown — flag
+    # it"), never a number mined from review prose. Defaults to always-unknown.
+    parse_usage: Callable[[str, str], tuple] = _usage_unknown
     # --- toolchain currency + model self-heal (all optional; a seat without a
     #     package manager simply reports "unknown" and is never auto-updated) ---
     latest_argv: Optional[Callable[[], list]] = None     # () -> argv that prints the latest version
@@ -140,6 +158,76 @@ def parse_model_answered(stdout: str, stderr: str) -> Optional[str]:
         return None
     cand = m.group(1).strip()
     return cand or None
+
+
+# Per-CLI token-usage parsers (v1.11 #3a). Grounded live on 2026-07-01 against the
+# installed CLIs with the streams captured separately. The poisoning rule from
+# parse_model_answered applies with more force here: review prose (stdout) and the
+# echoed prompt (stderr) can legitimately QUOTE usage lines/JSON — e.g. when the
+# material under review is this very skill or a CLI transcript — so a parser may
+# only accept usage from a position review content cannot occupy. Anything less
+# anchored returns unknown; never guess numbers.
+
+
+def claude_usage(stdout: str, stderr: str) -> tuple:
+    """claude: usage from the --output-format json result envelope ONLY.
+
+    Plain `claude -p` (the board's argv, text mode) emits NO usage anywhere —
+    stdout is the review text, stderr is empty; --verbose adds nothing in text
+    mode (verified live on claude 2.1.191, 2026-07-01). Usage exists only in the
+    `--output-format json` result envelope: the ENTIRE stdout is one JSON object
+    carrying usage.input_tokens / usage.output_tokens. Parse only that
+    whole-document shape — a review merely quoting such JSON is embedded in prose
+    and fails the full-stdout json.loads, so it can never be mined. Today's
+    text-mode spawns therefore honestly return unknown; if the invocation ever
+    adopts the json envelope, capture lights up with no further change. Counts
+    are AS REPORTED: the envelope's input_tokens excludes cache reads/writes
+    (they ride separate usage fields, billed at different rates) — one more
+    reason every downstream dollar figure stays labeled an estimate.
+    """
+    try:
+        data = json.loads(stdout)
+    except (ValueError, RecursionError):   # not JSON — or adversarially deep nesting
+        return (None, None, None)
+    if not isinstance(data, dict):
+        return (None, None, None)
+    usage = data.get("usage")
+    if not isinstance(usage, dict):
+        return (None, None, None)
+    tin, tout = usage.get("input_tokens"), usage.get("output_tokens")
+    if (isinstance(tin, int) and not isinstance(tin, bool) and tin >= 0
+            and isinstance(tout, int) and not isinstance(tout, bool) and tout >= 0):
+        return (tin, tout, tin + tout)
+    return (None, None, None)
+
+
+# `codex exec` ends stderr with a token footer. Two shapes seen in the wild:
+# the current two-line form ("tokens used" newline "13,976" — verified live on
+# codex-cli 0.142.2, 2026-07-01) and the older one-line "tokens used: 13,976".
+_CODEX_TOKENS_USED_LINE_RE = re.compile(r"^tokens used:\s*([\d,]+)$", re.IGNORECASE)
+_CODEX_COUNT_RE = re.compile(r"^\d{1,3}(?:,\d{3})*$|^\d+$")
+
+
+def codex_usage(stdout: str, stderr: str) -> tuple:
+    """codex: the TOTAL from the "tokens used" footer that terminates stderr.
+
+    codex reports one combined count (input+output+reasoning), never a split —
+    so tokens_in/tokens_out stay None and only tokens_total is filled. Anchored
+    to the TAIL of stderr on purpose: codex mirrors the echoed prompt AND the
+    reply onto stderr, either of which could quote a "tokens used" line, but the
+    CLI's own footer is always the last thing printed. Only the final line pair
+    (or final one-line form) is trusted; anything else is unknown.
+    """
+    lines = [ln.strip() for ln in stderr.splitlines() if ln.strip()]
+    if not lines:
+        return (None, None, None)
+    if (len(lines) >= 2 and lines[-2].lower() == "tokens used"
+            and _CODEX_COUNT_RE.match(lines[-1])):
+        return (None, None, int(lines[-1].replace(",", "")))
+    m = _CODEX_TOKENS_USED_LINE_RE.match(lines[-1])
+    if m:
+        return (None, None, int(m.group(1).replace(",", "")))
+    return (None, None, None)
 
 
 # v1 is always read-only — every adapter hardcodes its provider's read-only mode
@@ -408,6 +496,7 @@ REGISTRY: dict = {
         supports_isolation=True,
         isolates_network=True,   # --disallowed-tools WebSearch WebFetch removes web reach
         model_answered=parse_model_answered,
+        parse_usage=claude_usage,   # json result envelope only; text mode (today) → unknown
         latest_argv=claude_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=claude_update_argv,
@@ -430,6 +519,7 @@ REGISTRY: dict = {
         supports_isolation=True,
         isolates_network=True,   # --sandbox read-only has no network (verified: DNS fails inside)
         model_answered=parse_model_answered,
+        parse_usage=codex_usage,   # "tokens used" stderr footer — a TOTAL only, never a split
         latest_argv=codex_latest_argv,
         parse_latest=parse_npm_latest,
         update_argv=codex_update_argv,
@@ -456,6 +546,8 @@ REGISTRY: dict = {
         supports_isolation=True,    # fs scoping via cwd; network is NOT removable (below)
         isolates_network=False,  # no known flag disables GoogleSearch grounding — surfaced loudly
         model_answered=parse_model_answered,
+        # parse_usage stays _usage_unknown: `gemini -p` prints no usage on either
+        # stream (verified live on gemini-cli 0.46.0, 2026-07-01) — never guess.
         latest_argv=gemini_latest_argv,
         parse_latest=parse_brew_latest,
         update_argv=gemini_update_argv,
@@ -482,6 +574,8 @@ REGISTRY: dict = {
         supports_isolation=True,    # cwd scoping + --sandbox terminal restrictions
         isolates_network=False,  # agent-first harness; web/grounding not removable — surfaced loudly
         model_answered=_model_answered_none,
+        # parse_usage stays _usage_unknown: `agy -p` prints no usage on either
+        # stream (verified live on agy 1.0.15, 2026-07-01) — never guess.
         latest_argv=antigravity_latest_argv,
         parse_latest=parse_brew_cask_latest,
         update_argv=antigravity_update_argv,
@@ -509,6 +603,9 @@ REGISTRY: dict = {
         supports_isolation=True,   # fs scoping via cwd; a local model has nothing external to scope
         isolates_network=True,     # local model: no external network at all (intrinsic, not a flag)
         model_answered=_model_answered_none,
+        # parse_usage stays _usage_unknown: plain `ollama run` prints only the
+        # completion (eval counts appear only under --verbose, which the board
+        # doesn't pass). Local seat, so the cost is $0 either way — never guess.
         latest_argv=ollama_latest_argv,
         parse_latest=parse_brew_latest,
         update_argv=ollama_update_argv,

--- a/skills/advisory-board/scripts/_conductor/rounds.py
+++ b/skills/advisory-board/scripts/_conductor/rounds.py
@@ -62,6 +62,14 @@ class SeatRoundResult:
     source_hash: str            # sha256 of the source material (same across seats)
     round_packet_hash: str      # sha256 of THIS round's full packet (round 1 == approval hash)
     argv_preview: str           # the invocation, prompt elided (the black-box recorder)
+    # Token usage as REPORTED BY THE CLI in the captured output (v1.11 #3a) — all
+    # nullable, and None is the common, honest outcome today (most CLIs print no
+    # usage; see registry.py's per-seat parse_usage). tokens_total may be present
+    # while in/out are not (codex reports one combined count). Never estimated
+    # here — estimates live in constants.estimate_run and are labeled as such.
+    tokens_in: Optional[int] = None
+    tokens_out: Optional[int] = None
+    tokens_total: Optional[int] = None
 
     @property
     def usable(self) -> bool:
@@ -115,6 +123,16 @@ def _run_seat_round(seat: SeatConfig, blob: "PacketBlob", config: RunConfig, *,
         break
 
     answered = adapter.model_answered(result.stdout, result.stderr) if status in ("ran", "degraded") else None
+    # Token capture runs for degraded AND dropped seats (a failed spawn may still
+    # have burned tokens) — but NOT for a timeout: the parsers' anchor guarantees
+    # ("the CLI's own footer terminates stderr" / "the envelope is the whole
+    # stdout") only hold for a process that finished printing. A killed process
+    # returns PARTIAL streams whose tail could be echoed prompt/review content
+    # quoting a usage line — exactly the poisoning the anchors exist to exclude.
+    if result.timed_out:
+        tokens_in = tokens_out = tokens_total = None
+    else:
+        tokens_in, tokens_out, tokens_total = adapter.parse_usage(result.stdout, result.stderr)
     return SeatRoundResult(
         seat=seat.id,
         provider=seat.provider,
@@ -133,6 +151,9 @@ def _run_seat_round(seat: SeatConfig, blob: "PacketBlob", config: RunConfig, *,
         source_hash=config.source.sha256,
         round_packet_hash=round_packet_hash,
         argv_preview=_argv_preview(last_argv),
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        tokens_total=tokens_total,
     )
 
 

--- a/skills/advisory-board/scripts/render_verdict.py
+++ b/skills/advisory-board/scripts/render_verdict.py
@@ -50,6 +50,10 @@ from _verdict_labels import (  # noqa: E402  lens-aware label + framing (rendere
     lens_disclaimer,
     verdict_lead,
 )
+from _conductor.constants import (  # noqa: E402  v1.11 cost transparency (stdlib-only module)
+    PRICING_AS_OF,
+    price_band_usd,
+)
 
 STATUS_WORD = {"verified": "verified", "unverified": "unverified", "refuted": "REFUTED"}
 EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
@@ -421,6 +425,86 @@ def _round_review(run_dir, seat_name: str, round_no: int, verdict: str) -> str:
             f"Full review in `round-{round_no}/{seat_name.lower()}.md`.")
 
 
+def _seat_reported_token_totals(run_dir) -> "dict | None":
+    """Best-effort token totals from the run's run-metadata.tsv (v1.11 #3a), or None.
+
+    The conductor appends trailing token columns to run-metadata.tsv ONLY when a
+    seat CLI actually reported usage. No run dir, no TSV, no token columns, or no
+    known values → None, and the HTML footer stays byte-identical to the
+    tokenless baseline. Column positions are resolved by header name, never by
+    index, so this reads both TSV layouts.
+    """
+    if not run_dir:
+        return None
+    try:
+        with open(os.path.join(run_dir, "run-metadata.tsv"), encoding="utf-8") as handle:
+            lines = [ln for ln in handle.read().splitlines() if ln.strip()]
+    except OSError:
+        return None
+    if not lines:
+        return None
+    header = lines[0].split("\t")
+    if "tokens_total" not in header:
+        return None
+    idx = {name: i for i, name in enumerate(header)}
+
+    def _cell_int(row: list, name: str):
+        i = idx.get(name)
+        if i is None or i >= len(row):
+            return None
+        raw = row[i].strip().replace(",", "")
+        # isascii() guard: str.isdigit() accepts Unicode digit-class chars (e.g.
+        # "²") that int() rejects — a malformed cell must degrade to None, not raise.
+        return int(raw) if raw.isascii() and raw.isdigit() else None
+
+    tokens = rows = known_rows = 0
+    cost_low = cost_high = 0.0
+    priced_any = False
+    for ln in lines[1:]:
+        row = ln.split("\t")
+        rows += 1
+        tin = _cell_int(row, "tokens_in")
+        tout = _cell_int(row, "tokens_out")
+        ttotal = _cell_int(row, "tokens_total")
+        combined = ttotal if ttotal is not None else (
+            tin + tout if tin is not None and tout is not None else None)
+        if combined is None:
+            continue
+        known_rows += 1
+        tokens += combined
+        model_i = idx.get("model_requested")
+        model = row[model_i] if model_i is not None and model_i < len(row) else ""
+        band = price_band_usd(model, tin, tout, ttotal)
+        if band is not None:
+            cost_low += band[0]
+            cost_high += band[1]
+            priced_any = True
+    if not known_rows:
+        return None
+    return {
+        "tokens": tokens, "rows": rows, "known_rows": known_rows,
+        "cost_low": cost_low if priced_any else None,
+        "cost_high": cost_high if priced_any else None,
+    }
+
+
+def _token_totals_note(totals) -> str:
+    """One footer segment for the seat-reported totals ("" when unknown)."""
+    if not totals:
+        return ""
+    where_known = (" (where known — some seats reported no usage)"
+                   if totals["known_rows"] < totals["rows"] else "")
+    note = f"Seat-reported tokens{where_known}: {totals['tokens']:,}"
+    if totals["cost_low"] is not None:
+        if totals["cost_high"] - totals["cost_low"] < 0.005:
+            band = f"~${totals['cost_low']:.2f}"
+        else:
+            band = f"~${totals['cost_low']:.2f}–${totals['cost_high']:.2f}"
+        note += (f" · est. cost {band} at list prices dated {PRICING_AS_OF} "
+                 "(an estimate, not a bill)")
+    return note
+
+
 def build_handoff_data(data: dict, run_dir=None) -> dict:
     verdict = data.get("verdict", "")
     lens_preset = data.get("lens_preset")
@@ -449,11 +533,14 @@ def build_handoff_data(data: dict, run_dir=None) -> dict:
     actions = data.get("next_actions") or []
     # Footer provenance, in human terms — no internal file/script names. (The old
     # "Rendered from verdict.json by scripts/render_verdict.py" was a developer string
-    # that leaked onto the page; same for the subtitle below.)
+    # that leaked onto the page; same for the subtitle below.) The token/cost segment
+    # (v1.11 #3a) is "" — and the footer byte-identical to before — unless the run's
+    # TSV carries seat-reported usage; when present it is labeled an estimate.
     metadata = " · ".join(p for p in (
         f"Board: {board_str}" if board_str else "",
         f"{rounds_str} rounds" if rounds_str else "",
         data.get("date", ""),
+        _token_totals_note(_seat_reported_token_totals(run_dir)),
     ) if p)
     hd = {
         # non-RAW slots (the renderer escapes them) -> _plain; RAW slots -> _raw.

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -6810,5 +6810,364 @@ class TestRepoGroundingP5Verify(EnvMixin):
         self.assertEqual(run_bv([vpath, "--gate"])[0], bv.EXIT_GATE_FAIL)
 
 
+# --------------------------------------------------------------------------- #
+# v1.11 #3a — per-seat token capture (per-CLI usage parsers), the preflight
+# estimate, and the "if known" cost/time rendering with tokenless byte-identity
+# --------------------------------------------------------------------------- #
+
+
+class TestUsageParsers(unittest.TestCase):
+    # --- claude: whole-stdout json result envelope only --------------------- #
+
+    def test_claude_text_mode_is_unknown(self):
+        # Plain `claude -p` (the board's argv) prints only the review text — no
+        # usage anywhere (grounded live on claude 2.1.191, 2026-07-01).
+        self.assertEqual(rb.claude_usage("## Verdict\nConditional go...", ""),
+                         (None, None, None))
+
+    def test_claude_json_envelope_parses(self):
+        env = json.dumps({"type": "result", "result": "ok",
+                          "usage": {"input_tokens": 1200, "output_tokens": 345}})
+        self.assertEqual(rb.claude_usage(env, ""), (1200, 345, 1545))
+
+    def test_claude_quoted_usage_in_prose_is_not_mined(self):
+        # A review that QUOTES a usage envelope is embedded in prose — the
+        # whole-document json parse fails, so the number can never be mined.
+        prose = ('The API reports {"usage": {"input_tokens": 999, '
+                 '"output_tokens": 1}} per call — cache accordingly.')
+        self.assertEqual(rb.claude_usage(prose, ""), (None, None, None))
+
+    def test_claude_envelope_without_usage_is_unknown(self):
+        self.assertEqual(rb.claude_usage(json.dumps({"type": "result"}), ""),
+                         (None, None, None))
+        self.assertEqual(rb.claude_usage(json.dumps(["usage"]), ""), (None, None, None))
+
+    def test_claude_non_int_usage_is_unknown(self):
+        for tin, tout in (("12", 3), (True, 3), (None, 3), (-1, 3), (3, None)):
+            env = json.dumps({"usage": {"input_tokens": tin, "output_tokens": tout}})
+            self.assertEqual(rb.claude_usage(env, ""), (None, None, None), (tin, tout))
+
+    # --- codex: the "tokens used" footer that terminates stderr ------------- #
+
+    def test_codex_two_line_footer_total_only(self):
+        stderr = ("OpenAI Codex v0.142.2\n--------\nuser\nprompt echo\n"
+                  "codex\nready\ntokens used\n13,976\n")
+        self.assertEqual(rb.codex_usage("ready", stderr), (None, None, 13976))
+
+    def test_codex_one_line_footer(self):
+        self.assertEqual(rb.codex_usage("ready", "codex\nready\ntokens used: 4,657"),
+                         (None, None, 4657))
+
+    def test_codex_footer_must_terminate_stderr(self):
+        # A "tokens used" pair QUOTED mid-stream (echoed prompt or mirrored
+        # review) is not the CLI's footer — only the tail position is trusted.
+        stderr = "user\ntokens used\n123\ncodex\nthe real reply text\n"
+        self.assertEqual(rb.codex_usage("reply", stderr), (None, None, None))
+
+    def test_codex_empty_or_unrelated_stderr_is_unknown(self):
+        self.assertEqual(rb.codex_usage("ready", ""), (None, None, None))
+        self.assertEqual(rb.codex_usage("ready", "warning: sandbox note"),
+                         (None, None, None))
+        self.assertEqual(rb.codex_usage("ready", "tokens used\nnot-a-number"),
+                         (None, None, None))
+
+    # --- seats whose CLIs print no usage at all ------------------------------ #
+
+    def test_gemini_antigravity_ollama_are_always_unknown(self):
+        for seat in ("gemini", "antigravity", "ollama"):
+            adapter = rb.REGISTRY[seat]
+            self.assertEqual(adapter.parse_usage("a full review", "[router] noise"),
+                             (None, None, None), seat)
+
+    def test_registry_wires_the_grounded_parsers(self):
+        self.assertIs(rb.REGISTRY["claude"].parse_usage, rb.claude_usage)
+        self.assertIs(rb.REGISTRY["codex"].parse_usage, rb.codex_usage)
+
+
+class TestPriceBand(unittest.TestCase):
+    def test_split_prices_exactly_at_list(self):
+        band = rb.price_band_usd("claude-fable-5", 100_000, 20_000, None)
+        self.assertEqual(band[0], band[1])
+        self.assertAlmostEqual(band[0], (100_000 * 10.00 + 20_000 * 50.00) / 1e6)
+
+    def test_total_only_bands_between_input_and_output_price(self):
+        self.assertEqual(rb.price_band_usd("claude-fable-5", None, None, 1_000_000),
+                         (10.00, 50.00))
+
+    def test_unknown_model_or_no_tokens_is_none(self):
+        self.assertIsNone(rb.price_band_usd("mystery-model", 10, 10, 20))
+        self.assertIsNone(rb.price_band_usd("claude-fable-5"))
+
+    def test_unverified_price_entry_is_none_not_zero(self):
+        # An inline id whose price wasn't verified must price as unknown — a
+        # $0.00 would read as "free", which is a guess in the wrong direction.
+        for model, prices in rb.MODEL_PRICING_USD_PER_MTOK.items():
+            if prices[0] is None or prices[1] is None:
+                self.assertIsNone(rb.price_band_usd(model, None, None, 1000), model)
+
+
+class TestEstimateRun(unittest.TestCase):
+    MODELS = ["claude-fable-5", "gpt-5.5", "gemini-3.5-flash"]
+
+    def test_pure_and_deterministic(self):
+        a = rb.estimate_run(20_000, self.MODELS, 2, "summaries")
+        b = rb.estimate_run(20_000, self.MODELS, 2, "summaries")
+        self.assertEqual(a, b)
+        self.assertLess(a["tokens_low"], a["tokens_high"])
+        self.assertLess(a["minutes_low"], a["minutes_high"])
+        self.assertEqual((a["seats"], a["rounds"]), (3, 2))
+
+    def test_monotonic_in_source_seats_and_rounds(self):
+        base = rb.estimate_run(10_000, self.MODELS, 2, "summaries")
+        bigger_src = rb.estimate_run(100_000, self.MODELS, 2, "summaries")
+        more_seats = rb.estimate_run(10_000, self.MODELS * 2, 2, "summaries")
+        more_rounds = rb.estimate_run(10_000, self.MODELS, 3, "summaries")
+        for grown in (bigger_src, more_seats, more_rounds):
+            self.assertGreater(grown["tokens_low"], base["tokens_low"])
+            self.assertGreater(grown["tokens_high"], base["tokens_high"])
+
+    def test_cross_reading_ordering(self):
+        none = rb.estimate_run(10_000, self.MODELS, 2, "none")
+        summaries = rb.estimate_run(10_000, self.MODELS, 2, "summaries")
+        full = rb.estimate_run(10_000, self.MODELS, 2, "full")
+        self.assertLess(none["tokens_high"], summaries["tokens_high"])
+        self.assertLess(summaries["tokens_high"], full["tokens_high"])
+        # a single round never cross-reads, so the mode cannot change the numbers
+        one_none = rb.estimate_run(10_000, self.MODELS, 1, "none")
+        one_full = rb.estimate_run(10_000, self.MODELS, 1, "full")
+        for key in ("tokens_low", "tokens_high", "cost_low_usd", "cost_high_usd"):
+            self.assertEqual(one_none[key], one_full[key], key)
+
+    def test_unpriced_models_are_flagged_never_guessed(self):
+        est = rb.estimate_run(10_000, ["claude-fable-5", "totally-unknown-model"],
+                              2, "summaries")
+        self.assertIn("totally-unknown-model", est["unpriced_models"])
+        self.assertTrue(est["cost_is_partial"])
+        self.assertIsNotNone(est["cost_low_usd"])
+        self.assertIn("excludes unpriced", "\n".join(rb.render_estimate(est)))
+
+    def test_all_unpriced_means_cost_unknown(self):
+        est = rb.estimate_run(10_000, ["mystery-a", "mystery-b"], 2, "summaries")
+        self.assertIsNone(est["cost_low_usd"])
+        self.assertIn("cost    : unknown", "\n".join(rb.render_estimate(est)))
+
+    def test_local_seat_is_zero_cost(self):
+        est = rb.estimate_run(10_000, ["llama3.3"], 1, "none")
+        self.assertEqual((est["cost_low_usd"], est["cost_high_usd"]), (0.0, 0.0))
+
+    def test_render_estimate_wording_is_explicit(self):
+        text = "\n".join(rb.render_estimate(
+            rb.estimate_run(10_000, ["claude-fable-5"], 2, "summaries")))
+        self.assertIn("ESTIMATES, not measurements or a gate", text)
+        self.assertIn("tokens  :", text)
+        self.assertIn(rb.PRICING_AS_OF, text)
+
+
+class TestTokenRendering(unittest.TestCase):
+    def _rounds(self, with_tokens):
+        a = _sr("claude", 1, "## Verdict\nlong enough\nVERDICT: ship")
+        b = _sr("codex", 1, "## Verdict\nlong enough\nVERDICT: ship")
+        if with_tokens:
+            a.model_requested = "claude-fable-5"
+            a.tokens_in, a.tokens_out, a.tokens_total = 100_000, 20_000, 120_000
+            b.tokens_total = 50_000   # codex-style combined count, no split
+        return [[a, b]]
+
+    def test_tsv_without_tokens_is_baseline(self):
+        tsv = rb.render_run_metadata_tsv(self._rounds(False))
+        lines = tsv.splitlines()
+        self.assertEqual(tuple(lines[0].split("\t")), rb.RUN_METADATA_TSV_COLUMNS)
+        self.assertNotIn("tokens", tsv)
+        # existing consumers read the packet hash as the LAST column — still true
+        self.assertTrue(lines[1].endswith("pk1"))
+
+    def test_tsv_with_tokens_appends_trailing_columns(self):
+        tsv = rb.render_run_metadata_tsv(self._rounds(True))
+        lines = tsv.splitlines()
+        self.assertEqual(tuple(lines[0].split("\t")),
+                         rb.RUN_METADATA_TSV_COLUMNS + rb.RUN_METADATA_TSV_TOKEN_COLUMNS)
+        self.assertEqual(lines[1].split("\t")[-3:], ["100000", "20000", "120000"])
+        self.assertEqual(lines[2].split("\t")[-3:], ["-", "-", "50000"])
+
+    def test_cost_time_section_absent_without_tokens(self):
+        self.assertEqual(rb.render_cost_time_section(self._rounds(False)), [])
+        self.assertEqual(rb.render_cost_time_section([]), [])
+        self.assertEqual(rb.render_cost_time_section(None), [])
+
+    def test_cost_time_section_present_with_tokens(self):
+        text = "\n".join(rb.render_cost_time_section(self._rounds(True)))
+        self.assertIn("## Cost & time (best effort)", text)
+        self.assertIn("170,000", text)                       # 120k + 50k known
+        self.assertIn("2 of 2 seat-round(s)", text)
+        self.assertIn("never guessed", text)
+        self.assertIn("ESTIMATE", text)
+        self.assertIn("Wall clock (measured)", text)
+        # only the verified-price model is costed: fable-5 split at list price
+        expected = (100_000 * 10.00 + 20_000 * 50.00) / 1e6
+        self.assertIn(f"${expected:.2f}", text)
+
+    def test_seat_tokens_label_shapes(self):
+        [[a, b]] = self._rounds(True)
+        self.assertEqual(rb.seat_tokens_label(a),
+                         "in 100,000 · out 20,000 · total 120,000")
+        self.assertIn("no in/out split", rb.seat_tokens_label(b))
+        [[c, _]] = self._rounds(False)
+        self.assertIn("unknown", rb.seat_tokens_label(c))
+
+
+class TestTokenlessRunStaysByteIdentical(EnvMixin):
+    """The v1.11 standing invariant: a default mocked run (no seat reports usage)
+    must carry NO token/cost surface anywhere — same bytes as the pre-feature
+    baseline in run-metadata.md/tsv and the final-consensus.html footer."""
+
+    def test_default_mocked_run_has_no_token_surfaces(self):
+        out = tempfile.mkdtemp(prefix="board-notokens-")
+        code, _, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--yes"])
+        self.assertEqual(code, rb.EXIT_OK)
+        with open(os.path.join(out, "run-metadata.tsv")) as fh:
+            tsv = fh.read()
+        self.assertEqual(tuple(tsv.splitlines()[0].split("\t")),
+                         rb.RUN_METADATA_TSV_COLUMNS)
+        self.assertNotIn("tokens", tsv)
+        with open(os.path.join(out, "run-metadata.md")) as fh:
+            meta = fh.read()
+        self.assertNotIn("Cost & time", meta)
+        self.assertNotIn("Tokens as reported", meta)
+        # The HTML footer built AGAINST this run dir equals one built without it:
+        # no seat reported usage, so the metadata segment must not appear at all.
+        data = _verdict("caution", "caution", "caution", title="t")
+        with_dir = rv.build_handoff_data(data, run_dir=out)["metadata"]
+        without = rv.build_handoff_data(data, run_dir=None)["metadata"]
+        self.assertEqual(with_dir, without)
+        self.assertNotIn("tokens", with_dir)
+
+
+class TestDryRunEstimate(EnvMixin):
+    def test_dry_run_prints_the_estimate_block(self):
+        out = os.path.join(tempfile.mkdtemp(prefix="board-est-"), "run")
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out, "--dry-run"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("=== estimate (best effort — never a gate) ===", text)
+        self.assertIn("tokens  :", text)
+        self.assertIn("ESTIMATES, not measurements or a gate", text)
+        self.assertFalse(os.path.exists(out), "dry-run must still write nothing")
+
+    def test_dry_run_auto_rounds_notes_the_ceiling(self):
+        out = os.path.join(tempfile.mkdtemp(prefix="board-est-"), "run")
+        code, text, _ = run_cli(["run", "--source", SAMPLE, "--out", out,
+                                 "--dry-run", "--rounds", "auto"])
+        self.assertEqual(code, rb.EXIT_OK)
+        self.assertIn("--max-rounds ceiling", text)
+
+
+class TestHtmlFooterTokenTotals(unittest.TestCase):
+    def _run_dir_with_tokens(self):
+        d = tempfile.mkdtemp(prefix="board-tokens-")
+        cols = rb.RUN_METADATA_TSV_COLUMNS + rb.RUN_METADATA_TSV_TOKEN_COLUMNS
+        base = ["1", "seat", "prov", "model", "unknown", "ran", "ship",
+                "-", "1", "60.00", "0", "no", "ph", "pk"]
+        rows = []
+        for seat, model, tin, tout, ttotal in (
+                ("claude", "claude-fable-5", "100000", "20000", "120000"),
+                ("codex", "gpt-5.5", "-", "-", "50000"),
+                ("gemini", "gemini-3.5-flash", "-", "-", "-")):
+            row = list(base)
+            row[1], row[3] = seat, model
+            rows.append("\t".join(row + [tin, tout, ttotal]))
+        with open(os.path.join(d, "run-metadata.tsv"), "w") as fh:
+            fh.write("\t".join(cols) + "\n" + "\n".join(rows) + "\n")
+        return d
+
+    def test_footer_reports_totals_with_estimate_wording(self):
+        d = self._run_dir_with_tokens()
+        hd = rv.build_handoff_data(_verdict("ship", "ship", "ship", title="t"), run_dir=d)
+        meta = hd["metadata"]
+        self.assertIn("Seat-reported tokens", meta)
+        self.assertIn("170,000", meta)               # 120k + 50k; gemini unknown
+        self.assertIn("where known", meta)           # some seats reported nothing
+        self.assertIn("est. cost", meta)             # fable-5 has a verified price
+        self.assertIn("an estimate, not a bill", meta)
+        # and the totals survive to the rendered page footer
+        import render_handoff as rh
+        with open(rh.default_template()) as fh:
+            html_out = rh.render(hd, fh.read())
+        self.assertIn("Seat-reported tokens", html_out)
+
+    def test_footer_ignores_a_tokenless_tsv(self):
+        d = tempfile.mkdtemp(prefix="board-tokenless-")
+        with open(os.path.join(d, "run-metadata.tsv"), "w") as fh:
+            fh.write("\t".join(rb.RUN_METADATA_TSV_COLUMNS) + "\n")
+        data = _verdict("ship", "ship", "ship", title="t")
+        self.assertEqual(rv.build_handoff_data(data, run_dir=d)["metadata"],
+                         rv.build_handoff_data(data, run_dir=None)["metadata"])
+
+    def test_footer_ignores_a_missing_run_dir(self):
+        data = _verdict("ship", "ship", "ship", title="t")
+        ghost = os.path.join(tempfile.mkdtemp(prefix="board-ghost-"), "nope")
+        self.assertEqual(rv.build_handoff_data(data, run_dir=ghost)["metadata"],
+                         rv.build_handoff_data(data, run_dir=None)["metadata"])
+
+    def test_footer_survives_malformed_token_cells(self):
+        # A Unicode digit-class char ("²") passes str.isdigit() yet int() rejects
+        # it — the reader must degrade the cell to unknown, never raise (the
+        # best-effort/malformed-row contract).
+        d = tempfile.mkdtemp(prefix="board-badcell-")
+        cols = rb.RUN_METADATA_TSV_COLUMNS + rb.RUN_METADATA_TSV_TOKEN_COLUMNS
+        row = ["1", "claude", "Anthropic", "claude-fable-5", "x", "ran", "ship",
+               "-", "1", "60.00", "0", "no", "ph", "pk", "-", "-", "²"]
+        with open(os.path.join(d, "run-metadata.tsv"), "w") as fh:
+            fh.write("\t".join(cols) + "\n" + "\t".join(row) + "\n")
+        data = _verdict("ship", "ship", "ship", title="t")
+        self.assertEqual(rv.build_handoff_data(data, run_dir=d)["metadata"],
+                         rv.build_handoff_data(data, run_dir=None)["metadata"])
+
+
+class TestTimeoutNeverMinesPartialStreams(EnvMixin):
+    """A killed process returns PARTIAL streams (spawn.py), so the parsers' tail/
+    whole-document anchors don't hold — a timed-out seat must record unknown
+    tokens even when the partial tail looks exactly like a codex footer."""
+
+    def _run_codex_with_fake_spawn(self, fake):
+        from _conductor import rounds as rounds_mod
+        config = _config()
+        blobs = rb.build_packet(config)
+        codex_seat = next(s for s in config.board if s.name == "codex")
+        blob = next(b for b in blobs if b.seat == "codex")
+        real_spawn = rounds_mod.spawn
+        rounds_mod.spawn = lambda *a, **k: fake
+        try:
+            return rounds_mod._run_seat_round(
+                codex_seat, blob, config, round_no=1,
+                round_packet_hash=rb.packet_hash(blobs), workdir=None, timeout=1)
+        finally:
+            rounds_mod.spawn = real_spawn
+
+    def test_timed_out_partial_tail_is_not_mined(self):
+        # The mirrored prompt/review in a killed codex's partial stderr can end
+        # with a QUOTED "tokens used"/N pair; the guard must ignore it.
+        fake = rb.SpawnResult(124, "partial review text",
+                              "user\nquoting the docs:\ntokens used\n12,345\n",
+                              30.0, True)
+        r = self._run_codex_with_fake_spawn(fake)
+        self.assertTrue(r.timed_out)
+        self.assertEqual((r.tokens_in, r.tokens_out, r.tokens_total),
+                         (None, None, None))
+
+    def test_completed_footer_still_captured(self):
+        # Control: the same tail on a process that FINISHED is the CLI's own
+        # footer and is captured end-to-end through the round runner.
+        review = ("## Verdict\nGo with conditions — evidence, objection, risk, "
+                  "invariant and guardrail sections all present and long enough "
+                  "to pass the round-1 shape check for this control fixture.\n"
+                  "## Strongest objections\n- one\n## Risks\n- assumption\n"
+                  "## Concrete evidence\n- x\nVERDICT: caution\n")
+        fake = rb.SpawnResult(0, review, "model: gpt-5.5\ntokens used\n13,976\n",
+                              12.0, False)
+        r = self._run_codex_with_fake_spawn(fake)
+        self.assertFalse(r.timed_out)
+        self.assertEqual((r.tokens_in, r.tokens_out, r.tokens_total),
+                         (None, None, 13976))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
v1.11 Phase 1 (#3a) from `design/run-board-roadmap-v1.11-v1.15.md` — cost & time transparency: **capture + preflight estimate only** (the `--tier` presets are Phase 2, not in this PR).

## What

**1. Per-seat token capture (never guessed).** `SeatRoundResult` gains nullable `tokens_in`/`tokens_out`/`tokens_total`; each `SeatAdapter` gains a `parse_usage(stdout, stderr)` parser. Grounded live against the installed CLIs on 2026-07-01, streams captured separately:

| CLI | What it actually emits | Parser |
|---|---|---|
| claude 2.1.191 | plain `-p` (the board's argv, text mode): **nothing** — stdout is the review, stderr empty; `--verbose` adds nothing in text mode | whole-stdout `--output-format json` result envelope ONLY (`usage.input_tokens`/`output_tokens`); today's text-mode spawns honestly report unknown, and capture lights up automatically if the invocation ever adopts the json envelope |
| codex 0.142.2 | stderr **ends** with `tokens used` ⏎ `13,976` — a combined TOTAL, never an in/out split | tail-anchored whole-line match (plus the older one-line `tokens used: N` form); fills `tokens_total` only |
| gemini 0.46.0 | nothing on either stream | always unknown (commented in REGISTRY) |
| agy 1.0.15 | nothing on either stream | always unknown (commented) |
| ollama | plain `run` prints only the completion (eval counts are `--verbose`-only) | always unknown (commented; local seat is $0 regardless) |

Anti-poisoning: review prose / echoed prompts can QUOTE usage lines or JSON (e.g. when the board reviews this very skill), so parsers only accept usage from positions review content cannot occupy — claude: full-document JSON parse (quoted JSON embedded in prose fails `json.loads` over the whole stdout); codex: the footer that terminates stderr (final line pair only).

**2. Pricing table + pure preflight estimator.** `constants.MODEL_PRICING_USD_PER_MTOK`, dated (`PRICING_AS_OF = 2026-07-01`), keyed by the REGISTRY's inline model ids and checked against the providers' published prices that day: `claude-fable-5` $10/$50, `gpt-5.5` $5/$30, `gemini-3.5-flash` $1.50/$9 per MTok (uncached list rates), `llama3.3` $0 (local). The table supports `None` = "not verified" entries that render as *unknown* — never $0, never a guess (test-enforced). `estimate_run(source_bytes, models, rounds, cross_reading)` is pure/deterministic and returns token band + cost band + rough minutes; surfaced as an `=== estimate (best effort — never a gate) ===` block in `run --dry-run` (with an `auto`-rounds ceiling note), and SKILL.md's flag-a-large-run guidance now points at it. `price_band_usd()` prices a known split exactly at list and brackets a total-only count between all-input/all-output pricing. Sample output for the test fixture: `tokens ~14,856–25,656 · cost ~$0.20–$0.52 · roughly 2–10 minutes`.

**3. "If known" rendering, byte-identical when unknown.** When any seat-round carries reported usage: per-round `Tokens as reported by the seat CLIs (if known…)` lines and a `## Cost & time (best effort)` section in `run-metadata.md`; three trailing TSV columns; and a `Seat-reported tokens … (an estimate, not a bill)` segment in the `final-consensus.html` footer (read back from the run dir's TSV by header name). With all tokens unknown — every mocked/default run today — **run-metadata.md, run-metadata.tsv, and the html footer are byte-identical to baseline** (test-guarded).

**TSV columns decision:** the three token columns are appended **only when at least one seat-round actually reported usage**. Rationale: the existing suite (and any external consumer) reads the packet hash as the *last* column (`split("\t")[-1]` in `test_tsv_has_row_per_seat_per_round`), and the mocked default-run fixture outputs must not change — always-on columns would break both. `RUN_METADATA_TSV_TOKEN_COLUMNS` documents the conditional layout; the html-footer reader resolves columns by header name so it handles both layouts.

## Why

Roadmap v1.11 "Transparency & foundations": know what a run will cost and how long it takes — before launch (estimate) and after (capture) — always best-effort, never a gate. Substrate for Phase 2's `--tier` presets.

## Tests

676 → 712 (all green): `cd skills/advisory-board && python3 -m unittest discover -s tests -t tests`. The claude envelope parser was additionally validated against a live `claude -p --output-format json` response, and the codex footer against a live `codex exec` run (streams captured separately). An adversarial sub-agent review of the diff found no blockers and two minor hardening gaps, both fixed and regression-tested here: (1) a timed-out seat now always records unknown tokens — a killed process returns *partial* streams, so the parsers' tail/whole-document anchors don't hold and a quoted `tokens used` pair in the partial tail could have been mined; (2) the footer's TSV reader rejects non-ASCII digit-class cells (`"²".isdigit()` is True but `int()` raises) so a malformed cell degrades to unknown instead of crashing the render.

- `TestUsageParsers` — per-CLI fixtures: claude envelope / text-mode / quoted-JSON poisoning / non-int guards; codex two-line + one-line footers, mid-stream quoting rejected, unrelated stderr; gemini/agy/ollama always-unknown; registry wiring.
- `TestPriceBand` + `TestEstimateRun` — split-at-list vs total-band pricing; unverified-price-is-None-not-$0; determinism; monotonicity in source/seats/rounds; cross-reading ordering (none < summaries < full; mode irrelevant at 1 round); unpriced models flagged; local $0; explicit estimate wording.
- `TestTokenRendering` — conditional TSV trailing columns ("-" for unknown cells; baseline header when tokenless; packet hash still the last column), cost/time section presence/absence, seat token labels.
- `TestTokenlessRunStaysByteIdentical` — e2e mocked default run: baseline TSV header, no token/cost strings in `run-metadata.md`, html footer metadata equal with and without the run dir.
- `TestDryRunEstimate` — the estimate block prints, writes nothing, notes the `auto` ceiling.
- `TestHtmlFooterTokenTotals` — totals + "where known" + "an estimate, not a bill" wording reach the rendered page; tokenless TSVs, missing run dirs, and malformed token cells leave the footer untouched.
- `TestTimeoutNeverMinesPartialStreams` — a killed seat whose partial stderr tail quotes a codex footer records unknown; the same footer on a completed process is captured end-to-end through the round runner.

## Deliberately left out

- `--tier quick|standard|deep` presets (Phase 2).
- No new CLI flags; the only `cli.py` change is inside the existing dry-run block (kept minimal for the parallel history/doctor/digest PRs).
- No change to `verdict.json` (schema evolution is v1.12), `final-consensus.md`, or the `.raw` black-box records.
- No argv changes to any seat: claude keeps plain `-p` text mode (switching it to the json envelope so tokens flow would change the stdout contract, mocks, and shape checks — a deliberate later decision, not smuggled into a capture PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
