### PR TITLE
advisory-board: tests/README — command citations resolve via opt-in re-execution

### DIFF
--- a/skills/advisory-board/tests/README.md
+++ b/skills/advisory-board/tests/README.md
@@ -104,8 +104,10 @@ The M5 canonical-verdict layer adds:
   `path:line`/`symbol` resolves against the source (in-range → verified, out-of-range
   / absent-symbol → refuted, missing-file / no-source → unverified); `source` quotes
   resolve against the **captured packet only** (present → verified, absent → refuted,
-  no-packet → unverified — it never reaches the URL); `command` is unverified
-  (deferred), `judgment` is left unstamped.
+  no-packet → unverified — it never reaches the URL); `command` is unverified by
+  default (re-execution is opt-in), and resolves against re-execution under
+  `--allow-program NAME` (exit matches `expect_exit` and `expect` substring present
+  → verified, mismatch → refuted); `judgment` is left unstamped.
 - **The gate abstains in the torn regime** (`TestGateAbstain`, `TestGateReconcileVerdictVsBoard`,
   `TestGateRefutedAnywhere`) — `--gate` returns exit `3` ("human required") when the seats that
   ran straddle the `--fail-on` line with no strict majority, when the declared `verdict` clears


### PR DESCRIPTION
Docs-only truth fix. tests/README.md's M5 canonical-verdict notes still said `command` citations are 'unverified (deferred)', but command re-execution shipped in v1.4.0 (`verify_evidence.py`): opt-in via `--allow-program NAME`, verified iff exit matches `expect_exit` and any `expect` substring is present in output, mismatch → refuted.

This edit was found sitting uncommitted in the main checkout (blocking its fast-forward); verified against `verify_evidence.py:30-31,374-409` and landed properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)