### PR TITLE
advisory-board: roadmap — v1.11 shipped, M2 (v1.12) next

### DIFF
--- a/design/run-board-roadmap-v1.11-v1.15.html
+++ b/design/run-board-roadmap-v1.11-v1.15.html
@@ -424,26 +424,26 @@ footer.colophon code { background: var(--surface-2); }
           
           <span class="chip"><b>Baseline</b> advisory-board/v1.10.0 · `main` @ `be4c9b2` · 676 tests green</span>
           
-          <span class="chip"><b>Status</b> M1 (v1.11) in progress</span>
+          <span class="chip"><b>Status</b> M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 (v1.12) next — opens with the verdict-lifecycle schema DECISION phase</span>
           
         </div>
       </div>
       <div class="gauge">
-        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 29%">
+        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 34%">
           <circle class="ring-track" cx="60" cy="60" r="52" fill="none" stroke-width="11"/>
           <circle class="ring-arc" cx="60" cy="60" r="52" fill="none" stroke-width="11"
                   stroke-linecap="round" transform="rotate(-90 60 60)"
-                  stroke-dasharray="326.7" stroke-dashoffset="232.0"/>
-          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">29%</text>
+                  stroke-dasharray="326.7" stroke-dashoffset="215.6"/>
+          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">34%</text>
           <text class="ring-sub" x="60" y="76" text-anchor="middle" dominant-baseline="middle">complete</text>
         </svg>
-        <div class="gauge-count"><b>11</b> / 38 tasks done</div>
+        <div class="gauge-count"><b>13</b> / 38 tasks done</div>
       </div>
     </div>
 
     <div class="rail">
       
-      <span class="rail-item wip"><i class="dot"></i>M1</span>
+      <span class="rail-item done"><i class="dot"></i>M1</span>
       
       <span class="rail-item todo"><i class="dot"></i>M2</span>
       
@@ -475,16 +475,16 @@ footer.colophon code { background: var(--surface-2); }
     <div class="section-head"><h2 class="section-title">Milestones</h2><span class="rule"></span></div>
 
     
-    <article class="milestone wip">
+    <article class="milestone done">
       <div class="ms-head">
         <div class="ms-num">1</div>
         <div class="ms-head-main">
           <h3 class="ms-title">v1.11 — Transparency &amp; foundations</h3>
           <div class="ms-meta">
-            <span class="badge wip"><span class="dot"></span>In progress</span>
+            <span class="badge done"><span class="dot"></span>Done</span>
             <span class="ms-progress">
-              <span class="ms-bar"><span style="width:85%"></span></span>
-              11/13
+              <span class="ms-bar"><span style="width:100%"></span></span>
+              13/13
             </span>
           </div>
         </div>
@@ -632,17 +632,17 @@ footer.colophon code { background: var(--surface-2); }
         
       </div>
       
-      <div class="phase todo">
+      <div class="phase done">
         <div class="phase-head">
           <span class="phase-dot"></span>
           <h4 class="phase-title">Phase 6 — Reconcile &amp; release v1.11</h4>
-          <span class="phase-state">To do</span>
+          <span class="phase-state">Done</span>
         </div>
         <ul class="checklist">
           
-          <li class="todo"><span class="tick"></span><span class="task-text">CHANGELOG <code>v1.11.0</code> section reconciled and landed on <code>main</code> before tagging</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">CHANGELOG <code>v1.11.0</code> section reconciled and landed on <code>main</code> before tagging (runs-root re-homed to Changed, <code>history</code> to Added) <em>(PR #58)</em></span></li>
           
-          <li class="todo"><span class="tick"></span><span class="task-text">Tag <code>advisory-board/v1.11.0</code> on Tim&#x27;s <strong>explicit go</strong> → <code>release.yml</code> green, release body = changelog section</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">Tag <code>advisory-board/v1.11.0</code> on Tim&#x27;s <strong>explicit go</strong> (given 2026-07-01) → <code>release.yml</code> green, release published as Latest, body = changelog section</span></li>
           
         </ul>
         
@@ -1288,7 +1288,7 @@ footer.colophon code { background: var(--surface-2); }
 
   <!-- ===================== COLOPHON ===================== -->
   <footer class="colophon">
-    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 11/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
+    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 13/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
   </footer>
 
 </div>

--- a/design/run-board-roadmap-v1.11-v1.15.md
+++ b/design/run-board-roadmap-v1.11-v1.15.md
@@ -5,7 +5,7 @@
 - **Source:** 2026-07-01 four-agent review (feature surface · conductor architecture · artifacts/examples · market scan) + Tim's selection of items 1–14 from the ranked slate
 - **Owner:** Tim
 - **Baseline:** advisory-board/v1.10.0 · `main` @ `be4c9b2` · 676 tests green
-- **Status:** M1 (v1.11) in progress
+- **Status:** M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 (v1.12) next — opens with the verdict-lifecycle schema DECISION phase
 
 ## Overview
 
@@ -57,8 +57,8 @@ Testing: digest JSON golden file; timeout reaches the spawn call; new output-sha
 Gate: full suite.
 
 ### Phase 6 — Reconcile & release v1.11
-- [ ] CHANGELOG `v1.11.0` section reconciled and landed on `main` before tagging
-- [ ] Tag `advisory-board/v1.11.0` on Tim's **explicit go** → `release.yml` green, release body = changelog section
+- [x] CHANGELOG `v1.11.0` section reconciled and landed on `main` before tagging (runs-root re-homed to Changed, `history` to Added) _(PR #58)_
+- [x] Tag `advisory-board/v1.11.0` on Tim's **explicit go** (given 2026-07-01) → `release.yml` green, release published as Latest, body = changelog section
 Gate: `gh release view advisory-board/v1.11.0` shows Latest + full suite green.
 
 ## Milestone: v1.12 — The decision loop


### PR DESCRIPTION
Close out the v1.11 milestone in the roadmap: Phase 6 boxes ticked (CHANGELOG reconcile PR #58; tag advisory-board/v1.11.0 released as Latest on Tim's explicit go), status header updated to M1 SHIPPED / M2 next, HTML view regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)