### PR TITLE
advisory-board: verdict-lifecycle schema fields (v1.12 Phase 1)

### DIFF
--- a/design/run-board-roadmap-v1.11-v1.15.html
+++ b/design/run-board-roadmap-v1.11-v1.15.html
@@ -429,15 +429,15 @@ footer.colophon code { background: var(--surface-2); }
         </div>
       </div>
       <div class="gauge">
-        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 34%">
+        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 39%">
           <circle class="ring-track" cx="60" cy="60" r="52" fill="none" stroke-width="11"/>
           <circle class="ring-arc" cx="60" cy="60" r="52" fill="none" stroke-width="11"
                   stroke-linecap="round" transform="rotate(-90 60 60)"
-                  stroke-dasharray="326.7" stroke-dashoffset="215.6"/>
-          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">34%</text>
+                  stroke-dasharray="326.7" stroke-dashoffset="199.3"/>
+          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">39%</text>
           <text class="ring-sub" x="60" y="76" text-anchor="middle" dominant-baseline="middle">complete</text>
         </svg>
-        <div class="gauge-count"><b>13</b> / 38 tasks done</div>
+        <div class="gauge-count"><b>15</b> / 38 tasks done</div>
       </div>
     </div>
 
@@ -445,7 +445,7 @@ footer.colophon code { background: var(--surface-2); }
       
       <span class="rail-item done"><i class="dot"></i>M1</span>
       
-      <span class="rail-item todo"><i class="dot"></i>M2</span>
+      <span class="rail-item wip"><i class="dot"></i>M2</span>
       
       <span class="rail-item todo"><i class="dot"></i>M3</span>
       
@@ -657,16 +657,16 @@ footer.colophon code { background: var(--surface-2); }
 
     </article>
     
-    <article class="milestone todo">
+    <article class="milestone wip">
       <div class="ms-head">
         <div class="ms-num">2</div>
         <div class="ms-head-main">
           <h3 class="ms-title">v1.12 — The decision loop</h3>
           <div class="ms-meta">
-            <span class="badge todo"><span class="dot"></span>To do</span>
+            <span class="badge wip"><span class="dot"></span>In progress</span>
             <span class="ms-progress">
-              <span class="ms-bar"><span style="width:0%"></span></span>
-              0/9
+              <span class="ms-bar"><span style="width:22%"></span></span>
+              2/9
             </span>
           </div>
         </div>
@@ -677,17 +677,17 @@ footer.colophon code { background: var(--surface-2); }
       
 
       
-      <div class="phase todo">
+      <div class="phase done">
         <div class="phase-head">
           <span class="phase-dot"></span>
           <h4 class="phase-title">Phase 1 — Verdict-lifecycle schema design</h4>
-          <span class="phase-state">To do</span>
+          <span class="phase-state">Done</span>
         </div>
         <ul class="checklist">
           
-          <li class="todo"><span class="tick"></span><span class="task-text">DECISION: one additive evolution of <code>advisory-board/verdict@2</code> — optional <code>previous_run</code> lineage, optional <code>amendments[]</code> (append-only; author/timestamp/reason), and a reserved pointer for v1.13&#x27;s <code>changes</code> — with a compatibility test proving existing verdicts still validate and gate identically</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">DECISION: one additive evolution of <code>advisory-board/verdict@2</code> — optional <code>previous_run</code> lineage, optional <code>amendments[]</code> (append-only; author/timestamp/reason), and a reserved pointer for v1.13&#x27;s <code>changes</code> — with a compatibility test proving existing verdicts still validate and gate identically. <em>Recorded as D8: fields live inside <code>@2</code> (no version bump); tool/human-authored — the synthesizer merge strips them; <code>changes</code> refused loudly until v1.13.</em> <em>(PR #61)</em></span></li>
           
-          <li class="todo"><span class="tick"></span><span class="task-text"><code>references/verdict-schema.md</code> + <code>board_verdict.py</code> validation extended; no renderer breaks on absent fields</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text"><code>references/verdict-schema.md</code> + <code>board_verdict.py</code> validation extended; no renderer breaks on absent fields — byte-identity test-proven on present fields too (consensus md, sequence, handoff data, tldr/pr/slack) <em>(PR #61)</em></span></li>
           
         </ul>
         
@@ -1201,6 +1201,11 @@ footer.colophon code { background: var(--surface-2); }
         <div class="entry-body">each milestone re-scopes in its first phase; drift is corrected in this file, not in heads.</div>
       </li>
       
+      <li>
+        <div class="entry-head"><span class="entry-tag">D8</span><span class="entry-title">Verdict-lifecycle fields live inside <code>@2</code>, not a new <code>@3</code></span></div>
+        <div class="entry-body"><code>previous_run</code> + <code>amendments[]</code> are optional, validated strictly only when present, and invisible when absent, so every existing consumer and file is untouched; <code>@3</code> stays reserved for a genuinely structural break. The fields are tool/human-authored: the synthesizer merge strips them (a model must not fabricate provenance), the gate never reads them, and the reserved <code>changes</code> key is refused loudly until v1.13 defines it.</div>
+      </li>
+      
     </ol>
   </section>
   
@@ -1288,7 +1293,7 @@ footer.colophon code { background: var(--surface-2); }
 
   <!-- ===================== COLOPHON ===================== -->
   <footer class="colophon">
-    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 13/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
+    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 15/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
   </footer>
 
 </div>

--- a/design/run-board-roadmap-v1.11-v1.15.md
+++ b/design/run-board-roadmap-v1.11-v1.15.md
@@ -66,8 +66,8 @@ Gate: `gh release view advisory-board/v1.11.0` shows Latest + full suite green.
 One-shot verdicts become an ongoing advisory relationship: re-review a revised draft with a verdict delta, ask the board follow-ups, and amend a verdict with recorded human provenance. All three touch the verdict lifecycle, so the milestone opens with a single additive schema evolution instead of three ad-hoc bumps.
 
 ### Phase 1 — Verdict-lifecycle schema design
-- [ ] DECISION: one additive evolution of `advisory-board/verdict@2` — optional `previous_run` lineage, optional `amendments[]` (append-only; author/timestamp/reason), and a reserved pointer for v1.13's `changes` — with a compatibility test proving existing verdicts still validate and gate identically
-- [ ] `references/verdict-schema.md` + `board_verdict.py` validation extended; no renderer breaks on absent fields
+- [x] DECISION: one additive evolution of `advisory-board/verdict@2` — optional `previous_run` lineage, optional `amendments[]` (append-only; author/timestamp/reason), and a reserved pointer for v1.13's `changes` — with a compatibility test proving existing verdicts still validate and gate identically. _Recorded as D8: fields live inside `@2` (no version bump); tool/human-authored — the synthesizer merge strips them; `changes` refused loudly until v1.13._ _(PR #61)_
+- [x] `references/verdict-schema.md` + `board_verdict.py` validation extended; no renderer breaks on absent fields — byte-identity test-proven on present fields too (consensus md, sequence, handoff data, tldr/pr/slack) _(PR #61)_
 Testing: old fixture verdicts validate unchanged; new-field round-trip.
 Gate: full suite.
 

--- a/design/run-board-roadmap-v1.11-v1.15.md
+++ b/design/run-board-roadmap-v1.11-v1.15.md
@@ -168,6 +168,7 @@ Gate: release Latest + full suite green.
 - **D5** Everything is opt-in or additive — the no-flags default run stays byte-identical to v1.10.0 artifacts (the regression guard for the whole roadmap), except the runs root moving out of `/tmp`, which is loudly documented and opt-out.
 - **D6** Transform never touches the source — `--output revised-draft` writes new artifacts only; applying the revision is the human's act.
 - **D7** Estimates date from the 2026-07-01 architecture review — each milestone re-scopes in its first phase; drift is corrected in this file, not in heads.
+- **D8** Verdict-lifecycle fields live inside `@2`, not a new `@3` — `previous_run` + `amendments[]` are optional, validated strictly only when present, and invisible when absent, so every existing consumer and file is untouched; `@3` stays reserved for a genuinely structural break. The fields are tool/human-authored: the synthesizer merge strips them (a model must not fabricate provenance), the gate never reads them, and the reserved `changes` key is refused loudly until v1.13 defines it.
 
 ## Risks
 - **R1** CLI-wiring merge conflicts across parallel v1.11 PRs — the five phases are file-disjoint except arg parsing; mitigation: sequential merges, each later branch rebases before merge.
@@ -180,6 +181,7 @@ Gate: release Latest + full suite green.
 ## Later
 Discovered mid-milestone (R6), deliberately not folded into the phase that found it:
 - `--rounds 1` (incl. via `--tier quick`) + `--digest-format json` is a silent no-op — structured digests only exist for round 2+, so the run succeeds with zero JSON digests written. Pre-existing (#13); decide whether to refuse loudly or document. _(found during #3b adversarial review, 2026-07-01)_
+- `board_verdict.py` membership checks on hand-authored files crash with a raw TypeError (exit 1, not the clean schema exit 2) when a token field holds an unhashable value — e.g. top-level `"verdict": []`, `round_verdicts` entries, evidence `kind`/`status`. Pre-existing idiom across the file (the new lifecycle checks guard against it); sweep the remaining membership checks with isinstance guards in one pass. _(found during v1.12 P1 adversarial review, 2026-07-01)_
 
 ## Dependency order
 ```svg

--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -10,6 +10,26 @@ reserved for an explicit production-ready call. The verdict-JSON schema is versi
 
 ## [Unreleased]
 
+### Added
+- **Verdict-lifecycle schema fields (v1.12 Phase 1)** — ONE additive evolution of
+  `advisory-board/verdict@2` (the version string does not change; a verdict without the new
+  fields is byte-for-byte the same schema as before): optional `previous_run` lineage (object;
+  required non-empty `run_dir`, optional `title`/`date`/`verdict`/`verdict_sha256` — the sha
+  binds lineage to the prior verdict's *content*, not a movable path) and optional append-only
+  `amendments[]` (each entry requires the provenance trio `author`/`timestamp`/`reason`; effect
+  fields arrive with the `amend` tooling). Both are validated strictly WHEN PRESENT — like
+  evidence, identically under either schema id (`@1` included) — and are invisible when
+  absent; the gate never reads them. Every renderer reads named fields only, so
+  a lifecycle-carrying verdict renders identically — test-proven for the consensus markdown,
+  the implementation-sequence shape, the handoff data (the HTML's input), and the
+  tldr/pr/slack formats (`--format json` deliberately echoes the whole verdict, lifecycle
+  fields included). The top-level
+  `changes` key is RESERVED for the v1.13 revision artifact and refused loudly while undefined.
+  Lifecycle fields are tool/human-authored, never model reasoning: the synthesizer merge now
+  strips them (new `LIFECYCLE_KEYS`, alongside the protected skeleton keys) so a model reply
+  cannot fabricate an amendment trail or a prior-run link. This is the single schema evolution
+  v1.12's `--revise` / `ask` / `amend` build on — no further ad-hoc bumps.
+
 ## [v1.11.0] - 2026-07-01 — Transparency & foundations
 
 Know before you convene, and keep what you ran. A board run now tells you its **cost and

--- a/skills/advisory-board/references/verdict-schema.md
+++ b/skills/advisory-board/references/verdict-schema.md
@@ -102,6 +102,49 @@ packet, never a live URL fetch** (that would breach quarantine in gate mode). **
 (§9):** a `verified` stamp proves *the receipt resolves*, not that the inference is sound — it
 catches fabrication, not faulty reasoning.
 
+### Lifecycle fields (since v1.12 — optional, additive within `@2`)
+
+A verdict can now carry its own history. Both fields are **tool/human-authored** — written by
+the revise/amend tooling or by hand, never by a model: the synthesizer merge strips them from
+any model reply (a model must not fabricate an amendment trail or a prior-run link), and the
+gate never reads them (lineage and provenance don't move gates). A verdict without them is
+byte-for-byte the same schema as before — absent means absent, never `null`. Like evidence,
+lifecycle fields are validated **identically under either schema id**: an `@1` file carrying
+them (or a `changes` key) gets exactly the same checks as an `@2` file.
+
+- `previous_run` (optional object) — lineage to the run this verdict revises (written by
+  `--revise`, v1.12). `run_dir` (required, non-empty string: the prior run's artifact dir as
+  recorded at run time) plus optional `title` (string), `date` (string), `verdict`
+  (ship | caution | block — the prior verdict token), and `verdict_sha256` (64 lowercase hex:
+  the sha256 of the prior `verdict.json` bytes, binding lineage to *content*, not a movable
+  path).
+- `amendments[]` (optional list, **append-only by contract**) — human-owned tuning recorded
+  next to the board's words, never instead of them (`amend`, v1.12, appends; nothing ever
+  edits board fields in place). Each entry requires `author`, `timestamp` (ISO-8601 expected),
+  and `reason` — all non-empty strings; entries may carry additional effect fields (defined
+  with the `amend` tooling). Renderers that show an amended value show it **with** this
+  provenance.
+- `changes` — **reserved** for the v1.13 revision artifact (the edit → finding mapping of
+  `--output revised-draft`). Not yet defined: a verdict carrying a `changes` key is rejected
+  loudly today, so nothing squats on the name before it means something.
+
+```json
+"previous_run": {
+  "run_dir": "~/.advisory-board/runs/payments-idempotency-review-2026-06-25",
+  "date": "2026-06-25",
+  "verdict": "block",
+  "verdict_sha256": "9f2c…64 hex…"
+},
+"amendments": [
+  { "author": "tim", "timestamp": "2026-07-01T21:40:00", "reason": "confidence overstated: migration path untested", "field": "confidence", "from": "high", "to": "medium" }
+]
+```
+
+`format_output.py --format json` echoes the verdict faithfully, lifecycle fields included;
+every other renderer reads named fields only, so a lifecycle-carrying verdict renders
+identically until the feature that displays it (delta view in v1.12 `--revise`; amended-value
+provenance with `amend`).
+
 ## What `board_verdict.py` enforces
 
 Validation is strict so a malformed verdict can't quietly pass a gate. `scripts/board_verdict.py`
@@ -118,6 +161,10 @@ file *may* carry `evidence[]`, and a malformed item is rejected regardless of ve
 - if `unanimous` is present, it matches the seats' final-round verdicts.
 - every `evidence[]` item (on blockers/dissent/concerns or at the top level) is well-formed for
   its `kind`, and any `status` ∈ {verified, unverified, refuted}.
+- lifecycle fields, strictly **when present** (absent fields check nothing) and regardless of
+  schema version: `previous_run` is an object with a non-empty `run_dir` and type-checked
+  optional keys; every `amendments[]` entry is an object with non-empty
+  `author`/`timestamp`/`reason`; a `changes` key is rejected (reserved for v1.13).
 
 A schema violation exits `2`, distinct from a clean file that simply fails the gate (`1`).
 

--- a/skills/advisory-board/scripts/_conductor/synthesizer.py
+++ b/skills/advisory-board/scripts/_conductor/synthesizer.py
@@ -193,6 +193,13 @@ def synthesizer_template_sha() -> str:
 # emits with these names are dropped during the merge so the structural integrity
 # of `verdict.json` cannot be rewritten by a model reply.
 PROTECTED_SKELETON_KEYS = frozenset(("schema", "title", "date", "rounds", "board"))
+# Verdict-lifecycle fields (since v1.12) are tool/human-authored — lineage and
+# append-only human provenance, written by the revise/amend tooling, never by a
+# model. Stripped like the skeleton keys so a synthesizer reply cannot fabricate
+# an amendment trail or a prior-run link. A separate set (not folded into
+# PROTECTED_SKELETON_KEYS) so that set — and the prompt text enumerating it —
+# stays byte-stable.
+LIFECYCLE_KEYS = frozenset(("previous_run", "amendments", "changes"))
 
 
 def choose_synthesizer_seat(config: RunConfig, last_round_results: list,
@@ -447,14 +454,17 @@ def merge_synthesizer_content(skeleton: dict, content: dict) -> dict:
     """Merge the synthesizer's content fields into the conductor's skeleton.
 
     Keys in PROTECTED_SKELETON_KEYS are stripped from `content` before the merge
-    so a model reply cannot rewrite schema/title/date/rounds/board. Then the
-    conductor computes `unanimous` from the seats' final-round tokens and the
-    merged `verdict` — never trusting a model-asserted flag.
+    so a model reply cannot rewrite schema/title/date/rounds/board; LIFECYCLE_KEYS
+    are stripped for the same reason — lineage and amendments carry tool/human
+    provenance a model reply must not fabricate. Then the conductor computes
+    `unanimous` from the seats' final-round tokens and the merged `verdict` —
+    never trusting a model-asserted flag.
     """
     if not isinstance(content, dict):
         raise ValueError(f"synthesizer content must be a JSON object, got "
                          f"{type(content).__name__}")
-    safe = {k: v for k, v in content.items() if k not in PROTECTED_SKELETON_KEYS}
+    safe = {k: v for k, v in content.items()
+            if k not in PROTECTED_SKELETON_KEYS and k not in LIFECYCLE_KEYS}
     merged = {**skeleton, **safe}
     # `lens_preset` is conductor-authoritative (it names the run's board preset). It's
     # not in PROTECTED_SKELETON_KEYS — keeping that set, and the prompt's enumeration

--- a/skills/advisory-board/scripts/board_verdict.py
+++ b/skills/advisory-board/scripts/board_verdict.py
@@ -37,6 +37,15 @@ EVIDENCE_KINDS = {"code", "source", "command", "judgment"}
 EVIDENCE_STATUS = {"verified", "unverified", "refuted"}
 # Top-level keys whose items may each carry an `evidence[]` list.
 EVIDENCE_CONTAINERS = ("blockers", "dissent", "concerns")
+# Verdict-lifecycle fields (since v1.12) — optional and additive within @2:
+# `previous_run` (lineage to the run this one revises) and `amendments[]`
+# (append-only human tuning, each entry carrying its own provenance). They are
+# tool/human-authored, never model reasoning: the synthesizer merge strips them
+# (see _conductor/synthesizer.py LIFECYCLE_KEYS) and gate_outcome() never reads
+# them. `changes` is RESERVED for the v1.13 revision artifact and refused loudly
+# while undefined, so nothing squats on the name before it means something.
+LIFECYCLE_FIELDS = ("previous_run", "amendments", "changes")
+AMENDMENT_REQUIRED = ("author", "timestamp", "reason")
 
 EXIT_OK = 0
 EXIT_GATE_FAIL = 1
@@ -119,6 +128,55 @@ def iter_evidence_containers(data: dict):
     yield "verdict", data  # the top level may carry a bare evidence[]
 
 
+def _validate_lifecycle(data: dict) -> None:
+    """Lifecycle fields (since v1.12): validated strictly WHEN PRESENT, invisible
+    when absent — an existing verdict without them validates and gates
+    byte-identically. These fields carry lineage and human provenance, not board
+    reasoning, so gate_outcome() never reads them."""
+    if "changes" in data:
+        die("changes is reserved for the revision artifact (v1.13) and not yet "
+            "defined; remove it")
+
+    if "previous_run" in data:
+        prev = data["previous_run"]
+        if not isinstance(prev, dict):
+            die(f"previous_run must be an object when present; got {type(prev).__name__}")
+        run_dir = prev.get("run_dir")
+        if not isinstance(run_dir, str) or not run_dir.strip():
+            die("previous_run.run_dir must be a non-empty string")
+        for key in ("title", "date"):
+            if key in prev and not isinstance(prev[key], str):
+                die(f"previous_run.{key} must be a string when present; "
+                    f"got {type(prev[key]).__name__}")
+        # isinstance guard first: an unhashable value (list/dict) would TypeError
+        # on the `in` check and escape die()'s clean schema exit.
+        if "verdict" in prev and (not isinstance(prev["verdict"], str)
+                                  or prev["verdict"] not in SEVERITY):
+            die(f"previous_run.verdict must be one of {', '.join(SEVERITY)}; "
+                f"got {prev['verdict']!r}")
+        if "verdict_sha256" in prev:
+            sha = prev["verdict_sha256"]
+            if (not isinstance(sha, str) or len(sha) != 64
+                    or any(c not in "0123456789abcdef" for c in sha)):
+                die("previous_run.verdict_sha256 must be 64 lowercase hex chars "
+                    "when present (the sha256 of the prior verdict.json bytes)")
+
+    if "amendments" in data:
+        entries = data["amendments"]
+        if not isinstance(entries, list):
+            die(f"amendments must be a list when present; got {type(entries).__name__}")
+        for index, entry in enumerate(entries):
+            where = f"amendments[{index}]"
+            if not isinstance(entry, dict):
+                die(f"{where} must be an object")
+            missing = [key for key in AMENDMENT_REQUIRED if key not in entry]
+            if missing:
+                die(f"{where} missing field(s): {', '.join(missing)}")
+            for key in AMENDMENT_REQUIRED:
+                if not isinstance(entry[key], str) or not entry[key].strip():
+                    die(f"{where}: {key} must be a non-empty string")
+
+
 def validate(data: dict) -> None:
     """Strict schema check: a malformed verdict must not quietly pass a gate."""
     missing = [key for key in REQUIRED if key not in data]
@@ -197,6 +255,8 @@ def validate(data: dict) -> None:
     for label, obj in iter_evidence_containers(data):
         if "evidence" in obj:
             _validate_evidence_list(obj["evidence"], label)
+
+    _validate_lifecycle(data)
 
 
 # --------------------------------------------------------------------------- #

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -3443,6 +3443,158 @@ class TestSchemaV2Validation(unittest.TestCase):
             evidence=[{"kind": "code", "line": 1}]))  # missing path
 
 
+class TestVerdictLifecycle(unittest.TestCase):
+    """v1.12 Phase 1 — ONE additive evolution of verdict@2: optional
+    `previous_run` lineage, optional append-only `amendments[]` (each entry
+    carrying author/timestamp/reason provenance), and `changes` reserved for
+    the v1.13 revision artifact. Tool/human-authored, never model-emitted
+    (the synthesizer merge strips them); the gate never reads them."""
+
+    LIFECYCLE = {
+        "previous_run": {
+            "run_dir": "/runs/payments-2026-06-25",
+            "title": "Payments idempotency review",
+            "date": "2026-06-25",
+            "verdict": "block",
+            "verdict_sha256": "a" * 64,
+        },
+        "amendments": [
+            {"author": "tim", "timestamp": "2026-07-01T21:40:00",
+             "reason": "confidence overstated: migration path untested",
+             "field": "confidence", "from": "high", "to": "medium"},
+        ],
+    }
+
+    def _lifecycle(self):
+        return json.loads(json.dumps(self.LIFECYCLE))   # fresh copy per test
+
+    def _assert_rejects(self, data):
+        with self.assertRaises(SystemExit) as ctx:
+            bv.validate(data)
+        self.assertEqual(ctx.exception.code, bv.EXIT_SCHEMA)
+
+    # -- compatibility: invisible when absent, valid when present ------------
+
+    def test_old_fixture_carries_no_lifecycle_fields_and_validates(self):
+        with open(VERDICT_M5) as fh:
+            data = json.load(fh)
+        for key in bv.LIFECYCLE_FIELDS:
+            self.assertNotIn(key, data)
+        bv.validate(data)   # pre-v1.12 verdicts validate unchanged
+
+    def test_lifecycle_verdict_validates(self):
+        bv.validate(_verdict("ship", "ship", "ship", **self._lifecycle()))
+
+    def test_gate_ignores_lifecycle_fields(self):
+        # Lineage and provenance never move a gate: identical outcome tuples
+        # with and without the fields, on both fail-on lines.
+        for overall, finals in (("block", ("block", "block")),
+                                ("ship", ("ship", "ship")),
+                                ("caution", ("caution", "ship"))):
+            base = _verdict(overall, *finals)
+            withf = _verdict(overall, *finals, **self._lifecycle())
+            for fail_on in ("block", "caution"):
+                self.assertEqual(bv.gate_outcome(base, fail_on),
+                                 bv.gate_outcome(withf, fail_on))
+
+    def test_minimal_previous_run_is_enough(self):
+        bv.validate(_verdict("ship", "ship", "ship",
+                             previous_run={"run_dir": "/runs/x"}))
+
+    def test_empty_amendments_list_is_valid(self):
+        bv.validate(_verdict("ship", "ship", "ship", amendments=[]))
+
+    # -- strict when present --------------------------------------------------
+
+    def test_changes_key_is_reserved(self):
+        for value in ({}, [], None, "changes.json"):
+            self._assert_rejects(_verdict("ship", "ship", "ship", changes=value))
+
+    def test_previous_run_must_be_object(self):
+        self._assert_rejects(_verdict("ship", "ship", "ship",
+                                      previous_run="/runs/x"))
+
+    def test_previous_run_requires_run_dir(self):
+        self._assert_rejects(_verdict("ship", "ship", "ship", previous_run={}))
+        self._assert_rejects(_verdict("ship", "ship", "ship",
+                                      previous_run={"run_dir": "   "}))
+
+    def test_previous_run_verdict_token_checked(self):
+        # incl. unhashable values, which must die cleanly (exit 2), not TypeError
+        for bad in ("maybe", ["block"], {}, 2, None):
+            self._assert_rejects(_verdict("ship", "ship", "ship",
+                previous_run={"run_dir": "/runs/x", "verdict": bad}))
+
+    def test_previous_run_sha_shape_checked(self):
+        for bad in ("ABC" * 21 + "A", "g" * 64, "a" * 63, 123):
+            self._assert_rejects(_verdict("ship", "ship", "ship",
+                previous_run={"run_dir": "/runs/x", "verdict_sha256": bad}))
+
+    def test_amendments_must_be_list(self):
+        self._assert_rejects(_verdict("ship", "ship", "ship",
+            amendments={"author": "tim", "timestamp": "t", "reason": "r"}))
+
+    def test_amendment_requires_provenance_trio(self):
+        for entry in ({"author": "tim", "timestamp": "t"},           # no reason
+                      {"author": "tim", "reason": "r"},               # no timestamp
+                      {"timestamp": "t", "reason": "r"},              # no author
+                      {"author": "  ", "timestamp": "t", "reason": "r"},
+                      "not-an-object"):
+            self._assert_rejects(_verdict("ship", "ship", "ship",
+                                          amendments=[entry]))
+
+    def test_amendment_extra_effect_fields_allowed(self):
+        # Effect fields (what the amendment touches) are defined with the
+        # amend tooling (v1.12 P4); the schema only pins the provenance trio.
+        bv.validate(_verdict("ship", "ship", "ship", amendments=[
+            {"author": "tim", "timestamp": "2026-07-01T21:40:00",
+             "reason": "added caveat", "caveat": "check the migration path"}]))
+
+    # -- round-trip + layer boundaries ----------------------------------------
+
+    def test_verify_evidence_stamp_preserves_lifecycle_fields(self):
+        # A `code` citation (not judgment) so stamp() takes its real mutation
+        # path — with no source it stamps `unverified` — proving the write
+        # cycle runs AND leaves the lifecycle fields untouched.
+        data = _verdict("block", "block", "block",
+                        blockers=[{"title": "x", "evidence": [
+                            {"kind": "code", "path": "a.py", "line": 1}]}],
+                        **self._lifecycle())
+        ve.stamp(data, None, None)
+        self.assertEqual(data["blockers"][0]["evidence"][0]["status"], "unverified")
+        self.assertEqual(data["previous_run"], self.LIFECYCLE["previous_run"])
+        self.assertEqual(data["amendments"], self.LIFECYCLE["amendments"])
+
+    def test_renderers_ignore_lifecycle_fields(self):
+        # Until the features that display them land (delta view, amend
+        # provenance), a lifecycle-carrying verdict renders byte-identically.
+        base = _verdict("caution", "caution", "caution", title="T",
+                        blockers=[{"title": "b", "body": "x"}],
+                        next_actions=["do it"])
+        withf = json.loads(json.dumps(base))
+        withf.update(self._lifecycle())
+        self.assertEqual(rv.render_markdown(withf), rv.render_markdown(base))
+        self.assertEqual(rv.render_sequence_markdown(withf),
+                         rv.render_sequence_markdown(base))
+        self.assertEqual(rv.build_handoff_data(withf), rv.build_handoff_data(base))
+        for renderer in (fo.as_tldr, fo.as_pr, fo.as_slack):
+            self.assertEqual(renderer(withf), renderer(base))
+
+    def test_synthesizer_merge_strips_lifecycle_keys(self):
+        # A model reply must not fabricate lineage or an amendment trail.
+        skel = {"schema": "advisory-board/verdict@2", "title": "T", "date": "d",
+                "rounds": 2, "board": _seats("ship", "ship")}
+        content = {"verdict": "ship", "confidence": "high",
+                   "previous_run": {"run_dir": "/x"},
+                   "amendments": [{"author": "model", "timestamp": "t",
+                                   "reason": "fabricated"}],
+                   "changes": {"squatting": True}}
+        merged = rb.merge_synthesizer_content(skel, content)
+        for key in bv.LIFECYCLE_FIELDS:
+            self.assertNotIn(key, merged)
+        self.assertEqual(merged["verdict"], "ship")   # content fields still merge
+
+
 class TestGateAbstain(unittest.TestCase):
     def test_unanimous_block_fails(self):
         self.assertEqual(bv.gate_outcome(_verdict("block", "block", "block"), "block")[0], "fail")


### PR DESCRIPTION
v1.12 opens with its DECISION phase: ONE additive evolution of `advisory-board/verdict@2` that `--revise` (P2), `ask` (P3), and `amend` (P4) all build on — no further ad-hoc bumps.

**The decision (recorded as D8 in the roadmap):**
- The fields live **inside `@2`** — no version bump. Optional, validated strictly only when present, invisible when absent; `@3` stays reserved for a genuinely structural break.
- `previous_run` (object): required non-empty `run_dir`; optional `title`/`date`/`verdict`/`verdict_sha256` — the sha binds lineage to the prior verdict's **content**, not a movable path.
- `amendments[]` (append-only by contract): each entry requires the provenance trio `author`/`timestamp`/`reason`; effect fields arrive with the `amend` tooling (P4).
- `changes` is **reserved** for the v1.13 revision artifact and refused loudly while undefined — nothing squats on the name.
- Lifecycle fields are **tool/human-authored, never model reasoning**: the synthesizer merge strips them (new `LIFECYCLE_KEYS`, kept separate so `PROTECTED_SKELETON_KEYS` and the prompt text stay byte-stable) — a model reply cannot fabricate an amendment trail or a prior-run link. The gate never reads them.
- Like evidence, validation applies identically under either schema id (`@1` included).

**Tests (16 new):** old-fixture compat; gate invariance across all three outcome paths (fail/pass/abstain); strict-when-present rejections incl. unhashable token values dying cleanly at exit 2; `verify_evidence` stamp round-trip on the real mutation path; renderer byte-identity (consensus md, implementation-sequence, handoff data, tldr/pr/slack); synthesizer strip. Suite: **811 OK**.

**Adversarial review:** two parallel finders (correctness; schema-compat) — no real breakage. Empirically verified: every existing verdict JSON in the repo validates unchanged, synthesizer template sha byte-stable (recipe reproducibility intact), round-trips lossless, `changes` can never fail a model-synthesized run (stripped pre-validation). Three LOW findings fixed in this PR (unhashable-value guard + regression tests, @1-scope doc honesty, precise renderer claims); one pre-existing validator-wide idiom recorded in the roadmap's Later note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
