### PR TITLE
advisory-board: Opus 4.8 as the Claude seat's sanctioned fallback/downgrade

### DIFF
--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -10,6 +10,16 @@ reserved for an explicit production-ready call. The verdict-JSON schema is versi
 
 ## [Unreleased]
 
+### Changed
+- **Claude seat: Opus 4.8 registered as the one sanctioned fallback.** The seat's default
+  stays `claude-fable-5` at `--effort max` (the depth flagship); `fallback_models` now names
+  `claude-opus-4-8` — probe-and-propose only when Fable 404s, never auto-applied — and
+  SKILL.md documents it as the sanctioned per-run downgrade when Claude usage matters more
+  than Fable-tier depth (`--model claude=claude-opus-4-8`; Opus 4.8 accepts the same
+  `--effort max`, grounded live 2026-07-02 on CLI 2.1.191). SKILL.md also notes the
+  zero-Claude-usage posture: seat a board without the Claude seat (`--board codex,gemini`) —
+  every seat bills its own subscription.
+
 ### Added
 - **`--revise <prior run dir | verdict.json>` (v1.12 #1) — re-review a revised draft with the
   prior verdict as context.** `--source` is the revised draft; the round-1 prompts additionally

--- a/skills/advisory-board/SKILL.md
+++ b/skills/advisory-board/SKILL.md
@@ -45,7 +45,7 @@ If the user says "use defaults", stop asking the *optional* setup questions and 
 
 Target the strongest reasoning model each provider offers:
 
-- Claude seat: `claude-fable-5` (Anthropic's most capable model) at max effort — `--effort max`. Fable 5 is a premium tier (priced above Opus) and max effort means longer, costlier runs; swap it with `--model claude=<id>` if cost matters more than depth.
+- Claude seat: `claude-fable-5` (Anthropic's most capable model) at max effort — `--effort max`. Fable 5 is a premium tier (priced above Opus) and max effort means longer, costlier runs; the sanctioned swap when Claude usage matters more than depth is `--model claude=claude-opus-4-8` (also the seat's registered fallback if Fable is unavailable — Opus 4.8 runs the same `--effort max`). To conserve Claude usage entirely, seat a board without the Claude seat (`--board codex,gemini`) — the other seats bill their own subscriptions.
 - Codex seat: `gpt-5.5` with `model_reasoning_effort="xhigh"` (or the highest Codex reasoning setting available).
 - Gemini seat: Google's latest frontier reasoning model via the Gemini CLI (currently Gemini 3.1 Pro) with `thinkingLevel: HIGH` (or the highest available).
 

--- a/skills/advisory-board/scripts/_conductor/registry.py
+++ b/skills/advisory-board/scripts/_conductor/registry.py
@@ -504,7 +504,12 @@ REGISTRY: dict = {
         auth_hint="run `claude` once and sign in (Claude subscription, or set ANTHROPIC_API_KEY)",
         pkg_label="npm @anthropic-ai/claude-code",
         flags_verified_version="2.1.191",   # --model/--effort/--permission-mode plan verified here
-        fallback_models=(),   # Anthropic ids are stable; pin the current one, no guesses
+        # First (and only) sanctioned fallback: Opus 4.8 at the seat's same max
+        # effort (grounded live 2026-07-02: the CLI accepts --model claude-opus-4-8
+        # --effort max). Probe-and-propose only, never auto-applied — and it's also
+        # the sanctioned per-run downgrade when Claude usage matters more than
+        # Fable-tier depth (--model claude=claude-opus-4-8).
+        fallback_models=("claude-opus-4-8",),
     ),
     "codex": SeatAdapter(
         name="codex",

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -99,6 +99,14 @@ class TestRegistry(unittest.TestCase):
     def test_seats_registered(self):
         self.assertEqual(set(rb.REGISTRY), {"claude", "codex", "gemini", "antigravity", "ollama"})
 
+    def test_claude_seat_model_lineup(self):
+        # Default = Fable 5 at max effort; the one sanctioned fallback/downgrade
+        # is Opus 4.8 at the same effort (grounded live 2026-07-02; Tim's call).
+        a = rb.REGISTRY["claude"]
+        self.assertEqual(a.default_model, "claude-fable-5")
+        self.assertEqual(a.default_reasoning, "max")
+        self.assertEqual(a.fallback_models, ("claude-opus-4-8",))
+
     def test_antigravity_flags(self):
         a = rb.REGISTRY["antigravity"]
         argv = a.build_argv("Gemini 3.5 Flash (High)", "PROMPT", network=False)


### PR DESCRIPTION
Usage-conservation lever (Tim's decision tonight): the Claude seat's default stays **Fable 5 at max effort**, and **Opus 4.8** is now the one registered fallback (`fallback_models` — probe-and-propose when Fable 404s, never auto-applied) and the documented per-run downgrade (`--model claude=claude-opus-4-8`). Grounded live: CLI 2.1.191 accepts Opus 4.8 with the same `--effort max`. SKILL.md also documents the zero-Claude-usage posture (`--board codex,gemini` — each seat bills its own subscription). Registry lineup test added; suite 864 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)