### PR TITLE
advisory-board: format_output — accept {action, owner} next_actions (fix slack TypeError)

### DIFF
--- a/skills/advisory-board/CHANGELOG.md
+++ b/skills/advisory-board/CHANGELOG.md
@@ -10,7 +10,13 @@ reserved for an explicit production-ready call. The verdict-JSON schema is versi
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+- **`format_output.py` crashed on owner-carrying `next_actions[]` entries.** The schema says a
+  `next_actions[]` entry is a string *or* `{action, owner}` and every renderer accepts both
+  forms — `render_verdict.py` did, but `--format slack` raised `TypeError` on the join and
+  `--format pr` printed the raw dict repr. Both short formats now render the same one-line
+  form the implementation-sequence shape uses (`text — owner: NAME`), via the one normalizer
+  in `render_verdict.py`; plain-string entries stay byte-identical.
 
 ## [v1.13.0] - 2026-07-02 — Transform: the board hands back a fixed copy
 

--- a/skills/advisory-board/scripts/format_output.py
+++ b/skills/advisory-board/scripts/format_output.py
@@ -17,6 +17,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _verdict_labels import human_label, is_software_lens, lens_disclaimer  # noqa: E402  lens-aware label + disclaimer
 from board_verdict import effective_confidence  # noqa: E402  the ONE amended-confidence source (v1.12 P4)
+from render_verdict import _action_line  # noqa: E402  the ONE next_actions[] normalizer (string or {action, owner})
 
 
 def die(message: str) -> None:
@@ -95,7 +96,7 @@ def as_pr(data: dict) -> str:
     actions = data.get("next_actions", [])
     if actions:
         out.append("### Next actions")
-        out += [f"1. {a}" for a in actions]
+        out += [f"1. {_action_line(a)}" for a in actions]
         out.append("")
     seats = ", ".join(f"{s.get('seat', '?')} ({s.get('model', '?')})" for s in data.get("board", []))
     rounds = data.get("rounds", "?")
@@ -117,7 +118,7 @@ def as_slack(data: dict) -> str:
         out += [f"• {b.get('title', 'blocker')}" for b in blockers]
     actions = data.get("next_actions", [])
     if actions:
-        out.append("*Next:* " + "; ".join(actions))
+        out.append("*Next:* " + "; ".join(_action_line(a) for a in actions))
     disclaimer = _disclaimer(data)
     if disclaimer:
         out.append(f"_{disclaimer}_")

--- a/skills/advisory-board/tests/test_run_board.py
+++ b/skills/advisory-board/tests/test_run_board.py
@@ -6137,6 +6137,50 @@ class TestVerdictLabels(unittest.TestCase):
             bv.validate(_verdict("ship", "ship", "ship", lens_preset=42))
 
 
+class TestFormatOutputDictActions(unittest.TestCase):
+    """Regression: next_actions[] entries may be `{action, owner}` objects (the schema
+    says every renderer accepts both forms). render_verdict.py always normalized them;
+    format_output.py's slack format crashed (TypeError on the join) and the pr format
+    printed the raw dict repr. Both must render the same one-line form the sequence
+    shape uses, and plain-string entries must stay byte-identical."""
+
+    def _mixed(self):
+        return _verdict("caution", "caution", "caution", title="Relocation decision",
+                        next_actions=[
+                            "Build 6 months of runway",
+                            {"action": "Sign the two anchor clients", "owner": "Tim"},
+                        ])
+
+    def test_slack_renders_dict_actions_instead_of_crashing(self):
+        text = fo.as_slack(self._mixed())
+        self.assertIn("*Next:* Build 6 months of runway; "
+                      "Sign the two anchor clients — owner: Tim", text)
+
+    def test_pr_renders_dict_actions_as_one_line_not_dict_repr(self):
+        text = fo.as_pr(self._mixed())
+        self.assertIn("1. Sign the two anchor clients — owner: Tim", text)
+        self.assertNotIn("{'action'", text)
+
+    def test_string_actions_stay_byte_identical(self):
+        data = _verdict("ship", "ship", "ship", title="T",
+                        next_actions=["Do the thing", "Then the other"])
+        self.assertIn("*Next:* Do the thing; Then the other", fo.as_slack(data))
+        self.assertIn("1. Do the thing", fo.as_pr(data))
+
+    def test_slack_cli_end_to_end_on_dict_actions(self):
+        # The reported repro: --format slack over a verdict.json whose next_actions
+        # carry {action, owner} entries must exit 0, not TypeError.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "verdict.json")
+            with open(path, "w") as fh:
+                json.dump(self._mixed(), fh)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                code = fo.main([path, "--format", "slack"])
+            self.assertEqual(code, 0)
+            self.assertIn("owner: Tim", buf.getvalue())
+
+
 class TestLensAwareFraming(unittest.TestCase):
     """v1.7.x: the verdict banner leads with a plain "here's the call" answer and the
     consensus section drops the "ship" metaphor — for non-software lenses only. A


### PR DESCRIPTION
## What

Pre-existing defect on main (found 2026-07-02 while byte-identity-testing the v1.14 severity-filter PR; not introduced by it): `format_output.py --format slack` crashed with `TypeError: sequence item 0: expected str instance, dict found` when a verdict's `next_actions` contained `{"action": "...", "owner": "..."}` entries. `--format pr` didn't crash but printed the raw dict repr into the comment.

## Why this is the right side of the disagreement

`references/verdict-schema.md` is explicit: a `next_actions[]` entry is a string **or** `{action, owner}`, and "every renderer accepts both forms (a plain string renders unchanged)". `render_verdict.py` honored that (`_action_fields`/`_action_line`); `format_output.py` assumed strings. `board_verdict.py`'s validator places no constraint on `next_actions`, so dict entries are schema-valid end-to-end — the fix belongs in `format_output.py`.

## How

Both short formats now route entries through `render_verdict._action_line` — the one existing normalizer — so an owner-carrying entry renders `text — owner: NAME` exactly as the implementation-sequence shape does, and the two renderers can never drift on the accepted shape again. Audited the other paths: `tldr` never renders `next_actions`; `--format json` is a verbatim passthrough where dicts are legitimate. Both untouched. No import cycle: `render_verdict` has no back-edge to `format_output`, and its module level is side-effect-free (verified under hostile argv).

## Tests

- New `TestFormatOutputDictActions` (4 tests): slack dict rendering, pr one-line (no dict repr), plain-string byte-identity, and the reported CLI repro end-to-end (`--format slack` exits 0).
- Verified the regression tests fail on the pre-fix code (TypeError / dict repr).
- Full suite: **1286 OK** (1282 baseline + 4 new).

## Review

Adversarial skeptic pass (Opus) on the frozen diff: **no findings** across import safety, byte-identity (incl. non-string-scalar coercion), coverage sweep of every `next_actions` consumer, degenerate-shape fuzzing (15 malformed entries — both renderers degrade identically by construction), and test-validity checks. Proportionate to the 3-line fix — no board pass.

CHANGELOG updated under `## [Unreleased]` → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
