### PR TITLE
advisory-board: roadmap — v1.14 shipped (release green)

### DIFF
--- a/design/feature-tracker.html
+++ b/design/feature-tracker.html
@@ -56,7 +56,7 @@
   <p class="sub">Fourteen features across five releases · derived from the roadmap
   (<code>design/run-board-roadmap-v1.11-v1.15.md</code>) — the markdown is the source of
   truth; regenerate with <code>render_tracker.py</code>, never hand-edit.<br>
-  Plan updated: 2026-07-02 · M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 (v1.14) release in flight — P1 PR #71 · P2 PR #73 · P3 PR #75 · tag next</p>
+  Plan updated: 2026-07-02 · M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 SHIPPED (`advisory-board/v1.14.0`, 2026-07-02 — P1 PR #71 · P2 PR #73 · P3 PR #75) · M5 (v1.15) next — full design pass first</p>
 
   <div class="bar"><div></div></div>
   <div class="barlab">14 of 15 slate items shipped (93%) — fourteen
@@ -71,7 +71,7 @@
   <h2>Releases</h2>
   <table>
     <tr><th>Tag</th><th>Milestone</th><th>Feature boxes</th><th>Status</th></tr>
-    <tr class="released"><td class="ver">v1.11</td><td>Transparency &amp; foundations</td><td class="num">11/11</td><td><span class="pill released">RELEASED</span></td></tr><tr class="released"><td class="ver">v1.12</td><td>The decision loop</td><td class="num">7/7</td><td><span class="pill released">RELEASED</span></td></tr><tr class="released"><td class="ver">v1.13</td><td>Transform: the board hands back a fixed copy</td><td class="num">4/4</td><td><span class="pill released">RELEASED</span></td></tr><tr class="gate"><td class="ver">v1.14</td><td>Signal quality &amp; run experience</td><td class="num">4/4</td><td><span class="pill gate">AT RELEASE GATE</span></td></tr><tr class="pending"><td class="ver">v1.15</td><td>Rubric-first deliberation</td><td class="num">0/4</td><td><span class="pill pending">PENDING</span></td></tr>
+    <tr class="released"><td class="ver">v1.11</td><td>Transparency &amp; foundations</td><td class="num">11/11</td><td><span class="pill released">RELEASED</span></td></tr><tr class="released"><td class="ver">v1.12</td><td>The decision loop</td><td class="num">7/7</td><td><span class="pill released">RELEASED</span></td></tr><tr class="released"><td class="ver">v1.13</td><td>Transform: the board hands back a fixed copy</td><td class="num">4/4</td><td><span class="pill released">RELEASED</span></td></tr><tr class="released"><td class="ver">v1.14</td><td>Signal quality &amp; run experience</td><td class="num">4/4</td><td><span class="pill released">RELEASED</span></td></tr><tr class="pending"><td class="ver">v1.15</td><td>Rubric-first deliberation</td><td class="num">0/4</td><td><span class="pill pending">PENDING</span></td></tr>
   </table>
 
   <p class="foot">Status derives from the plan's checkboxes: a feature is SHIPPED when

--- a/design/run-board-roadmap-v1.11-v1.15.html
+++ b/design/run-board-roadmap-v1.11-v1.15.html
@@ -424,20 +424,20 @@ footer.colophon code { background: var(--surface-2); }
           
           <span class="chip"><b>Baseline</b> advisory-board/v1.10.0 · `main` @ `be4c9b2` · 676 tests green</span>
           
-          <span class="chip"><b>Status</b> M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 (v1.14) release in flight — P1 PR #71 · P2 PR #73 · P3 PR #75 · tag next</span>
+          <span class="chip"><b>Status</b> M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 SHIPPED (`advisory-board/v1.14.0`, 2026-07-02 — P1 PR #71 · P2 PR #73 · P3 PR #75) · M5 (v1.15) next — full design pass first</span>
           
         </div>
       </div>
       <div class="gauge">
-        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 84%">
+        <svg class="ring" viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Overall progress 87%">
           <circle class="ring-track" cx="60" cy="60" r="52" fill="none" stroke-width="11"/>
           <circle class="ring-arc" cx="60" cy="60" r="52" fill="none" stroke-width="11"
                   stroke-linecap="round" transform="rotate(-90 60 60)"
-                  stroke-dasharray="326.7" stroke-dashoffset="52.3"/>
-          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">84%</text>
+                  stroke-dasharray="326.7" stroke-dashoffset="42.5"/>
+          <text class="ring-pct" x="60" y="57" text-anchor="middle" dominant-baseline="middle">87%</text>
           <text class="ring-sub" x="60" y="76" text-anchor="middle" dominant-baseline="middle">complete</text>
         </svg>
-        <div class="gauge-count"><b>32</b> / 38 tasks done</div>
+        <div class="gauge-count"><b>33</b> / 38 tasks done</div>
       </div>
     </div>
 
@@ -449,7 +449,7 @@ footer.colophon code { background: var(--surface-2); }
       
       <span class="rail-item done"><i class="dot"></i>M3</span>
       
-      <span class="rail-item wip"><i class="dot"></i>M4</span>
+      <span class="rail-item done"><i class="dot"></i>M4</span>
       
       <span class="rail-item todo"><i class="dot"></i>M5</span>
       
@@ -930,16 +930,16 @@ footer.colophon code { background: var(--surface-2); }
 
     </article>
     
-    <article class="milestone wip">
+    <article class="milestone done">
       <div class="ms-head">
         <div class="ms-num">4</div>
         <div class="ms-head-main">
           <h3 class="ms-title">v1.14 — Signal quality &amp; run experience</h3>
           <div class="ms-meta">
-            <span class="badge wip"><span class="dot"></span>In progress</span>
+            <span class="badge done"><span class="dot"></span>Done</span>
             <span class="ms-progress">
-              <span class="ms-bar"><span style="width:80%"></span></span>
-              4/5
+              <span class="ms-bar"><span style="width:100%"></span></span>
+              5/5
             </span>
           </div>
         </div>
@@ -1027,15 +1027,15 @@ footer.colophon code { background: var(--surface-2); }
         
       </div>
       
-      <div class="phase todo">
+      <div class="phase done">
         <div class="phase-head">
           <span class="phase-dot"></span>
           <h4 class="phase-title">Phase 4 — Docs, review, release v1.14</h4>
-          <span class="phase-state">To do</span>
+          <span class="phase-state">Done</span>
         </div>
         <ul class="checklist">
           
-          <li class="todo"><span class="tick"></span><span class="task-text">Docs + CHANGELOG on <code>main</code>; tag <code>advisory-board/v1.14.0</code> on Tim&#x27;s explicit go → release green</span></li>
+          <li class="done"><span class="tick">✓</span><span class="task-text">Docs + CHANGELOG on <code>main</code>; tag <code>advisory-board/v1.14.0</code> on Tim&#x27;s explicit go → release green <em>CHANGELOG <code>## [v1.14.0] - 2026-07-02 — Signal quality &amp; run experience</code> landed on main (PR #76) before the annotated tag; release workflow green; repo Latest. Standing release go (2026-07-02, v1.13–v1.15) covered the tag.</em></span></li>
           
         </ul>
         
@@ -1323,7 +1323,7 @@ footer.colophon code { background: var(--surface-2); }
 
   <!-- ===================== COLOPHON ===================== -->
   <footer class="colophon">
-    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 32/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
+    Rendered from <code>run-board-roadmap-v1.11-v1.15.md</code> &middot; 5 milestones &middot; 33/38 tasks complete. The markdown plan is the source of truth &mdash; regenerate with <code>render_plan.py</code>; never hand-edit this file.
   </footer>
 
 </div>

--- a/design/run-board-roadmap-v1.11-v1.15.md
+++ b/design/run-board-roadmap-v1.11-v1.15.md
@@ -5,7 +5,7 @@
 - **Source:** 2026-07-01 four-agent review (feature surface · conductor architecture · artifacts/examples · market scan) + Tim's selection of items 1–14 from the ranked slate
 - **Owner:** Tim
 - **Baseline:** advisory-board/v1.10.0 · `main` @ `be4c9b2` · 676 tests green
-- **Status:** M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 (v1.14) release in flight — P1 PR #71 · P2 PR #73 · P3 PR #75 · tag next
+- **Status:** M1 SHIPPED (`advisory-board/v1.11.0`, 2026-07-01) · M2 SHIPPED (`advisory-board/v1.12.0`, 2026-07-02) · M3 SHIPPED (`advisory-board/v1.13.0`, 2026-07-02) · M4 SHIPPED (`advisory-board/v1.14.0`, 2026-07-02 — P1 PR #71 · P2 PR #73 · P3 PR #75) · M5 (v1.15) next — full design pass first
 
 ## Overview
 
@@ -139,7 +139,7 @@ Testing: event sequence golden on a mocked run; tracker renders from fixture sta
 Gate: full suite.
 
 ### Phase 4 — Docs, review, release v1.14
-- [ ] Docs + CHANGELOG on `main`; tag `advisory-board/v1.14.0` on Tim's explicit go → release green
+- [x] Docs + CHANGELOG on `main`; tag `advisory-board/v1.14.0` on Tim's explicit go → release green _CHANGELOG `## [v1.14.0] - 2026-07-02 — Signal quality & run experience` landed on main (PR #76) before the annotated tag; release workflow green; repo Latest. Standing release go (2026-07-02, v1.13–v1.15) covered the tag._
 Gate: release Latest + full suite green.
 
 ## Milestone: v1.15 — Rubric-first deliberation


### PR DESCRIPTION
P4 release box ticked (v1.14.0 green, repo Latest), status line → M4 SHIPPED, views regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)