### PR TITLE
advisory-board: v1.15 P1 design pass — fact sheet + roundtable brief

### DIFF
--- a/design/v1.15-rubric-design-inputs.md
+++ b/design/v1.15-rubric-design-inputs.md
@@ -1,0 +1,326 @@
+# v1.15 rubric-first deliberation — design-brief inputs (fact sheet)
+
+_Scouted 2026-07-02 against `main` @ `3b7a0b4` (post-v1.14.0, M4 fully shipped: PR #71/#73/#75, tag `advisory-board/v1.14.0`) as input for the v1.15 Phase 1 full design pass ("Grilling + dogfood roundtable on the rubric design," roadmap line 150). Paths relative to `skills/advisory-board/` unless stated otherwise. This is a working design document, not user-facing docs. Full suite green: 1426 tests (`python3 -m unittest discover -s tests -t tests`)._
+
+---
+
+## 1. Rounds machinery
+
+**Conductor entry points.** The whole run body lives in `scripts/_conductor/cli.py`. `_execute_run()` wraps `_run_after_activate()` (cli.py:421) in a `try/finally` that stamps a terminal `interrupted` outcome on any abnormal exit (cli.py:399-418) — any new pre-round-1 pass must run *inside* this guard to inherit that safety net.
+
+**Round 1 fan-out** — cli.py:435-437:
+```python
+print("\n=== round 1 (fan-out) ===")
+tracker.round_started(1)
+r1 = run_round(config, blobs, approval, round_no=1, on_seat=_seat_cb)
+```
+Followed immediately by `write_round_artifacts(config, r1, 1)` (cli.py:438) and a "one voice is not a board" guard: `if len(usable1) < 2:` exits `EXIT_PREFLIGHT_NOGO` (cli.py:443-455) before any later round is attempted.
+
+**Round 2…N loop** — cli.py:457-523, a `while round_no <= target:` loop:
+```python
+rN_blobs, board_packet = build_round2(config, prev, round_no=round_no)   # cli.py:478
+...
+rN = run_round(config, rN_blobs, approval, round_no=round_no, on_seat=_seat_cb)   # cli.py:504
+write_round_artifacts(config, rN, round_no)
+rounds_done.append(rN)
+...
+mv = board_movement(prev, rN)   # cli.py:509
+movements.append(mv)
+```
+`target = max_rounds if is_auto else int(config.rounds)` (cli.py:467-469). `config.rounds` is a **string** `"1"|"2"|"3"|"auto"` (`scripts/_conductor/config.py:102`), not an int with no notion of a phase-0 round — `--rounds auto` loops "while the board is still MOVING" (cli.py:462-465) and stops when `mv["moved"] < DEFAULT_CONVERGE_THRESHOLD` (cli.py:518, threshold = 1, `convergence.py:45`) or at `--max-rounds` (`DEFAULT_MAX_ROUNDS`, cli.py:13). An explicit `--rounds N` always runs exactly N rounds regardless of movement (cli.py:466, 522-523: `stop_reason = "round-count"`).
+
+**ThreadPoolExecutor fan-out** — `scripts/_conductor/rounds.py:266-274`, inside `run_round()` (signature at rounds.py:173-176):
+```python
+if parallel and len(seats) > 1:
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=len(seats)) as pool:
+        futures = {pool.submit(_one, s): s for s in seats}
+        for fut, seat in futures.items():
+            results[seat.id] = fut.result()
+```
+`max_workers = len(seats)` — one worker per seat in that round; falls back to serial when `parallel=False` or only one seat remains (rounds.py:272-274). `_run_seat_round()` (rounds.py:94-97) does the actual per-seat spawn + one retry on `Timeout|InvalidOutput` (rounds.py:125-136).
+
+**`on_seat` callback (v1.14 #10)** — `run_round()`'s docstring (rounds.py:180-187): `on_seat(event, seat_id, round_no, result)`, `event` is `"running"` (rounds.py:253, `result=None`) or a terminal state `"done"|"dropped"` derived from `result.usable` (rounds.py:261-262). The `_notify` wrapper (rounds.py:244-250) swallows any exception from the callback ("a bad callback can never break the fan-out").
+
+**Round-1 vs round-2 packet content** (`scripts/_conductor/prompts.py`):
+- Round-1 builder: `build_round1_prompt()` (prompts.py:326-351), template `ROUND1_TEMPLATE` (prompts.py:177-202), version `PROMPT_TEMPLATE_VERSION = "advisory-board/round1@2"` (prompts.py:244; grounded variant `@3`, prompts.py:245).
+- Round-2+ builder: `build_round2_prompt()` (prompts.py:506-531), template `ROUND2_TEMPLATE` (prompts.py:430-452), version `ROUND2_TEMPLATE_VERSION = "advisory-board/round2@3"` (prompts.py:469; grounded `@4`, prompts.py:250) — parameterized by `{round_no}`/`{prev_round}` so the same template drives round 3+ under `--rounds auto` (comment prompts.py:427-429).
+- Round 2 adds, that round 1 lacks: (a) an instruction to report "Where you CHANGED YOUR MIND and where you STILL DISSENT" (prompts.py:447); (b) a `{cross_reading_block}` — either `ROUND2_PEERS_BLOCK` (prompts.py:456-460, the board's prior-round reviews) or `ROUND2_SOLO_BLOCK` (prompts.py:461-467, the seat's own prior review only), selected by `--cross-reading`; (c) a required `BASIS:` line (`BASIS_LINE_INSTRUCTION`, prompts.py:125-136) in addition to `VERDICT_LINE_INSTRUCTION` — round 1 has **only** the VERDICT instruction (prompts.py:202), no BASIS line ("a round-1 reply carries no BASIS line, so this is None there by construction," rounds.py:90).
+- Round 1 (not round 2) carries `{revision_context}` (`REVISION_CONTEXT_BLOCK`, prompts.py:215-227) for `--revise` runs — "the revision clause is round-1 only" (prompts.py:295-296).
+- Both share `{source_material}` (re-supplied every round — each CLI spawn is stateless, comment prompts.py:420-425), `{repo_grounding}`/`{repo_evidence_ask}`, and `{output_override}` (Claude-only).
+
+**Role/persona/lens injection**: both builders pass `role_emphasis=seat.lens` straight from `SeatConfig.lens` (prompts.py:346 round1, prompts.py:524 round2) into the template's `"Role emphasis:\n{role_emphasis}"` slot (ROUND1_TEMPLATE prompts.py:179-180; ROUND2_TEMPLATE prompts.py:432-433). There is no separate "persona" object — lens text *is* the seat's framing (see §9).
+
+**Where a pre-round-1 "rubric-agreement round" would hook in**: between `tracker.activate()`-adjacent setup and the `print("\n=== round 1 (fan-out) ===")` line at cli.py:435, inside `_run_after_activate()`. It needs its own fan-out call (a `run_round`-shaped or purpose-built spawn — see §4's generalizable seven-part pattern), its own artifact-writing convention analogous to `write_round_artifacts(config, r1, 1)` (cli.py:438), and its own packet-hash/egress accounting (round 1's hash re-assertion against `approval.content_hash` happens *inside* `run_round` itself, rounds.py — a pre-round reusing `run_round` would need `round_no` semantics decided, since `round_no` today is 1-indexed and feeds filenames/templates directly). The rubric's output (agreed criteria + weights) would then need to be threaded into `build_round1_prompt`/`ROUND1_TEMPLATE` as a new conditionally-spliced placeholder, mirroring how `{revision_context}` is conditionally spliced today (prompts.py:339-343).
+
+---
+
+## 2. Convergence
+
+**Module**: `scripts/_conductor/convergence.py` (251 lines), framed explicitly as a pure function: "a PURE function over the parsed `VERDICT:` token + the citation set of each seat's round artifacts... it never reads meaning out of the prose" (convergence.py:1-10, restating §11/principle #1).
+
+**Token vocabulary**: `VERDICT_TOKENS = ("ship", "caution", "block")` (convergence.py:40) — identical to `board_verdict.py`'s `SEVERITY` (§6). `BASIS_TOKENS = ("independent", "evidence", "deference")` (convergence.py:121), purely advisory/self-reported: "it never gates and never overrides the one VERDICT token" (convergence.py:117-118).
+
+**`parse_verdict()`** (convergence.py:90-112): scans every line for a `VERDICT:` label via regex `_VERDICT_LINE` (convergence.py:60), rejects markdown-quoted/indented/code-span lines (`_is_quoted_verdict_line()`, convergence.py:65-87), rejects lines naming zero or >1 tokens (the 3-token instruction echo, or a hedge), requires the matched token be the **first alphabetic word** of the value, and the **last qualifying line wins**.
+
+**How movement/consensus is computed — entirely token- and set-based, never numeric**:
+```python
+def seat_movement(prev_text, curr_text) -> dict:   # convergence.py:197-210
+    prev_v, curr_v = parse_verdict(prev_text), parse_verdict(curr_text)
+    verdict_shift = prev_v != curr_v
+    new_cites = citations(curr_text) - citations(prev_text)
+    return {..., "moved": bool(verdict_shift or new_cites)}
+```
+A seat "moved" iff its verdict token changed **OR** it introduced ≥1 new concrete citation (a `frozenset` from `citations()`, convergence.py:177-194, shape-guarded to backticked code-spans/slash-paths, deliberately excluding quoted prose — "it would keep `auto` from ever converging," convergence.py:157-158). No partial/numeric degree of movement exists anywhere.
+
+`board_movement()` (convergence.py:213-235) aggregates movement across a round transition, counting only seats usable in **both** rounds (`considered`); `moved` = count of movers. `DEFAULT_CONVERGE_THRESHOLD = 1` (convergence.py:45) — auto keeps going while ≥1 seat still moves.
+
+**What a numeric per-criterion score convergence would need vs. reuse**:
+- Reusable as-is: the "usable in both rounds" overlap-gating pattern in `board_movement()`; the `--rounds auto` stop-rule wiring in cli.py:514-520 (the loop only consumes a boolean "still moving," agnostic to how that boolean is derived).
+- New machinery required: (a) a parser for per-criterion numeric score lines — `parse_verdict`'s "last line wins, one scalar" design assumes exactly one token per reply, but a rubric reply needs one score **per criterion**, so a labeled multi-line format is new; (b) a numeric movement/convergence definition — e.g. `abs(curr_score - prev_score) >= epsilon` per criterion or a board-wide variance/spread threshold — nothing like this exists today; (c) `SeatRoundResult.verdict`/`.basis` are single-value properties (rounds.py:78-91) — per-criterion scores would need a dict-shaped equivalent; (d) `gate_outcome()` (§6) drives ship/block/abstain purely off the token chain today and has no numeric-aggregation path.
+
+---
+
+## 3. Prompt templates
+
+| Pass | Template constant | Version constant | Template lines | Builder |
+|---|---|---|---|---|
+| Round 1 | `ROUND1_TEMPLATE` | `PROMPT_TEMPLATE_VERSION` = `advisory-board/round1@2` (`@3` grounded) | prompts.py:177-202 | `build_round1_prompt` (prompts.py:326) |
+| Round 2+ | `ROUND2_TEMPLATE` | `ROUND2_TEMPLATE_VERSION` = `advisory-board/round2@3` (`@4` grounded) | prompts.py:430-452 | `build_round2_prompt` (prompts.py:506) |
+| Synthesizer | `SYNTHESIZER_TEMPLATE` | `SYNTHESIZER_TEMPLATE_VERSION` = `advisory-board/synthesizer@2` (synthesizer.py:185) | synthesizer.py:90-179 | `build_synthesizer_prompt` (synthesizer.py:310-369) |
+| Revision | `REVISION_TEMPLATE` | `REVISION_TEMPLATE_VERSION` = `advisory-board/revision@1` (revision.py:259) | revision.py:185-255 | `build_revision_prompt` (revision.py:342+) |
+| Endorsement | `ENDORSEMENT_TEMPLATE` | `ENDORSEMENT_TEMPLATE_VERSION` = `advisory-board/endorsement@1` (endorsement.py:173) | endorsement.py:110-168 | `build_endorsement_prompt` (endorsement.py:244-265) |
+| Ask (post-verdict) | `ASK_TEMPLATE` | `PROMPT_TEMPLATE_ASK` = `advisory-board/ask@1` (prompts.py:362) | prompts.py:364-387 | `build_ask_prompt` (prompts.py:406-416) |
+
+**The §11 reference** (see §4 quote below) governs every one of these: the conductor builds clean packets/skeletons, a model reasons the content, the conductor mechanically validates before writing anything.
+
+**The generalizable "spawn a seat" pattern** every non-round pass (synthesizer → revision → endorsement, in that historical order) follows, confirmed verbatim in `endorsement.py`'s module docstring:
+> "This GENERALIZES the revision spawn path (`_conductor/revision.py`): the same template-versioning + sha discipline, DATA-fence markers + neutralizer, board-seat egress rule... two-attempt retry set (timeout|invalid), raw black-box record, and never-fail-the-run failure posture." (endorsement.py:12-17)
+
+Concretely, each pass has: (1) dedicated BEGIN/END fence-marker constants (e.g. `SYNTHESIZER_BEGIN/END_MARKER`, synthesizer.py:68-69); (2) a `neutralize_X_markers()` scrubbing that pass's own (and, for endorsement, the revision pass's) fence markers before splice; (3) a `X_template_sha()` hashing the raw template bytes for recipe provenance; (4) a `build_X_prompt()` builder; (5) a `run_X()` spawn function mirroring `_run_seat_round`'s two-attempt retry loop, importing `RETRYABLE_FAILURES`/`spawn` directly from `_conductor.spawn` and reusing the identical `ThreadPoolExecutor(max_workers=len(seats))` construction (endorsement.py:590-591, byte-identical shape to rounds.py:268); (6) a `render_X_raw()` black-box recorder mirroring `render_raw_record` (rounds.py:300-333); (7) a strict parse+validate step that raises/rejects rather than guesses on malformed output.
+
+**Where a rubric-proposal or scoring prompt would go**: a new sibling module (e.g. `_conductor/rubric.py`), following this exact seven-part shape — own fence markers, own `neutralize_rubric_markers`, `RUBRIC_TEMPLATE`/`RUBRIC_TEMPLATE_VERSION`, `rubric_template_sha()`, `build_rubric_prompt()`, `run_rubric_pass()` with the same ThreadPoolExecutor fan-out, `render_rubric_raw()`, and a strict `parse_rubric_reply()` — exactly paralleling `endorsement.py`'s relationship to `revision.py`.
+
+---
+
+## 4. Chair/synthesizer mechanics
+
+**§11 — the canonical text** (found in `design/run-board-conductor.md:141-143`, section "## 11. Synthesis and reuse"; this is the section every `§11` in-code comment points back to):
+> "The conductor produces per-seat artifacts and packets deterministically; **synthesis stays a reasoning task** (consensus, dissent, minority report, the evidence/judgment/couldn't-verify split). v1: the conductor stops at clean packets and hands synthesis to the orchestrating agent (or one neutral-synthesizer seat) to populate the canonical `verdict.json`; then it **calls** `verify_evidence.py`, `render_handoff.py`, and `board_verdict.py`. v1.x: promote the synthesizer to a spawned neutral seat (a seat that didn't debate, or a blind merge — per `epistemics.md`) so the chain is one command."
+
+The roadmap's own restatement (run-board-roadmap-v1.11-v1.15.md:18, standing invariant 3): "§11 holds — the conductor plumbs, the models reason; anything that merges meaning (rubric merge, revision drafting) is a seat's job, not code." This is the direct license for — and constraint on — a rubric-merging "chair" seat: it must be a spawned seat, not conductor code, exactly like the synthesizer.
+
+**`scripts/_conductor/synthesizer.py` — the precedent a chair seat would reuse.** Module docstring frames it as explicitly "NOT a 4th board seat" — no lens, briefed only on final-round reviews + conductor-extracted VERDICT tokens, outputs CONTENT fields only, merged into a conductor-owned skeleton, then validated by the same `board_verdict.validate` gate uses.
+
+- **Template + sha discipline**: `SYNTHESIZER_TEMPLATE` (synthesizer.py:90-179); `SYNTHESIZER_TEMPLATE_VERSION = "advisory-board/synthesizer@2"` (synthesizer.py:185, comment 182-184: "Bump when the template shape... changes. The sha covers the exact bytes, so any edit changes the recorded sha even without a bump."); `synthesizer_template_sha()` (synthesizer.py:188-189).
+- **DATA-fence**: `SYNTHESIZER_BEGIN_MARKER`/`SYNTHESIZER_END_MARKER` (synthesizer.py:68-69); `neutralize_synth_markers()` (synthesizer.py:72-79) — "Defense-in-depth, not the only defense... this is bytes," not prose framing.
+- **`choose_synthesizer_seat()`** (synthesizer.py:205-233), exact precedence: (1) `--synthesizer-seat` if given, must be a board seat, else `die("the synthesizer egresses to a provider already covered by the run's disclosure, so it must reuse a board seat")` (synthesizer.py:223-225); (2) else `"claude"` if seated (227-228); (3) else first `usable` seat from the last round (229-232); (4) else `config.board[0]` (233). Docstring: "The point isn't the model identity — fresh CLI spawns are stateless, so any board seat re-invoked with a fresh, no-lens prompt IS a 'model with no prior round.' The PROMPT (no lens, no source) makes it neutral, not the seat name" (synthesizer.py:216-218).
+- **`build_skeleton()`** (synthesizer.py:236-298): conductor-authoritative shell (`schema`, `title`, `date`, `lens_preset`, `rounds`, `board[]`, `previous_run` when revising). "Every field here is conductor-authoritative — none of it is reasoning."
+- **`PROTECTED_SKELETON_KEYS`** = `frozenset(("schema", "title", "date", "rounds", "board"))` (synthesizer.py:195) — keys the model is not allowed to set; dropped on merge. Interpolated directly into the prompt via `{protected_keys}` (synthesizer.py:88-89, 123-125, 372) so the prompt's own enumeration and the merge-time defense cannot drift apart (byte-stability discipline).
+- **`LIFECYCLE_KEYS`** = `frozenset(("previous_run", "amendments", "changes"))` (synthesizer.py:202) — a *separate* set from `PROTECTED_SKELETON_KEYS` specifically "so that set — and the prompt text enumerating it — stays byte-stable" (synthesizer.py:196-201).
+- **`merge_synthesizer_content()`** (synthesizer.py:459-485): strips both key-sets from model content, merges over the skeleton, re-pins `lens_preset`, computes `unanimous` itself from final-round tokens (never trusting a model-asserted flag).
+- **`extract_json_object()`** (synthesizer.py:386-419): fenced ` ```json ` block(s) preferred (`_JSON_FENCE` regex, 383); brace-balanced fallback (`_bare_brace_objects()`, 422-456); **LAST** candidate wins (iterates `reversed(candidates)`, 406-417) — "well-behaved models occasionally prefix a one-liner... before the fence."
+- **`validate_verdict()`** (synthesizer.py:488-517): lazy `import board_verdict`, calls `.validate(data)`, captures `SystemExit`, returns the stripped error string or `None`.
+- **Failure posture**: `RETRYABLE_FAILURES = frozenset({FAILURE_TIMEOUT, FAILURE_INVALID})` (spawn.py:172, preceded by comment "Everything else (AuthFailure, NoOutput, ModelNotFound) is non-recoverable → immediate drop"); `_classify_synthesizer_shape()` (synthesizer.py:663-696); two-attempt retry in `run_synthesizer()` (synthesizer.py:604-619); on failure, `verdict-rejected.json` (cli.py:712-729) and exit posture: default `EXIT_OK` (0, "a synth hiccup never discards the successful rounds"), `--strict-exit` → `EXIT_NO_VERDICT` (4, constants.py:56-59).
+- **Black-box record**: `render_synthesizer_raw()` (synthesizer.py:711-746) — command, prompt-source/version/sha, packet-hash, model-requested/answered, exit/timeout/elapsed/attempts, status, failure-class, parse/schema-error, accepted, then STDOUT/STDERR.
+
+**`scripts/_conductor/revision.py` — the second precedent (v1.13's generalization of the same pattern).** Its own docstring: "This GENERALIZES the synthesizer spawn path... What differs is the reply CONTRACT and the artifact" (revision.py:8-12). Analogous pieces: `REVISION_TEMPLATE`/`REVISION_TEMPLATE_VERSION`/`revision_template_sha()`; **three** fence-marker pairs (mapping, draft, and a third `REVISION_SOURCE_BEGIN/END` for the source-under-revision, revision.py:148-162); `choose_revision_seat()` (revision.py:266-296) mirrors `choose_synthesizer_seat` but selects on the **unique seat-id axis** (not name) so `claude#2` on a duplicate board resolves correctly; `_classify_revision_shape()`; two-attempt retry in `run_revision()`; `render_revision_raw()`.
+
+What revision.py adds that is genuinely **new** (not reused from synthesizer) — the mechanical never-model-asserted verification layer, directly relevant to a rubric-merging chair:
+- `resolvable_findings()`/`duplicate_titles()` (revision.py:299-333) — conductor enumerates a ground-truth skeleton (there: findings by `{list, index, title}`; for a rubric, presumably proposed criteria) the model must reference, never invent ids for.
+- `_assert_finding_ref()` (revision.py:501-532) — full composite cross-assert against ground truth, not title-only.
+- `reconcile_edits()`/`_opcode_hunks()` (revision.py:592-639, 535-551) — INV-1: every mechanical hunk (there: a `difflib` diff) must be claimed by ≥1 model locator and vice versa; any discrepancy rejects.
+- `check_completeness()` (revision.py:642-668) — every blocker resolved-or-listed-unresolved.
+- `build_changes()` (revision.py:710-830) — assembles the artifact, strips private bookkeeping, stamps conductor-computed fields (never model-asserted).
+
+**This is the strongest structural precedent for a rubric-merging chair**: the conductor enumerates a skeleton (there: findings; for rubric, seat-proposed criteria), the model reasons over it and returns structured claims (a merged criteria list + weights), and the conductor mechanically cross-asserts/reconciles those claims (e.g., every seat's proposed criterion appears in the merge or is explicitly dropped-with-reason; weights are conductor-summed and checked, never trusted from the model) before anything is written — mirroring `endorsement.py`'s "P2 endorsement invariant" pre-declaration pattern (see §5) for how a field can be reserved ahead of a later phase.
+
+---
+
+## 5. Verdict schema
+
+**Top-level keys of `advisory-board/verdict@2`** (verdict-schema.md example + `REQUIRED`/optional checks in `board_verdict.py`): `schema`, `title`, `date`, `verdict`, `confidence`, `unanimous`, `lens_preset`, `rounds`, `board[]`, `blockers[]`, `dissent[]`, `concerns[]`, `caveats[]`, `open_questions[]`, `next_actions[]`, plus lifecycle fields `previous_run`, `amendments[]`, `changes`.
+- `REQUIRED = ("schema", "verdict", "confidence", "board", "rounds")` — board_verdict.py:47.
+- `SEAT_REQUIRED = ("seat", "model", "round_verdicts")` — board_verdict.py:48.
+- `SCHEMAS = {"advisory-board/verdict@1", "advisory-board/verdict@2"}` (board_verdict.py:45); an unrecognized `schema` value is rejected outright (board_verdict.py:322-323).
+
+**`EVIDENCE_CONTAINERS`** = `("blockers", "dissent", "concerns")` — board_verdict.py:55, preceded by comment (54): "Top-level keys whose items may each carry an `evidence[]` list." Consumed by `iter_evidence_containers()` (board_verdict.py:168-176), which additionally yields `("verdict", data)` for a bare top-level `evidence[]`.
+
+**Per-seat data**: lives in `board[]`, each entry `{seat, model, lens, round_verdicts[], dropped, id?}` (verdict-schema.md:20-29); validated at board_verdict.py:337-364 — `SEAT_REQUIRED` check, type checks, a dropped seat's empty-`round_verdicts` exemption (356-361: "recording None placeholders would be the conductor inventing a verdict, which §11 forbids"), token-validity check against `SEVERITY` (362-364), and a board-wide `>= 2 seats that ran` floor (366-368).
+
+**Additive-without-version-bump discipline (D8/D9/D10/D13)**. `_validate_lifecycle()` (board_verdict.py:179-313) runs unconditionally from `validate()` (board_verdict.py:395), i.e. under `@1` or `@2` alike. Its docstring: "Lifecycle fields (since v1.12): validated strictly WHEN PRESENT, invisible when absent — an existing verdict without them validates and gates byte-identically... the gate never reads them" (board_verdict.py:180-183). The schema doc echoes: "A verdict without them is byte-for-byte the same schema as before — absent means absent, never `null`... validated identically under either schema id" (verdict-schema.md:130-133). `LIFECYCLE_FIELDS = ("previous_run", "amendments", "changes")` — board_verdict.py:65.
+
+**The reserved/pre-declared-key pattern** — two variants exist, both usable precedent for a future `scorecard` key:
+1. **The `changes` key has already graduated from "reserved" to fully implemented** (v1.13 shipped it) — `_validate_lifecycle()` at board_verdict.py:189-216 now validates it strictly as `{artifact, sha256}` exactly: `unknown = set(changes) - {"artifact", "sha256"}` → `die(...)` (189-196); both keys required (197-199); `artifact` must be a bare filename, no path separator/`..`/absolute (200-211, mirrors `board_changes`' own bare-filename gate); `sha256` must be 64 lowercase hex chars (212-216). **The precedent v1.13 fact sheet's language ("changes is reserved for the revision artifact... and not yet defined") is now stale** — this is worth flagging explicitly to whoever writes the v1.15 brief, since it may be read as still-current.
+2. **The still-active "stamp empty, don't reserve in the validator" pattern**, from `revision.py:815-829` (P2 shipping ahead of P4's endorsement pass): `"endorsements": []` is stamped by the conductor in P2 with an internal-only guard — "the model cannot author endorsements at all in P2... the guard against a non-empty endorsements ever reaching a written changes.json lives HERE, not in the validator: an internal error, never blamed on the model" (revision.py:818-829, raises `RevisionInternalError` if non-empty). `references/changes-schema.md:6` echoes: "`endorsements` is empty and conductor-asserted empty before any write." **This is the closer precedent for a `scorecard` key introduced ahead of full implementation**: pre-declare the field, stamp it empty/absent at the source, keep the validator permissive (so a later phase filling the same field needs no validator change), and guard the invariant with an internal exception rather than a model-blame message.
+
+**Strict-validator conventions a `scorecard@1` (or in-verdict `scorecard`) would need to match**, per `references/changes-schema.md` and `board_verdict.py`:
+- Model-authored vs conductor-computed split, verbatim (changes-schema.md:80-83): "Everything structural is **conductor-computed** — the model authors only `summary`, `resolves`, and (on an `unresolved` entry) `reason`/`note`; the conductor computes `n`, `status`, the shas, `source_type`, `revision_seat`, `title`, and the `endorsements` rows."
+- Cross-assert / no-id-fabrication (changes-schema.md:115-118; code at revision.py:501-532): every ref cross-asserted against ground truth by full composite, index bounds-checked, title exact-matched; mismatch rejects the whole artifact.
+- Completeness check (changes-schema.md:193-194): every verdict blocker resolved-or-listed; best-effort for lesser tiers.
+- sha256 pinning convention (changes-schema.md:87-89): sha256 over the UTF-8 text as read, universal-newline (LF)-normalized, "the same value the run recipe and the egress records bind."
+- Append-only / conductor-only status stamping (changes-schema.md:121-122): `status` is conductor-computed from mechanical reconciliation, "never taken from the model."
+- Strict-unknown-key refusal (changes-schema.md:204-205): `board_changes.py` "validates the schema (strict — unknown top-level keys refused, exact field types, locator shape checks, `resolves`-list enum {blockers, concerns})" — same style as board_verdict.py:192-196's `changes` inner-object check.
+- Reject path never destroys prior good artifacts (changes-schema.md:198-200): a failure takes the reject path (`*-rejected.*` + loud warning + exit 0, `--strict-exit` → 4) — never discards completed rounds or the verdict.
+
+**Validation entry point**: `def validate(data: dict) -> None` — board_verdict.py:316-395, raises `SystemExit(EXIT_SCHEMA)` via `die()` (board_verdict.py:74-76) on any violation. `load(path)` (79-90) reads + parses + calls `validate`. CLI `main()` (758-806) calls `load` then optionally `gate_outcome` for `--gate`. `board_verdict.py` and `board_changes.py` are otherwise invoked as standalone CLI subprocesses — the only in-process imports are `synthesizer.py`'s `validate_verdict()` (488-517) and `revision.py`'s `validate_changes()` (839-858), both doing a lazy `import` + `SystemExit` capture.
+
+**No prior art for "scorecard"/"rubric" in code**: a full-tree grep confirms zero hits for "scorecard" anywhere in `scripts/` or `references/`; "rubric" appears exactly twice, both in `scripts/render_tracker.py` (lines 24, 108), both naming the v1.15 roadmap milestone — not any existing schema/code. This is a clean-slate schema addition, constrained only by the synthesizer/revision spawn pattern and the lifecycle-field additive discipline documented above.
+
+---
+
+## 6. Gate
+
+**Token set**: exactly `SEVERITY = {"ship": 0, "caution": 1, "block": 2}` (board_verdict.py:36) — no fourth token. `CONFIDENCE = {"low", "medium", "high"}` (board_verdict.py:37). `FINDING_SEVERITY = {"concern": 0, "blocker": 1}` (board_verdict.py:44, a *separate* severity axis for findings, used by `--min-severity`, not to be confused with the verdict-token `SEVERITY`).
+
+**`gate_outcome()`** — board_verdict.py:463-527, `def gate_outcome(data: dict, fail_on: str, min_severity: str = None)`. Returns `("pass"|"fail"|"abstain", reason)`. Docstring:
+> "Decide the gate from OBSERVED cross-seat agreement... `abstain` ('human required') fires when: 1. any citation is refuted... 2. the seats that ran are genuinely torn at the threshold... 3. the declared `verdict` field *clears* the gate while a majority of seats *trip* it... Synthesis ESCALATION is honored: a declared verdict that trips the gate fails it, even if the seats lean the other way... Only DE-escalation below the observed board is distrusted." (board_verdict.py:464-478)
+
+`min_severity` (v1.14 P1) "COMPOSES WITH `fail_on`: it is an ADDITIONAL condition for a FAIL... It can only turn a would-be fail into a pass; it never escalates a pass, and it never touches the abstain integrity checks" (board_verdict.py:480-488).
+
+**CLI enforcement**: `--gate` flag (board_verdict.py:769, `action="store_true"`, help: "exit 1 when the verdict meets the fail threshold (3 to abstain)"); `--fail-on` (choices `caution`,`block`, default `block`, board_verdict.py:770); `--min-severity` (dest `min_severity`, choices `blocker`,`concern`, default `None`, board_verdict.py:774, help notes "Only narrows a fail to a pass"). Exit codes: `EXIT_OK=0`, `EXIT_GATE_FAIL=1`, `EXIT_SCHEMA=2`, `EXIT_ABSTAIN=3` (board_verdict.py:68-71). `main()` dispatch (board_verdict.py:793-802) prints `"gate: ABSTAIN - {reason}"` / `"gate: FAIL - {reason}"` / `"gate: pass - {reason}"` and returns the matching exit code.
+
+**No separate `gate.py` module** — confirmed (`find . -iname "*gate*"` returns nothing); all gate logic lives in `board_verdict.py`.
+
+**Plain-language / lens-aware verdict rendering** — this exists and is directly relevant to "scores map to ship/caution/block" for a non-software rubric board. `scripts/_verdict_labels.py` (full file):
+- `SOFTWARE_LABELS = {"ship": "SHIP", "caution": "SHIP WITH CHANGES", "block": "DO NOT SHIP YET"}` (line 29) — used ONLY for the `software-architecture` lens preset (and the absent/`None` default, for backward compatibility).
+- `PLAIN_LABELS = {"ship": "Go ahead", "caution": "Proceed with care", "block": "Stop and rethink"}` (line 32) for every other/unknown lens.
+- `PLAIN_NOTES` (lines 36-40) — a one-line "what this means" note per plain verdict.
+- `human_label(token, lens_preset, decision)` (lines 75-91): precedence is an explicit `decision` field (verbatim, no note) > software-lens label (no note) > plain label + note.
+- `lens_disclaimer(lens_preset)` (94-110): `LEGAL_DISCLAIMER` for `legal-contract`, `UNIVERSAL_DISCLAIMER` for every other non-software lens, `None` for software — "approved wording — keep... VERBATIM" (line 52).
+- `CALL_LEADS`/`verdict_lead()` (132-166) and `BLOCKERS_HEADING_PLAIN`/`blockers_heading()` (142-183) extend the same lens-aware framing to the banner headline and section heading.
+- **This is renderer-only** — "this never touches the verdict.json schema or the machine gate" (line 105) — the machine `verdict` token stays `ship|caution|block` everywhere; only the human-facing label changes. A rubric feature mapping numeric scores to a gate outcome would presumably still emit one of these three tokens for gate compatibility, with the human-facing scorecard rendered separately (see §7).
+
+**Existing numeric-to-token/band precedent**: the independence/echo score (v1.14 #9, `scripts/_conductor/echo_score.py`) is the only place a continuous signal maps to a coarse label today: `ECHO_BANDS = ("low", "moderate", "high")` plus `NOT_COMPUTED = "not_computed"` (echo_score.py:71-72) — explicitly "a COARSE band... never a false-precision 0-100 number" (echo_score.py:22-24) and "FLAGS possible echo; it does not prove independence" (echo_score.py:27-28). Thresholds are deliberately coarse and rule-based, not a tuned formula: `_OVERLAP_HIGH = 0.60`, `_OVERLAP_MODERATE = 0.30` (echo_score.py:77-78, comment: "the point is a band a reader can defend from the named sub-signals, not a tuned number"); the band decision (`_band()`, echo_score.py:223-264) requires **both** a strong flip-toward-majority AND any self-reported deference for a same-provider board to read `"high"` — an explicit anti-false-positive rule, not a weighted sum. `echo_score()`'s return always carries a one-line `explanation` naming which sub-signals drove the band — "never a bare number." This coarse-band, rule-explained-not-weighted-formula philosophy is the closest existing design precedent for how per-criterion numeric rubric scores might roll up to a ship/caution/block token.
+
+---
+
+## 7. Render surfaces
+
+**Byte-identity invariant of record** — `scripts/render_handoff.py:45-50`, verbatim:
+> "Template-evolution invariant (settled v1.12 P4, extended v1.13 P3): a feature's `<head>` CSS may evolve freely — the committed examples carry head-CSS drift — but the rendered BODY must stay byte-identical for a run WITHOUT that feature. A new section MUST whole-drop (heading, markup, and any preceding authoring comment) to ZERO body bytes when its fields are empty, so it leaves no residue. The head-CSS exemption is deliberate; the body byte-identity is enforced by test."
+
+Any rubric/scorecard section in the HTML handoff must whole-drop to zero body bytes on a non-`--rubric` run, per this invariant, and is body-byte-tested.
+
+**Run card / artifact tree** — `scripts/_conductor/artifacts.py`, `render_run_card()` (artifacts.py:81-181) and `render_artifact_tree()` (artifacts.py:255-314+). The run card's per-seat listing (artifacts.py:82-85):
+```python
+seats = "\n".join(
+    f"    - {s.id:<7} {s.provider:<10} {s.model:<18} [{s.reasoning}]  — {s.lens}"
+    for s in config.board
+)
+```
+followed by header fields (mode, network, sensitivity, rounds/cross-reading, lens preset, output, synthesizer, source, out dir), then optional conditional sections for `revised-draft` output (115-162), repo grounding (163-169), and revision lineage (170-177) — a rubric summary line would slot in as one more such conditional block. The artifact tree is built by conditional `parts +=` blocks gated on config flags, e.g.:
+```python
+if config.output == "revised-draft":          # artifacts.py:287
+    ...
+    parts += ["  prompts/revision.prompt", "  revision/<seat>.md   revision/<seat>.raw", draft_line]
+    if config.endorse:                          # artifacts.py:304
+        parts += ["  prompts/endorsement-<seat>.prompt", "  endorsement/<seat>.md   endorsement/<seat>.raw"]
+```
+A rubric round would extend this exact pattern: `if config.rubric: parts += ["  prompts/rubric-<seat>.prompt", "  rubric/<seat>.md   rubric/<seat>.raw", "  rubric.json"]` (naming illustrative, not prescribed). The echo-score sidecar is listed the same way (artifacts.py:278-281, gated on `≥2 rounds`).
+
+**Consensus render** (`scripts/render_verdict.py`) — `build_handoff_data()` (render_verdict.py:1175) is the central function producing the dict `render_handoff.py` renders from; `render_delta_markdown()` (362) is the closest existing precedent for a new structured section (the v1.12 revise-delta banner) being spliced into `final-consensus.md`. A rubric/scorecard table would be a new function alongside these, feeding a new `handoff-data.json` key, following the same drop-to-empty convention (render_verdict.py:1207+ pattern quoted "keeps the default output byte-identical," e.g. lines 1247, 1279, 1300).
+
+**Live progress view (v1.14 P3)** — `scripts/_conductor/status.py` (556 lines), schema `STATUS_SCHEMA = "advisory-board/status@1"` (status.py:62). The stage vocabulary is a literal enumerable tuple:
+```python
+STAGES = ("preflight", "egress", "round", "synthesis", "revision", "endorsement", "run")   # status.py:88
+```
+A rubric-agreement pass would extend this tuple with a new stage token (e.g. `"rubric"`), following the exact same `started`/`done` (and, for seats, `running`/`dropped`/`retry`) state vocabulary (`STATES`, status.py:83). **RH-1 invariant** (status.py:34-37): the tracker defers its first disk write until post-egress-approval, so a preflight NO-GO or egress refusal never produces `status.*` — any new stage must respect this ordering. Writes are lock-serialized and best-effort (status.py:20-22).
+
+**Severity filters (v1.14 P1)** — `--filter` (`FILTER_CHOICES = ("all", "blockers+dissent", "blockers")`, `scripts/_severity_filter.py:30`, `DEFAULT_FILTER = "all"`, line 31) on `render_verdict.py`/`format_output.py`; `--min-severity` composes with `--gate`'s `fail_on` (board_verdict.py:480-488, see §6). The kept-tier mapping is explicit (`_severity_filter.py:37-41`): `_KEPT = {"all": {"blockers","dissent","concerns"}, "blockers+dissent": {"blockers","dissent"}, "blockers": {"blockers"}}`, with elision always loud, never silent (`elision_note()`, line 60, requires exact dropped counts). Note `--filter` lives only on the renderer CLIs (`format_output.py:163`, `render_verdict.py:1461`), never on `run_board.py`/`cli.py`'s `run` subcommand; `--min-severity` is `board_verdict.py`-only (line 774) — the two flags are on disjoint CLIs and don't overlap. These filter *findings* (blockers/concerns/dissent), a different axis from rubric *criteria scores* — no direct interaction exists today, but a scorecard render would need its own filter posture decision (always show all criteria? filter by score band?) since it doesn't fit the existing blocker/concern/dissent tiers.
+
+**Independence/echo score (v1.14 P2)** — `scripts/_conductor/echo_score.py` (304 lines). Computes over the **final round transition** only (round N-1 → N), combining three sub-signals: flip-toward-majority, citation-overlap (Jaccard), and self-reported `BASIS` deference count (echo_score.py:1-40). Only computed when `len(rounds_done) >= 2` (cli.py:541-549), written to `echo-score.json` and read best-effort by `render_verdict.build_handoff_data`. This is a plausible interaction point the roadmap flags: a rubric round occurring *before* round 1 changes what "final round transition" means for echo — the metric explicitly scores "the seats usable in BOTH final rounds" (echo_score.py:34-40), so inserting a rubric round earlier in the pipeline should not, by construction, change which rounds echo_score compares (it only ever looks at the last two *opinion* rounds) — but this needs to be an explicit design decision, not an assumption.
+
+---
+
+## 8. Flags & recipe
+
+**Every `run` subcommand flag** (argparse setup in `scripts/_conductor/cli.py`, `add_argument` calls with line numbers):
+
+Shared across `init`/`run` (cli.py:1199-1312): `--source` (1199), `--mode {gate,advisory}` (1200), `--rounds {1,2,3,auto}` (1202), `--max-rounds` (1203), `--cross-reading` (1207), `--tier {quick,standard,deep}` (1209), `--lens` (1219), `--board` (1223), `--model` (1224), `--sensitivity {public,redacted,local-only}` (1226), `--output` (1229), `--source-type {prose,code}` (1238), `--revision-seat` (1243), `--no-endorse` (1249), `--out` (1256), `--runs-root` (1258), `--ephemeral` (1262), `--no-live-status` (1266), `--title` (1273), `--from-recipe` (1275), `--revise` (1279), `--synthesize` (1289), `--synthesizer-seat` (1296), `--repo` (1301), `--repo-include` (1309), `--repo-exclude` (1312).
+
+`run`-only (cli.py:1338-1362): `--dry-run` (1338), `--yes` (1340), `--skip-sensitivity-gate` (1342), `--update-tools` (1344), `--timeout` (1347), `--digest-format` (1354), `--strict-exit` (1362).
+
+Other subcommands: `p_tool` (`doctor`) — `--board`/`--update`/`--install`/`--yes` (1370-1375); `p_hist` (`history`) — `--runs-root` (1388); `p_ask` (`ask`) — positional `question` + `--run`/`--seat`/`--sensitivity`/`--yes`/`--skip-sensitivity-gate` (1396-1408); `p_render`/`p_verify`/`p_consensus`/`p_validate` all take `passthrough` (argparse.REMAINDER) delegating to the standalone scripts.
+
+**How flags are recorded in the recipe** — `config_to_recipe()`, `scripts/_conductor/recipe.py:232-289`. Records: `schema, title, date, mode, sensitivity, rounds, max_rounds, cross_reading, lens, output, out_dir, prompt_template(+sha256), round2_template(+sha256), synthesize, synthesizer_seat, synthesizer_template(+sha256), source_kind/ref/bytes/lines/sha256, board[], egress_consent, egress_providers, isolation_network(_unenforced), isolation_filesystem`. Conditionally added: `repo` (only when grounding is on, recipe.py:288-289). **`config.live_status` is deliberately NOT recorded** — "a presentation flag for a NON-record artifact... follows the `--strict-exit`/`--digest-format` convention" (recipe.py:282-285) — this is the precedent for whether a `--rubric` flag's *presence* (vs. its *resolved content*) belongs in the recipe: content that changes record-artifact shape (like `endorse`) IS persisted; pure presentation flags are not. A rubric round almost certainly changes record-artifact shape (new `rubric/` dir, new scorecard section), so by this precedent it likely needs its own recipe key + template version + sha, analogous to `synthesize`/`synthesizer_template`.
+
+**`--tier` preset resolution — the closest existing precedent for a preset system**. `TIER_PRESETS` (`scripts/_conductor/constants.py:128-151`) is a dict of `{"rounds", "cross_reading", "reasoning"}` per tier (`quick`/`standard`/`deep`). Resolution order, quoted verbatim from `resolve_config()` (config.py:538-551):
+> "`--tier` (v1.11 #3b): one flag for the run's cost/depth posture, applied as a BASE beneath explicit flags — `--rounds`/`--cross-reading`/per-seat reasoning always win, built-in defaults fill last. Refused alongside `--from-recipe`: the recipe records the RESOLVED values... never the tier name, so replay is exact without a tier."
+
+Concretely (config.py:590-593): `rounds = str(getattr(args, "rounds", None) or (base or {}).get("rounds") or tier_vals.get("rounds") or "2")` — explicit flag > recipe > tier base > hardcoded default. **`--tier` is never persisted in the recipe itself** — only its resolved effects are (rounds, cross_reading, per-provider reasoning). This is the model a `--rubric` panel-preset flag would need to follow if it, too, resolves to a bundle of other settings.
+
+**Existing personas/lenses (the closest thing to seat "roles")** — `LENS_PRESETS` (`scripts/_conductor/constants.py:71-102`), six named trios, each an ordered list of three lens description strings (e.g. `software-architecture`, `product-strategy`, `research-paper`, `legal-contract`, `business-decision`, `writing-editing`); `DEFAULT_LENS = "software-architecture"` (line 103). `resolve_board()` (config.py:325-374) assigns `lens = lens_overrides.get(sid) or (lenses[index] if index < len(lenses) else lenses[-1])` (config.py:365-366) — lens is a positional-slot default, only overridable per-seat via `--lens SEAT=...`. **There is no separate "persona" object beyond the lens string** — the lens text *is* injected directly as `role_emphasis` into the round prompt (see §3). A "stakeholder/audience panel preset" would most naturally be a **new `LENS_PRESETS` entry** (e.g. `"stakeholder-review"`) plus possibly a parallel mechanism for naming the seats themselves (there is none today beyond provider name/alias — see next point), OR an orthogonal preset dict shaped like `TIER_PRESETS` if it needs to bundle board composition + lens + rounds together.
+
+**`--board` seat definition** (`resolve_board()`, config.py:325-374; `assign_seat_ids()`, config.py:300-321): seats are `(alias|None, provider)` pairs parsed from a comma string via `parse_board()` (config.py:825-850, default `"claude,codex,gemini"`, config.py:831); `assign_seat_ids()` turns bare-repeated providers into `provider#1, #2...` for uniqueness (byte-identical to legacy for a unique-provider board). Each resulting `SeatConfig` (config.py:69-92) is `{id, name/provider, adapter, model, lens, reasoning, timeout_s}` — **no persona/role field beyond `lens`**. `REGISTRY` (`scripts/_conductor/registry.py:482`) is a flat provider→adapter map (`claude`, `codex`, `gemini`, `antigravity`, `ollama`, `constants.py:61-67`) with no grouping/bundle concept. Confirmed by a repo-wide grep for "bundle"/"seat group"/"board preset": there is **no existing named seat-composition-bundle mechanism at all** — `--tier` (cost/depth preset) and `--lens` (focus-preset, via `parse_lens_args()`, config.py:914-940, whose "board_preset" name refers to a *lens* preset riding the `--lens` flag, not seat composition) are the only two "one-flag preset" precedents today, and neither changes which providers or how many seats sit on the board. A stakeholder/audience panel preset that bundles specific seats + lenses (+ possibly default rubric criteria) together under one name would be a genuinely new third preset axis, not an extension of an existing one.
+
+---
+
+## 9. Audience/stakeholder panel preset
+
+Builds directly on the lens-preset + plain-language-rendering machinery documented in §6 and §8:
+- `LENS_PRESETS` already has non-software lenses (`business-decision`, `product-strategy`, `legal-contract`, `research-paper`, `writing-editing`) that drive both the round-prompt `role_emphasis` (§3) and, via `lens_preset` on the verdict, the entire plain-language rendering family in `_verdict_labels.py` (§6) — labels, disclaimers, banner leads, section headings all already flip to non-developer-friendly text keyed on `lens_preset`.
+- No existing mechanism ties a lens preset to a specific *board composition* (which providers, how many seats) or to rubric criteria — `--tier` and `--lens` are independent axes today (`resolve_board()` takes both but doesn't couple them).
+- A stakeholder/audience panel preset for v1.15 would likely need: (a) a new `LENS_PRESETS`-style entry or a new preset dict (parallel to `TIER_PRESETS`) that can also imply default rubric criteria per audience type; (b) a decision on whether `--rubric` implies a specific lens or is orthogonal to lens choice entirely.
+
+---
+
+## 10. Things the roadmap glosses — interactions to design explicitly
+
+- **`--revise` + `--rubric`.** `scripts/_conductor/revise.py` (its own module docstring, lines 1-17) builds a "MECHANICAL digest of the prior verdict (tokens, titles, citations — no re-reasoning, §11) plus a unified diff," injected into round-1 prompts so "the material lands inside the packet blobs" and the egress hash covers it automatically. `prepare_revision()` runs at config.py:281-282 territory (`_resolve_run_dir(config.revise_of)`, then `_load_prior_verdict`). **No existing analog for replaying a prior rubric** — a `--revise` run today re-derives nothing about rubric-equivalent state because no rubric exists yet. The v1.15 design must decide: does `--revise --rubric` re-run the rubric-agreement round from scratch, or mechanically carry forward the prior run's agreed criteria (à la the prior-verdict digest)? The existing precedent (mechanical carry-forward, never re-reasoned) suggests the latter is more consistent with the codebase's §11 discipline.
+- **`--rounds 1` / `--tier quick` + rubric.** The roadmap's own "Later" list already flags a **related, unresolved** issue: "`--rounds 1` (incl. via `--tier quick`) + `--digest-format json` is a silent no-op — structured digests only exist for round 2+, so the run succeeds with zero JSON digests written" (run-board-roadmap-v1.11-v1.15.md:189). A rubric-agreement round occurring *before* round 1 sidesteps this specific issue (it's not round-2+ dependent) but raises the analogous question fresh: does `--tier quick` (1 round, reduced reasoning) get a lighter-weight rubric pass too, or does rubric agreement always cost a fixed extra round regardless of tier? `config.rounds` being a string enum with no "phase 0" concept (§1) means this needs explicit new plumbing either way.
+- **Independence/echo score vs rubric scores.** As noted in §7, echo_score always compares the *last two opinion rounds* — inserting a rubric round earlier should not change what echo_score compares, but this is an assumption to verify/decide explicitly, not inherited automatically.
+- **Digest/persistent runs.** `run_board.py history` (v1.11 #5) reads `verdict.json` + `run-metadata` per persisted run (`~/.advisory-board/runs/<slug>-<date>/`) — a rubric/scorecard summary column in `history`'s table is a natural v1.15 extension but nothing today anticipates a numeric-scores column; the table's current columns (title, date, verdict, confidence, unanimous, seats) are all string/bool, no numeric precedent.
+- **Token budget for an extra round.** No `token_budget`/`MAX_PACKET`-style constant exists anywhere in the codebase (confirmed by grep across `scripts/_conductor/*.py` and `scripts/*.py`). The only existing size preflight is D11's revision-oversized-source refusal: `revision_max_bytes()` ceiling, refused loudly at `config.py:714-719` ("Better a loud refusal than a silently-short board-derived copy"). A rubric round adds one more full-board fan-out (same packet-hash/egress machinery as any round) — cost is already tracked per-seat via `tokens_in`/`tokens_out` on `SeatRoundResult` (v1.11 #3a) and surfaced by `estimate_run()`/`--dry-run`, so a rubric round's cost is presumably folded into that estimator the same way an extra debate round would be, but no code currently accounts for a "rubric round" in `estimate_run()`'s round-counting.
+- **No weight-sum validation precedent anywhere.** Confirmed by grep (`sum(...weight`, `== 100`, `== 1.0`, `total.*weight` all return nothing in `scripts/`/`references/`) — a rubric's weighted criteria summing to 100% (or 1.0) would be entirely new validation logic; there is no existing numeric-invariant-sum pattern to mirror (the closest structural analog is INV-1's reconciliation completeness check in `revision.py`, which is set-coverage, not arithmetic).
+
+---
+
+## Test suite, mocks, validator discipline (supporting facts)
+
+**Layout**: `tests/` has 4 top-level files + `mocks/` + `fixtures/` (with `fixtures/src/`). `test_run_board.py` is 14,784 lines / 1310 `def test_` functions; `test_md.py` (32), `test_render_engine.py` (19), `test_render_plan.py` (39). **Full suite: 1426 tests**, confirmed green via `python3 -m unittest discover -s tests -t tests` at the scouted commit (33.8s).
+
+**Mocks PATH trick** — `tests/mocks/` contains fake `claude`/`codex`/`gemini`/`agy`/`ollama`/`npm`/`brew` executables (bash scripts). `EnvMixin.setUp()` (`tests/test_run_board.py:78-91`) does:
+```python
+os.environ["PATH"] = MOCKS + os.pathsep + os.environ.get("PATH", "")
+os.environ["ADVISORY_BOARD_NOW"] = "2026-06-25"
+for seat in ("CLAUDE", "CODEX", "GEMINI", "AGY", "OLLAMA"):
+    os.environ[f"MOCK_{seat}_MODE"] = "go"
+self.runs_root = tempfile.mkdtemp(prefix="ab-test-runs-root-")
+os.environ["ADVISORY_BOARD_RUNS_ROOT"] = self.runs_root
+```
+Each mock (e.g. `tests/mocks/claude`) reads the prompt from stdin and switches behavior by sniffing markers: `"MATERIAL UNDER REVIEW"` → review reply; `"You are the SYNTHESIZER"` → synth reply (checked before/overriding the review marker); `"PRIOR RUN CONTEXT"` → ask reply. **A rubric pass would need its own marker convention** (e.g. a "You are the RUBRIC..." frame) added to every mock executable for the test suite to exercise it, following this exact established pattern.
+
+**Validator discipline**: `board_verdict.py`'s `_validate_lifecycle` and sibling checks consistently use `isinstance` guards before membership (`in`) checks specifically to avoid raw `TypeError` crashes on unhashable hand-authored values (board_verdict.py:229-230 comment: "isinstance guard first: an unhashable value (list/dict) would TypeError on the `in` check and escape die()'s clean schema exit"). The roadmap's "Later" section (run-board-roadmap-v1.11-v1.15.md:190) still flags this as a **partially-open** pre-existing risk on *other* membership checks in the file beyond the lifecycle ones already guarded — worth a fresh sweep before adding a `scorecard` validator with its own membership checks, so the same mistake isn't repeated.
+
+---
+
+## Open questions the brief must ask
+
+1. Is the rubric-agreement pass a new "round 0" using the existing `run_round`/`ThreadPoolExecutor` machinery directly, or a wholly separate spawn function (like synthesizer/revision/endorsement) that doesn't reuse `round_no` semantics at all?
+2. Who proposes criteria (every seat independently, round-0-style) and who merges them — a spawned "chair" seat exactly generalizing `synthesizer.py`'s pattern (§4), and does the chair's seat-selection precedence mirror `choose_synthesizer_seat()`/`choose_revision_seat()` exactly, or need new rules?
+3. Is a rubric criterion identified by title (inheriting the fragility the D9 revision-seat roundtable already relitigated once for findings) or does this get a real conductor-assigned id — and if the latter, is this the moment `@3` finally gets used, or does the D8 "additive inside `@2`" discipline extend once more?
+4. Do per-criterion scores replace the `VERDICT: ship|caution|block` token entirely, sit alongside it, or get algorithmically reduced to it (and by what pure function — weighted average? threshold? something the echo-score "coarse band, no false precision" philosophy would apply to)?
+5. Does `parse_verdict`'s "last line wins, one scalar" contract get replaced by a multi-line per-criterion parser, and if so what's the new machine-parseable line format (`VERDICT:` is precedent — is it `SCORE[criterion]: N` or a fenced block)?
+6. What happens to `--rounds auto`'s movement-based convergence — does score convergence coexist with token/citation convergence, or replace it for a rubric run?
+7. Does a weighted-criteria rubric require weight-sum validation (100%/1.0) — and if so, who computes the sum (conductor, never model-trusted, per every other numeric-invariant precedent in this codebase)?
+8. Is `--rubric` orthogonal to `--tier` and `--lens`, or does it imply defaults for either (e.g., does a stakeholder-panel preset bundle `--rubric` + a specific `--lens` + specific board composition, the way `--tier` bundles rounds/cross-reading/reasoning)?
+9. Does `--revise` on a rubric run re-agree the rubric from scratch or mechanically carry the prior rubric forward (§10) — and if carried forward, does that count as new egress content needing its own consent-hash coverage, following the `--revise` precedent exactly?
+10. Does the rubric round respect `RH-1` (no `status.*` before egress approval) and get its own `STAGES` token, and does it get its own recipe-persisted template version + sha (per `synthesize`/`synthesizer_template`'s precedent) since it changes record-artifact shape?
+11. Is the `changes` key precedent (now fully implemented, not just reserved) the right model for how `scorecard` enters `verdict.json` — a tool-authored pointer to a separate `scorecard.json` artifact with its own strict schema-and-validator (`board_scorecard.py`?), mirroring `changes`/`board_changes.py` exactly?
+12. What is the failure/degrade posture when seats can't agree on a rubric (analogous to D14's "conflicting findings degrade loudly, never silently, never fatally" for the revision seat) — does a chair merge failure block the whole run, or degrade to a default/no-rubric path?
+
+## Risks
+
+Quoted from `design/run-board-roadmap-v1.11-v1.15.md`:
+- **R3** (packet growth, extant from v1.12, directly relevant precedent): "`--revise` packet growth (source + diff + prior verdict) — mitigation: quick-verdict-sized prior digest, not the full handoff; token budget checked like any round-2 packet." (line 182) — no equivalent mitigation or token-budget check exists yet for a rubric round's packet.
+- **R5** (this milestone, verbatim): "Rubric-first destabilizes the default path — strictly opt-in behind `--rubric`; the byte-identical default-run guard (D5) is the regression net; own design phase before code." (line 184)
+- **R6** (scope-creep guard, verbatim): "Fourteen items invite scope creep — anything discovered mid-milestone goes to a 'later' note in this file, not into the current phase; the roadmap only grows by PR." (line 185)
+
+Independent risk observations from this scout (not roadmap quotes):
+- **No token-budget precedent to extend.** Confirmed no `token_budget`/`MAX_PACKET`-style constant exists anywhere; the rubric round's packet-size risk has no existing mechanism to plug into beyond the per-seat token capture (v1.11 #3a) and `estimate_run()`, neither of which currently model a pre-round-1 pass.
+- **No weight-sum (or any numeric-invariant-sum) validation precedent exists anywhere in the codebase** — a weighted-criteria rubric introduces genuinely new validator territory, not an extension of an existing pattern.
+- **Convergence-never-terminating risk under `--rounds auto`.** Today's stop rule (`moved < 1`) is binary and always eventually quiets (verdicts have only 3 values, citations are finite). A numeric score-convergence rule using a continuous epsilon threshold risks a board that oscillates near the boundary without ever dropping below threshold — this needs an explicit design decision (e.g., a max-rounds ceiling is already the hard backstop, `DEFAULT_MAX_ROUNDS`, so total non-termination is bounded, but "effectively never converges, always hits the ceiling" is a real usability risk worth naming).
+- **The `changes`-is-reserved language in the v1.13 precedent fact ssheet is now stale** (§5) — v1.13 shipped `changes` as a fully validated field. Anyone reusing that fact sheet as a template for v1.15 should not carry forward its now-superseded "reserved, not yet defined" framing; the more current, still-active precedent for a not-yet-implemented key is the P2 `endorsements: []` stamp-empty pattern in `revision.py` (§5).
+- **`STAGES`/`STATES` tuples in `status.py` are a literal, hand-maintained enum** (status.py:83, 88) — adding a `"rubric"` stage is a one-line change but every consumer that pattern-matches on the stage tuple (terminal-line rendering, HTML tracker) needs auditing for exhaustiveness, the same class of risk the roadmap's "Later" section already flags for `board_verdict.py`'s membership checks.
+- **Seat-role modeling gap for "stakeholder panel."** Lens presets today are pure prose strings injected as `role_emphasis` (§3, §9) with no structured persona object (name, priorities, voice) — a genuinely richer "stakeholder" persona (e.g., "a skeptical CFO" vs. "an end user") may need more than a new `LENS_PRESETS` entry; it's a plain-string extension of an existing mechanism, not a new one, unless the design wants structured persona metadata.

--- a/design/v1.15-rubric-first-design-brief.md
+++ b/design/v1.15-rubric-first-design-brief.md
@@ -1,0 +1,131 @@
+# v1.15 rubric-first deliberation — design brief
+
+_Design roundtable brief, 2026-07-02. Facts scouted against `main` @ `3b7a0b4` (post-v1.14.0); the full fact sheet is `design/v1.15-rubric-design-inputs.md`. You are ruling on a design, not reviewing code._
+
+## How to read this brief and what we need back
+
+You are a design-review board for the **Advisory Board** conductor — a provider-agnostic CLI that convenes multiple frontier-model seats (via their own CLIs) to review a source document or codebase and produce a schema-validated verdict. This brief proposes the design for **v1.15 "Rubric-first deliberation"** — the last milestone of the current roadmap — and asks you to rule on nine numbered questions, **Q1–Q9**. Each question states the options and a strawman. Attack the strawmen.
+
+- **SHIP** = the strawmen are sound as specified; note refinements as concerns.
+- **CAUTION/BLOCK** = one or more strawmen are wrong or dangerous — say **which question**, why, and what to do instead.
+- In your review, give an explicit ruling per question, labeled `Q1:` … `Q9:`, each with a one-paragraph rationale naming the trade-off you weighed. Flag genuine dissent rather than splitting differences.
+
+## Product context (what the tool is today, v1.14.0)
+
+- `run_board.py run` resolves a config (seats, models, lens, sensitivity), runs a preflight, gets hash-bound egress consent, then fans out 1–3 review rounds (or `--rounds auto`) with cross-reading. Every seat's round-1 prompt embeds the **full source text**; each round is a parallel `ThreadPoolExecutor` fan-out with per-seat retry, and all prompts/replies are recorded raw (black-box discipline).
+- Each seat's reply must carry a machine-parseable `VERDICT: ship|caution|block` line (last qualifying line wins, exactly one token, quoted/hedged lines rejected). Round 2+ adds a self-reported `BASIS:` line (independent/evidence/deference) and cross-reading of peers' prior reviews.
+- **Convergence is purely token- and set-based.** A seat "moved" iff its verdict token changed OR it introduced ≥1 new concrete citation; `--rounds auto` stops when fewer than 1 seat moves, with `--max-rounds` (default 3) as the hard ceiling. **No numeric machinery exists anywhere in convergence.**
+- `--synthesize` spawns a **synthesizer seat**: a no-lens reasoning seat, briefed only on the final-round reviews + conductor-extracted VERDICT tokens, whose JSON is merged into a conductor-authored skeleton (protected keys stripped; `unanimous` computed from tokens, never model-asserted) and schema-validated against `advisory-board/verdict@2`. Failure → `verdict-rejected.json` + loud warning + exit 0 (`--strict-exit` → 4); a synth hiccup never discards the successful rounds.
+- This spawn pattern has been generalized twice (v1.13): a **revision seat** (`--output revised-draft`, produces `changes.json` + a revised copy, conductor mechanically reconciles every edit against a real diff — INV-1) and a parallel **endorsement pass** (per-edit ENDORSE/OBJECT/ABSTAIN from the non-revision seats). Each pass has the same seven parts: template+sha in the recipe, DATA-fence markers + neutralizer, board-seat-only egress rule, two-attempt retry on timeout|invalid, raw black-box record, strict parse/validate, never-fail-the-run posture.
+- **Gate:** `board_verdict.py --gate` exits 1 when the verdict meets `--fail-on` (default block), 3 (ABSTAIN) when seats are torn at the threshold, a citation is refuted, or the declared verdict *clears* a gate a majority of seats *trip*. Escalation is honored; de-escalation is distrusted. `confidence` is self-reported and **the gate never reads it** — a gameable number must not move a gate.
+- **Rendering is lens-aware.** The machine token stays `ship|caution|block` everywhere; the human label flips by lens preset (`SHIP WITH CHANGES` for software; `Proceed with care` + a what-this-means note for everyone else). Six `LENS_PRESETS` exist (software-architecture, product-strategy, research-paper, legal-contract, business-decision, writing-editing); a lens is a plain prose string injected as the seat's "Role emphasis" — there is no structured persona object.
+- **v1.14 additions:** severity filters on the renderers; an **independence/echo score** over the final round transition that rolls sub-signals into a COARSE band (low/moderate/high, "never a false-precision 0-100 number", always with a named explanation); a live status view (`status@1`, stage tokens `preflight/egress/round/synthesis/revision/endorsement/run`, first disk write deferred until post-consent — RH-1).
+- **Presets:** `--tier quick|standard|deep` bundles rounds/cross-reading/reasoning, applied as a base beneath explicit flags and **never persisted** (the recipe records resolved values only). There is **no** preset that changes board composition, and **no** weight-sum or numeric-invariant validation anywhere in the codebase.
+
+## The v1.15 goal
+
+Today the board opines first and structure emerges later (the synthesizer splits evidence from judgment after the fact). **Rubric-first inverts that:** with `--rubric`, the seats **agree weighted criteria before opining**, then score the source per criterion each round, and converge on scores — so disagreement is localized ("we differ on criterion 3, not on everything") and the verdict is auditable against stated standards. Plus an optional audience/stakeholder panel preset so a non-developer can convene "the room this decision would face." Deliberately the last milestone: it touches prompts, rounds, convergence, schema, gate, and render.
+
+## Hard constraints (settled — do not relitigate; design within them)
+
+- **R5 / D5 byte-identity:** strictly opt-in behind `--rubric`. The no-flags default run stays byte-identical to v1.10.0 artifacts; every render section whole-drops to zero body bytes on a non-rubric run.
+- **§11 — the conductor plumbs, the models reason:** "anything that merges meaning (rubric merge, revision drafting) is a seat's job, not code." The criteria merge is reasoning → a spawned **chair seat**, not conductor code. Conversely, everything structural (ids, weights arithmetic, completeness checks) is conductor-computed and never model-trusted.
+- **D8 discipline:** new verdict fields are additive inside `@2` — strictly validated when present, invisible when absent, tool-authored where they assert provenance, and **the gate never reads a gameable number** (the `confidence` precedent).
+- **No new egress category:** every seat already receives the full source in round 1; a rubric-proposal pass sends the same source to the same providers, and the chair is a board seat. Disclosure needs a purpose mention, not a new consent category. All injected material lands inside the consent-hashed packet (the `--revise` precedent).
+- **Stdlib-only Python.** No pip dependencies.
+- **Failure never discards successful work** (the synthesizer posture), and content never moves exit codes (D14 precedent: exit codes stay about pipeline integrity).
+- **Coarse over precise:** the echo-score philosophy — a reader-defensible band with a named explanation beats a tuned formula — applies to anything numeric this feature renders.
+
+## Facts about the current code (the roadmap glosses all five of these)
+
+1. **There is no "round 0" concept.** `config.rounds` is a string enum `"1"|"2"|"3"|"auto"`; `round_no` is 1-indexed and feeds filenames, templates, and status events directly. A rubric-agreement pass before round 1 is *new pipeline structure*, not a parameter tweak — the natural shape is a dedicated module (like synthesizer/revision/endorsement) hooked in just before the round-1 fan-out, inside the interrupted-outcome guard, with its own stage token and artifact conventions.
+2. **The reply parser assumes one scalar per reply.** `parse_verdict` scans for a single `VERDICT:` line (last wins). Per-criterion scores need a genuinely new multi-line labeled format and parser — nothing existing extends to it.
+3. **Convergence has no numeric path.** "Moved" = token changed OR new citations appeared. Score-based convergence must define numeric movement from scratch, and a continuous epsilon rule risks a board that oscillates forever near the boundary (bounded only by `--max-rounds`).
+4. **The schema has a proven two-artifact pattern.** v1.13's `changes.json`: a separate artifact of record with its own strict validator (`board_changes.py`, unknown-keys-refused, model-authored fields enumerated and minimal), pinned from `verdict.json` by a tool-authored `{artifact, sha256}` pointer validated strictly-when-present. A `scorecard.json` + `board_scorecard.py` + `verdict.json.scorecard` pointer would mirror it exactly.
+5. **No seat-composition preset exists.** `--tier` bundles cost/depth; `--lens` supplies per-position focus strings; neither changes who sits on the board. A "stakeholder panel" that bundles seats + lenses (+ default criteria?) would be a genuinely new third preset axis — or a deliberately modest new lens preset that isn't.
+
+## The questions
+
+### Q1 — Pipeline shape: what exactly does `--rubric` insert?
+
+Strawman: **one proposal fan-out + one chair merge, before round 1.**
+
+1. **Rubric-proposal pass** — every board seat, in parallel (the existing fan-out machinery), receives the full source + its lens and returns 3–7 proposed criteria, each `{title, description, weight}`, in a fenced structured block. Same packet-hash/egress discipline as any round.
+2. **Chair merge** — a spawned reasoning seat (§11) receives all proposals (not the source afresh) and returns the merged rubric: deduplicated criteria, reconciled weights, and — for every seat-proposed criterion that didn't survive — an explicit drop-with-reason. The conductor cross-asserts completeness (every proposal accounted for), assigns criterion ids, and validates the arithmetic; the merged rubric is written as an artifact and **injected into every subsequent round prompt**.
+3. Opinion rounds then run as today, plus per-criterion scoring (Q3).
+
+Alternatives to rule on: a *debate* round where seats see each other's proposals and iterate before the chair merges (more deliberative, one more fan-out of cost); or no proposal pass at all — the chair alone drafts the rubric from the source (cheaper, but then the criteria are one seat's framing wearing the board's name — the same R4-style objection that made endorsement default-on in v1.13). Rule on the strawman's single-shot proposal→merge shape, and on the floor: ≥2 usable proposals required (the "one voice is not a board" rule), else the run refuses.
+
+### Q2 — The chair: who is it, and how is it chosen?
+
+The chair merges meaning, so it is a seat (§11) — but *which* seat? Options:
+
+- **(a) Reuse the synthesizer-selection rules verbatim** (a `--chair-seat` flag that must name a board seat, else `claude` if seated, else first usable seat), as `choose_revision_seat` already did. The prompt makes it neutral, not the seat name: fresh CLI spawns are stateless.
+- **(b) The chair is always the synthesizer seat** (one "reasoning seat" identity per run, fewer flags, but couples two roles that could legitimately differ — and `--rubric` without `--synthesize` then has to resolve a synthesizer seat anyway).
+- **(c) A rotating/least-invested rule** (e.g. the seat whose proposal the merge draws least from) — clever, unverifiable, and it puts merge-quality incentives into seat selection where nothing today does.
+
+**Strawman: (a)** — a `--chair-seat` flag mirroring `--synthesizer-seat`/`--revision-seat` exactly, same precedence, same board-seat-only egress rule, defaulting independently of the synthesizer choice. Also rule: does the chair's merge get an endorse-style check from the other seats (each seat confirms the merged rubric before scoring — one more fan-out), or is scoring-under-the-rubric itself the acceptance act? Strawman: **scoring is acceptance** — a seat that scores under the merged rubric has adopted it; a per-criterion objection channel (Q3's `RUBRIC-NOTE:` line) records disagreement without an extra round.
+
+### Q3 — Scores and the VERDICT token: replace, coexist, or derive?
+
+The `VERDICT: ship|caution|block` line is the canonical gate axis, the convergence signal, and the schema backbone. Options:
+
+- **(a) Scores replace the token on rubric runs** — the purest "rubric-first" reading, but it forks the gate, the parser, convergence, the schema, and every renderer into two modes, and a rubric run's verdict stops being comparable with every prior run.
+- **(b) Scores coexist with the token: each seat scores every criterion AND still declares its own VERDICT line**, informed by its scores. The token chain (gate, convergence, synthesizer, schema) is untouched; scores are additive structure.
+- **(c) The token is derived from the scores by formula** (conductor-computed weighted total + thresholds) — but that is the conductor generating a verdict, which §11 forbids, and a threshold formula is exactly the false-precision the echo-score philosophy rejects.
+
+**Strawman: (b).** Reply format: after the merged rubric is injected with conductor-assigned ids (`c1`…`cN`), each scoring reply carries one `SCORE c3: 4` line per criterion (integer **1–5**; the parser applies `parse_verdict`'s hardening per line — last qualifying line per id wins, quoted/hedged lines rejected, a missing or out-of-range score is a parse failure triggering the standard seat retry), plus an optional `RUBRIC-NOTE:` line for objections to the rubric itself. Also rule on the scale: 1–5 integers (coarse, defensible) vs 0–10 vs 0–100 (false precision). And: are criterion ids conductor-assigned at merge time (models never mint identity — note the board's own D9 ruling rejected ids *for findings* because they'd have been a schema evolution mid-flight; criteria are a new object with no legacy, so ids are free here) — strawman: yes, `c1`…`cN` in merge order.
+
+### Q4 — How do scores map to ship/caution/block?
+
+Given Q3(b), the seats' tokens still gate. What do the *numbers* do?
+
+- **(a) Nothing beyond rendering** — the scorecard renders per-seat and board-mean weighted totals with a coarse band; the gate reads only tokens. Zero gate risk, but then "converge on scores" has no teeth and a seat whose scores scream *block* while its token says *ship* goes unremarked.
+- **(b) A consistency check feeding the existing ABSTAIN machinery** — the conductor computes each seat's weighted total (arithmetic, not judgment); when a seat's total sits in the worst band while its declared token is `ship` (or vice versa), that's the same class of contradiction as "declared verdict clears a gate the seats trip", and the gate's abstain path already exists for exactly this: a human must look. Bands would be fixed and coarse (e.g. thirds of the scale), never tuned.
+- **(c) Scores drive the verdict via thresholds** — rejected above (§11, false precision, gameable).
+
+**Strawman: (a) for the gate, with (b) recorded as an explicit open extension** — ship v1.15 with scores strictly informational (the `confidence` precedent: a gameable number never moves a gate), render the contradiction loudly in the scorecard (a ⚠ row when token and band disagree), and leave gate integration to a future decision once real scored runs exist to calibrate against. Rule hard on this: is a rendered-but-not-gating contradiction honest enough, or does shipping a scorecard the gate ignores undermine the feature's promise?
+
+### Q5 — Schema: where does the scorecard live?
+
+- **(a) Inside `verdict.json`** — one file, but it bloats a judgment record with per-seat-per-round-per-criterion matrices, and the synthesizer would have to be trusted to transcribe scores it didn't produce (the conductor parsed them from round replies).
+- **(b) A separate `scorecard.json` artifact of record** — schema `advisory-board/scorecard@1`, its own strict validator (`board_scorecard.py`, mirroring `board_changes.py` discipline: unknown keys refused, model-authored fields enumerated and minimal), pinned from `verdict.json` by a tool-authored `scorecard: {artifact, sha256}` pointer validated strictly-when-present, invisible when absent (the shipped `changes` pointer precedent, byte-for-byte).
+
+**Strawman: (b)**, with this conductor-computed shape: `criteria[]` = `{id, title, description, weight, proposed_by[], dropped_from[]?}` (weights integer percentages, conductor-validated to sum to exactly 100 — the first numeric-sum invariant in the codebase, so state it loudly); `scores[]` = `{seat, round, criterion, score}` rows parsed by the conductor from round replies (per-round, not final-only — the trajectory *is* the convergence story); `rubric_notes[]` = the seats' recorded objections; per-seat weighted totals and bands conductor-computed at write time. Model-authored content is only what a model actually said (criterion prose, notes); everything structural — ids, weights arithmetic, totals, bands, shas — is conductor-computed. Rule on: per-round scores vs final-round-only, and whether the chair's drop-with-reason records live here or in a separate rubric artifact.
+
+### Q6 — Convergence under `--rounds auto`
+
+Today: moved = token changed OR new citations. For a rubric run:
+
+- **(a) Add score movement to the same boolean** — a seat also "moved" if any criterion score changed since the previous round. Integer 1–5 scores make the epsilon question moot (any change ≥ 1 by construction); the existing threshold ("keep going while ≥1 seat moves") and `--max-rounds` ceiling are untouched. Oscillation (a seat flapping 3↔4 forever) is bounded by the ceiling, exactly as token-flapping already is.
+- **(b) Replace token convergence with score convergence on rubric runs** — e.g. stop when board-wide per-criterion spread ≤ 1. More "converge on scores" in spirit, but it invents a new stop rule with new failure modes, and a board can agree on every number while still flipping tokens.
+
+**Strawman: (a)** — one movement definition, widened. Also rule: should the run card / status line surface *which* criteria are still moving (cheap, useful) — strawman yes, in the round-done detail string.
+
+### Q7 — What exactly does `--rubric` opt into, and how does it compose?
+
+Strawman: `--rubric` is a plain boolean, **orthogonal to `--tier`, `--lens`, `--synthesize`, and `--output`**: any tier can run rubric-first (quick tier = 1 opinion round, still proposal+merge first); the rubric round always costs what it costs (one fan-out + one chair spawn) — a tier never silently skips it. It is **recorded in the recipe** with the rubric/chair template versions + shas (it changes record-artifact shape — the `synthesize` precedent, not the `live_status` presentation-flag precedent). It gets its own `STAGES` token for the live view, respects RH-1 (no disk writes before consent), and `--from-recipe` replays it exactly. Rule on one addition: does `--rubric` **require** `--synthesize`? The scorecard is conductor-parsed (no synthesizer needed), but a rubric run without a verdict.json has no pointer to pin the scorecard to. Strawman: **no hard requirement** — the scorecard artifact stands alone (like round artifacts do); the verdict pointer appears only when synthesis runs. Attack that if you think an unpinned scorecard invites tampering claims.
+
+### Q8 — The audience/stakeholder panel preset
+
+The roadmap promises "an optional audience/stakeholder panel preset" — a non-developer convening "the room this decision would face" (a skeptical CFO, an end user, a compliance reviewer…). Options:
+
+- **(a) A new `LENS_PRESETS` entry** (e.g. `stakeholder-panel`: three lens strings voicing distinct stakeholder archetypes) — pure prose, rides the entire existing lens machinery including plain-language verdict rendering; ships in an afternoon; but archetypes are fixed at three and generic.
+- **(b) A new preset axis bundling board composition + lenses + default criteria** — the full vision, but board-composition presets don't exist, criteria-defaults would pre-empt the seats' own proposal pass (tension with the feature's premise!), and it's a third preset system to maintain.
+- **(c) (a) now, (b) never-promised** — ship `stakeholder-panel` (and possibly a second, e.g. `investor-pitch`) as lens presets, document the combo (`--rubric --lens stakeholder-panel`), and record that structured personas are out of scope for v1.15.
+
+**Strawman: (c).** The lens string IS the persona mechanism today; a richer persona object is a different milestone. Also rule: should a stakeholder-lens run default any rubric behavior (strawman: no — presets that silently imply other flags are how `--tier`'s "never persisted, base-beneath-flags" complexity got necessary; keep the axes orthogonal and document the combination instead).
+
+### Q9 — Failure and degrade posture
+
+Three failure sites, three postures to rule on:
+
+- **Proposal pass:** a seat's proposal spawn fails after retry → **drop that seat's proposal** (the chair merges what arrived), floor of ≥2 usable proposals else the run refuses loudly **before any opinion round spends tokens** (nothing to salvage yet — contrast the synthesizer, which fails *after* the expensive rounds and therefore must not discard them). Strawman: refusal exits like a preflight NO-GO, not a mid-run degrade.
+- **Chair merge:** two-attempt retry (timeout|invalid); on final failure — **(i) degrade to a non-rubric run** (loud warning, run card states it, rounds proceed plain) vs **(ii) refuse and stop** (the user explicitly asked for rubric-first; silently delivering a different deliberation shape breaks the ask). Strawman: **(ii) refuse** — `rubric-rejected.json` + the failed chair raw record are written for the post-mortem, exit non-zero. This is the one place the never-fail-the-run posture does NOT apply, because nothing valuable has been produced yet to protect. Attack this hard — it's the strawman most at odds with the codebase's reflexes.
+- **Scoring lines:** a seat whose reply lacks a valid score line for some criterion after the standard retry → the seat stays usable for tokens/convergence, the scorecard records its missing cells as absent (rendered as "—", never imputed), and the weighted total for that seat is marked partial. Content never moves exit codes (D14).
+
+Also rule (Q9b): `--revise` on a rubric run. Strawman: the prior run's agreed rubric is **mechanically carried forward** (the §11 no-re-reasoning precedent: revision context is a mechanical digest, never re-derived) so scores are comparable across revisions — re-agreement is not offered in v1.15. The carried rubric lands inside the consent-hashed packet like all revision context.
+
+## What happens with your rulings
+
+Decisions get recorded as D15+ in the roadmap (`design/run-board-roadmap-v1.11-v1.15.md`), and the v1.15 milestone's placeholder phases get rewritten from them — gating Phase 2 (rubric round + chair merge), Phase 3 (scoring rounds + score-based convergence), and Phase 4 (schema, gate, scorecard render) before release v1.15.0. Where you dissent from each other, the dissent is recorded too — this board's disagreements have changed shipped designs before (the v1.12 chain-consistency ruling, the v1.13 endorsement-default reversal).


### PR DESCRIPTION
## Summary
v1.15 Phase 1 (rubric-first deliberation, the roadmap's last milestone) design-pass inputs, following the v1.13 P1 precedent:

- `design/v1.15-rubric-design-inputs.md` — scouted fact sheet of every integration point the rubric feature touches (rounds machinery, convergence, prompt templates, chair/synthesizer spawn pattern, verdict schema + lifecycle discipline, gate, render surfaces incl. byte-identity invariant, flags/recipe, lens presets), with file:line anchors against `main` @ 3b7a0b4.
- `design/v1.15-rubric-first-design-brief.md` — the self-contained design brief for the 3-seat dogfood roundtable: nine numbered questions (Q1–Q9) with attackable strawmen covering pipeline shape, chair selection, score/token relationship, score→gate mapping, scorecard schema, convergence, flag composition, the stakeholder panel preset, and failure posture.

Docs only — no code. The roundtable runs next; rulings get recorded as D15+ and the M5 placeholder phases rewritten from them (the Phase 1 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)