### PR TITLE
repo: make tag releases idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -93,7 +97,39 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
-          gh release create "$TAG" \
-            --title "$SKILL $VERSION" \
-            --notes-file notes.md \
-            --verify-tag
+          verify_existing_release() {
+            EXPECTED_NAME="$SKILL $VERSION" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          release = json.loads(Path("existing-release.json").read_text())
+          expected_name = os.environ["EXPECTED_NAME"]
+          expected_body = Path("notes.md").read_text()
+          if release.get("name") != expected_name:
+              raise SystemExit(
+                  f"existing release title mismatch: {release.get('name')!r} != {expected_name!r}"
+              )
+          if release.get("body") != expected_body:
+              raise SystemExit("existing release body does not match the changelog section")
+          PY
+          }
+
+          if gh release view "$TAG" --json name,body > existing-release.json 2>/dev/null; then
+            verify_existing_release
+            echo "::notice::release $TAG already exists with the expected title and notes"
+            exit 0
+          fi
+
+          if gh release create "$TAG" \
+              --title "$SKILL $VERSION" \
+              --notes-file notes.md \
+              --verify-tag; then
+            exit 0
+          fi
+
+          # A duplicated tag event can race between the initial existence check
+          # and creation. Accept that race only when the winning release is exact.
+          gh release view "$TAG" --json name,body > existing-release.json
+          verify_existing_release
+          echo "::notice::a concurrent run created $TAG with the expected title and notes"


### PR DESCRIPTION
## Summary

- serialize release jobs per tag
- make reruns and duplicate tag deliveries idempotent
- accept an existing release only when its title and changelog body match exactly
- preserve a hard failure for mismatched or missing releases

## Why

GitHub delivered the `advisory-board/v1.16.0` tag event twice. One run correctly published the release; the concurrent run received `Release.tag_name already exists` and failed. The published release is correct and remains untouched.

## Validation

- workflow YAML parsed locally
- exact comparison against the published v1.16.0 title/body passed
- `git diff --check` passed
