### PR TITLE
Add team-workflow pack v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "name": "skills",
+  "owner": {
+    "name": "Tim Harris",
+    "url": "https://github.com/timharris707"
+  },
+  "metadata": {
+    "description": "Marketplace for the skills in this repository: the advisory-board skill and the team-workflow pack."
+  },
+  "plugins": [
+    {
+      "name": "advisory-board",
+      "source": "./",
+      "strict": false,
+      "version": "1.16.0",
+      "description": "Convene a board of leading AI models to review the same decision, debate across rounds, and hand back one clear recommendation.",
+      "license": "MIT",
+      "skills": [
+        "./skills/advisory-board"
+      ]
+    },
+    {
+      "name": "team-workflow",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "description": "A portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, decision maps, throwaway prototypes, and autonomous research lanes. Versioned as one pack (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
+      "license": "MIT",
+      "skills": [
+        "./skills/router",
+        "./skills/setup",
+        "./skills/decision-map",
+        "./skills/prototype",
+        "./skills/research"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  router-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Structural check, standard library only: marketplace.json is valid and
+      # claims every skills/<dir>; the team-workflow router roster names every
+      # pack skill; every router link resolves. See the script's docstring.
+      - name: Check router and catalog freshness
+        run: python3 scripts/check_router_freshness.py
+
   advisory-board:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is provider-agnostic: a skill may ship adapter metadata for a sp
 | Skill | Purpose |
 | --- | --- |
 | [Advisory Board](./skills/advisory-board/SKILL.md) | Convene a board of leading AI models to review the same decision, debate across rounds, and hand back one clear recommendation. |
+| [Team-Workflow pack](#team-workflow-pack) | Five skills that ship and version together — a portable discipline for tracked, multi-session, agent-assisted development: decision maps, throwaway prototypes, autonomous research, a once-per-repo setup interview, and a router entry point. |
 
 ## Advisory Board
 
@@ -52,6 +53,44 @@ Every run ends in a single, self-contained HTML handoff that opens offline in an
 
 The look comes from one template, [`handoff-template.html`](./skills/advisory-board/references/handoff-template.html), so any agent that installs the skill renders the same clean output.
 
+## Team-Workflow Pack
+
+**A workflow for teams building with agents — without the collisions.** The team-workflow pack is a portable discipline for tracked, multi-session, agent-assisted development: decide before you build, prototype what discussion can't settle, research what sources can answer, and keep parallel sessions from stepping on each other. Everything repo-specific lives in one binding doc the setup skill seeds; every skill defers judgment calls to **the decider** — the role your repo names, not a person the pack assumes.
+
+| Skill | Reach for it when |
+| --- | --- |
+| [router](./skills/router/SKILL.md) | Unsure which pack skill applies, or orienting a new session/repo. The pack's single entry point. |
+| [setup](./skills/setup/SKILL.md) | Installing the pack into a repo or refreshing its bindings — the once-per-repo interview that seeds the binding doc and templates. |
+| [decision-map](./skills/decision-map/SKILL.md) | The work is genuinely foggy: open questions gate each other and nobody can spec it in one sitting. |
+| [prototype](./skills/prototype/SKILL.md) | The question is "how should this look / behave / feel in action" — throwaway code whose verdict is the deliverable. |
+| [research](./skills/research/SKILL.md) | A question is answerable from primary sources and should run fire-and-report, ending in a cited findings file. |
+
+The pack versions **as one unit**: a single tag `team-workflow/vX.Y.Z`, a single
+[`CHANGELOG.md`](./skills/team-workflow/CHANGELOG.md), and a matching plugin version — consuming
+repos pin one pack version and upgrade deliberately. See [`RELEASING.md`](./RELEASING.md).
+
+### Install as a Claude Code plugin
+
+```text
+/plugin marketplace add timharris707/skills
+/plugin install team-workflow@skills
+```
+
+This repo is a Claude Code plugin marketplace ([`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json)) hosting both `team-workflow` (the five pack skills as one plugin) and `advisory-board` (`/plugin install advisory-board@skills`).
+
+### Install without the plugin system
+
+Clone the repo and copy or symlink the skill directories into wherever your runtime discovers skills — for Claude Code, the personal skills folder:
+
+```bash
+git clone https://github.com/timharris707/skills.git
+for s in router setup decision-map prototype research; do
+  ln -s "$(pwd)/skills/skills/$s" ~/.claude/skills/$s
+done
+```
+
+(Adjust the first path segment to your checkout's name; symlinks track updates on `git pull`, copies pin what you have.) Other agent runtimes can read each `SKILL.md` directly — start with the [router](./skills/router/SKILL.md).
+
 ## Repository Layout
 
 ```text
@@ -76,6 +115,17 @@ skills/
       board_verdict.py
       format_output.py
       README.md
+  router/            # team-workflow pack: entry point
+  setup/             # team-workflow pack: binding interview + seeded templates
+  decision-map/      # team-workflow pack
+  prototype/         # team-workflow pack
+  research/          # team-workflow pack
+  team-workflow/
+    CHANGELOG.md     # the pack's single changelog (pack-scoped tags resolve here)
+.claude-plugin/
+  marketplace.json   # plugin marketplace: advisory-board + team-workflow
+scripts/
+  check_router_freshness.py   # CI: router roster and marketplace stay in sync with skills/
 docs/
   index.md
   advisory-board.md
@@ -99,10 +149,12 @@ GitHub Pages-ready documentation lives in [`docs/`](./docs/) — the Advisory Bo
 
 ## Releases
 
-Each skill is versioned independently and published as a GitHub release from a skill-scoped tag
-(`<skill>/vX.Y.Z`). Per-skill changes are tracked in that skill's `CHANGELOG.md` (e.g.
-[`skills/advisory-board/CHANGELOG.md`](./skills/advisory-board/CHANGELOG.md)); see
-[`RELEASING.md`](./RELEASING.md) for how releases are cut.
+Standalone skills version independently and publish as GitHub releases from skill-scoped tags
+(`<skill>/vX.Y.Z`), with changes tracked in that skill's `CHANGELOG.md` (e.g.
+[`skills/advisory-board/CHANGELOG.md`](./skills/advisory-board/CHANGELOG.md)). The team-workflow
+pack versions as one unit under a pack-scoped tag (`team-workflow/vX.Y.Z`) with one
+[pack changelog](./skills/team-workflow/CHANGELOG.md). See [`RELEASING.md`](./RELEASING.md) for
+how releases are cut.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,14 @@ which publishes the release automatically — you never run `gh release create` 
   capabilities and deliberate default expansions whose old behavior remains available through
   explicit flags; and **patch** for backward-compatible fixes. Model and artifact schema versions
   such as `advisory-board/verdict@N` are separate axes and do not replace the skill version.
+- **Packs:** skills that ship and version **together** release under one **pack-scoped tag**
+  instead of per-skill tags. The `team-workflow` pack (router, setup, decision-map, prototype,
+  research) releases as `team-workflow/vX.Y.Z` with one changelog at
+  [`skills/team-workflow/CHANGELOG.md`](skills/team-workflow/CHANGELOG.md) — exactly the path the
+  release workflow derives from the tag prefix, so pack releases run through the existing workflow
+  unchanged. Individual pack skills never get their own tags. The pack's plugin `version` in
+  [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) mirrors the latest pack tag;
+  bump it in the release commit. Standalone skills (e.g. advisory-board) keep per-skill tags.
 - **Cadence:** cut a release **when a milestone PR merges to `main`** — not on every PR. Infra-only,
   CI-only, and docs-only PRs do **not** get a tag or release (no tag → the workflow never fires).
 - **Notes source:** each skill keeps a [`CHANGELOG.md`](skills/advisory-board/CHANGELOG.md)

--- a/scripts/check_router_freshness.py
+++ b/scripts/check_router_freshness.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Router / catalog freshness check (CI).
+
+Routers rot exactly when skills are added or renamed, so CI enforces the
+structural invariants instead of convention:
+
+  1. `.claude-plugin/marketplace.json` is valid JSON, and every skill path a
+     plugin claims resolves to a directory containing `SKILL.md`.
+  2. Every directory under `skills/` is accounted for: it is claimed by exactly
+     one marketplace plugin, or it is the pack's changelog home
+     (`skills/team-workflow/`, which deliberately carries no SKILL.md — the
+     release workflow derives that path from the pack tag).
+  3. Every skill in the team-workflow plugin appears in the router's roster
+     (`skills/router/SKILL.md`), except the router itself.
+  4. Every relative `.md` link in the router resolves to an existing file.
+
+Standard library only. Exit 0 = fresh; exit 1 = stale, with one line per problem.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / "skills"
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+ROUTER = SKILLS_DIR / "router" / "SKILL.md"
+PACK_PLUGIN = "team-workflow"
+# Non-skill directories under skills/ that are allowed to exist.
+NON_SKILL_DIRS = {"team-workflow"}  # pack changelog home (skills/<tag-prefix>/CHANGELOG.md)
+
+errors = []
+
+
+def claim_paths(plugin):
+    """A plugin's claimed skill dirs as skills/<name> strings."""
+    out = []
+    for raw in plugin.get("skills", []):
+        rel = raw[2:] if raw.startswith("./") else raw
+        out.append(rel.rstrip("/"))
+    return out
+
+
+def main():
+    # 1. Marketplace parses; claimed paths resolve.
+    try:
+        marketplace = json.loads(MARKETPLACE.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: cannot read {MARKETPLACE.relative_to(ROOT)}: {exc}")
+        return 1
+
+    claimed = {}  # skills/<name> -> [plugin names]
+    for plugin in marketplace.get("plugins", []):
+        for rel in claim_paths(plugin):
+            claimed.setdefault(rel, []).append(plugin.get("name", "<unnamed>"))
+            path = ROOT / rel
+            if not (path / "SKILL.md").is_file():
+                errors.append(
+                    f"marketplace plugin '{plugin.get('name')}' claims '{rel}' "
+                    "but there is no SKILL.md there"
+                )
+
+    for rel, owners in claimed.items():
+        if len(owners) > 1:
+            errors.append(f"'{rel}' is claimed by more than one plugin: {', '.join(owners)}")
+
+    # 2. Every skills/ directory is accounted for.
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        rel = f"skills/{entry.name}"
+        has_skill_md = (entry / "SKILL.md").is_file()
+        if entry.name in NON_SKILL_DIRS:
+            if has_skill_md:
+                errors.append(f"'{rel}' is the pack changelog home but now carries a SKILL.md")
+            continue
+        if not has_skill_md:
+            errors.append(f"'{rel}' has no SKILL.md and is not a known non-skill directory")
+            continue
+        if rel not in claimed:
+            errors.append(f"'{rel}' is not claimed by any plugin in marketplace.json")
+
+    # 3 + 4. Router roster covers the pack; router links resolve.
+    try:
+        router_text = ROUTER.read_text()
+    except OSError as exc:
+        print(f"ERROR: cannot read {ROUTER.relative_to(ROOT)}: {exc}")
+        return 1
+
+    pack = next(
+        (p for p in marketplace.get("plugins", []) if p.get("name") == PACK_PLUGIN), None
+    )
+    if pack is None:
+        errors.append(f"marketplace.json has no '{PACK_PLUGIN}' plugin entry")
+    else:
+        for rel in claim_paths(pack):
+            name = rel.rsplit("/", 1)[-1]
+            if name == "router":
+                continue
+            if f"../{name}/" not in router_text:
+                errors.append(f"pack skill '{name}' does not appear in the router roster")
+
+    for link in re.findall(r"\]\((\.\.?/[^)#]+\.md)\)", router_text):
+        if not (ROUTER.parent / link).resolve().is_file():
+            errors.append(f"router links to '{link}' which does not exist")
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}")
+        print(f"router freshness: {len(errors)} problem(s)")
+        return 1
+    print("router freshness: OK (marketplace, skills/ catalog, and router roster agree)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/decision-map/SKILL.md
+++ b/skills/decision-map/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: decision-map
+description: Chart or work a decision map for genuinely foggy work — a new primitive, a milestone charter, an integration nobody can spec in one sitting — before any build slice is written. Use when asked to chart a decision map, work a map ticket, or plan a decision-heavy effort whose open questions gate each other.
+---
+
+# Decision Map
+
+You are running a decision-map session. The protocol authority is [references/protocol.md](references/protocol.md) — read it first, whole; this skill only sequences the session. If the consuming repo has a domain-vocabulary or context doc (see its team-workflow binding doc, seeded by the setup skill), load that too and use its terms.
+
+A decision map exists to turn fog into recorded decisions. It produces decisions, not deliverables: when the map's frontier is empty, the scope specs and builds as ordinary tracked work.
+
+## Mode 1 — charting a new map (invoked with a scope or destination)
+
+1. Write the destination paragraph first — one paragraph on what "decided" looks like for this scope — then survey the fog against the current code and docs per the protocol's charting section.
+2. Choose the weight by fog density (deep → child gate-decision tickets, resolved most-gating-first; shallow → single-sitting adjudication) and say which you chose and why. When the survey finds no fog, take the early exit: write a normal work-item spec instead and say so.
+3. Write the map doc, tracked, at `docs/<scope>-decision-map.md` (or the docs home your binding doc names) with both ledgers (Not yet specified / Out of scope) present, even when empty.
+4. Deep weight: file the child tickets on the repo's tracker, wire blocking edges between dependent tickets per the protocol's recipe, and post the suggested resolution order (most-gating-first) on the parent ticket.
+5. Brief the decider on the map and the first frontier round.
+
+## Mode 2 — working a ticket (invoked with a map ticket)
+
+1. Claim the ticket per the repo's claim recipe (the tracker-discipline binding applies unchanged).
+2. Run the ticket by its type per the protocol's ticket-type table (prototype tickets invoke the prototype skill; research tickets follow the research skill).
+3. Record the outcome on the ticket, write the one-line verdict back into the map doc, and name any newly unblocked tickets (the frontier moved).
+
+## Done when (checkable — verify each line before reporting complete)
+
+- Charting: the map doc exists tracked in the repo with a destination paragraph, both ledgers, and every surveyed question either ticketed, listed under Not yet specified, or ruled Out of scope with its ruling — no question left unplaced.
+- Working: the ticket carries its recorded outcome, the map doc carries the check-off pointer, and blocking edges/labels reflect the new frontier.
+- Map close: the protocol's map-done condition holds, verified against both ledgers → parent ticket closed, build work filed normally.
+
+## Hard guardrails
+
+- Sessions brief decisions; the decider decides. On reaching a decision point, record the recommendation and stop there — the round brief is the deliverable, never the answer.
+- Deviations from a recorded decision go back to the decider; carry them as questions in the next round brief, never as reinterpretations inside a build brief.

--- a/skills/decision-map/references/protocol.md
+++ b/skills/decision-map/references/protocol.md
@@ -1,0 +1,70 @@
+# Decision-map protocol
+
+How a team charts genuinely foggy work — a new primitive, a milestone charter, an integration whose shape nobody can spec in one sitting — before any build slice is written. The core bet: a wrong guess made silently inside a build brief is far more expensive than a decision recorded on a ticket before building starts.
+
+Vocabulary and repo bindings come from the consuming repo's team-workflow binding doc (seeded by the setup skill): the tracker, the claim recipe, the frontier query, and above all **the decider** — the named role that adjudicates decisions in this repo. Sessions brief decisions; the decider decides.
+
+## Standing invariants (every map, every weight)
+
+- **The map doc lives tracked in the repo's docs** (`docs/<scope>-decision-map.md`, or the docs home the binding doc names), so it is reviewable like any other source-of-truth doc.
+- **Child tickets ride the existing tracker machinery**: a `gate-decision` type label, the repo's claim recipe, one session per ticket. A map invents no parallel tracker.
+- **Adjudication authority is unchanged: sessions brief the decision, the decider decides.** A session that reaches a decision point records its recommendation on the ticket and waits — a grilling ticket is answered by the decider, on the record, before anything downstream builds on it.
+- **A map produces decisions, not deliverables.** When the map's frontier is empty, the scope specs and builds normally; deviations from a recorded decision go back to the decider, never into a build brief.
+
+## Charting a map (destination first)
+
+1. **State the destination** before surveying anything: one paragraph on what "decided" looks like for this scope (a speccable milestone, a buildable primitive, an adjudicated slate). The destination bounds every later out-of-scope call.
+2. **Survey the fog against current code**: every open question gets a cluster section with the question, why it is foggy, code pins (file:line evidence of what exists today), options with costs, and what it gates.
+3. **Choose the weight by fog density**:
+   - **Deep fog** (the questions gate each other; a wrong guess reshapes schemas, interfaces, or writer sets): each cluster becomes a child `gate-decision` ticket ("<SCOPE> DECISION: …", body mirroring its map section), resolved **one per session** in most-gating-first order. Child tickets are claimed via the repo's claim recipe like any work item.
+   - **Shallow fog** (questions are independent and briefing-sized): adjudicate the whole map **single-sitting** with the decider, verdicts inlined directly in the map doc.
+4. **No-fog early exit**: when the survey finds every question answerable from existing decisions, code, or evidence, stop — write a normal work-item spec and file it on the tracker. A map with nothing undecided is overhead, not planning.
+
+## The map doc carries two ledgers (never merged)
+
+- **Not yet specified** — in-scope fog: questions inside the destination that are not yet ticket-shaped (usually because an open decision must land first). Entries here **graduate into tickets** as the frontier advances; an empty section means every known unknown has a ticket.
+- **Out of scope** — ruled past the destination by an explicit decision, with the ruling recorded. Entries here **never graduate**; reopening one is a new adjudication with the decider, not a ticket.
+
+Every decided ticket writes back to the map: check the cluster off with a one-line verdict plus a pointer to the ticket (the ticket holds the full record — the map holds the index). The map is done when its frontier is empty AND the Not-yet-specified ledger is empty — every open decision has a ticket or an explicit out-of-scope line.
+
+## Ticket types (four; each human-in-the-loop or autonomous)
+
+| Type | Mode | What it is |
+|---|---|---|
+| **grilling** (default) | human-in-the-loop | A briefed decision round with the decider (below). The agent looks up **facts** (codebase, docs, evidence archives — never asked of the decider); the decider answers **decisions**. |
+| **research** | autonomous | An investigation against primary sources ending in a cited findings file — the research skill's contract. Fire-and-report; multiple research tickets may run in parallel. |
+| **prototype** | human-in-the-loop | Throwaway code answering a "how should it look / behave / feel" question via the prototype skill; its bindings live in that skill. |
+| **task** | either | Real-world work that unblocks a decision (provision something, run an errand-shaped step, coordinate with a vendor). Rides normal lane discipline when it touches the repo. |
+
+Reach-for guidance between grilling and prototype: simple frames resolve in discussion; questions answerable from existing screenshots or artifacts resolve from those. The moment the question is "I need to see/feel this in action," it is a prototype ticket.
+
+## Grilling runs in frontier rounds
+
+A grilling ticket defaults to **rounds, not one question at a time**: each round briefs the decider with the **entire settled frontier** of open decisions — numbered, each with a recommended answer and the evidence behind it. Sequencing rules:
+
+- A question whose answer depends on another question still open **this round** waits for a later round.
+- A background fact-lookup blocks only its own downstream questions — the rest of the round proceeds.
+- The ticket is done when the frontier is empty: **nothing left silently assumed.** Any question the session answered for itself is a fact (with a source), never a decision.
+
+Rounds are briefed to the decider; sessions never self-answer a decision.
+
+## Research tickets
+
+A research ticket runs autonomously against primary sources and ends in a cited findings file linked from the ticket. The full contract — source discipline, findings-file shape, and the questionnaire terminal move for facts only an external human holds — is the research skill's; a map's research tickets follow it unchanged.
+
+## Blocking edges (map tickets AND build slices)
+
+Blocked-on-a-ticket work carries a **native tracker dependency edge**, so the frontier un-blocks itself the moment the blocker closes. On GitHub Issues (the pack's reference tracker — see the tracker binding):
+
+```bash
+# NOTE: -F issue_id takes the blocker's DATABASE id — not its #number, not its node_id.
+# Fetch it with: gh api repos/{owner}/{repo}/issues/<blocker-number> --jq .id
+gh api repos/{owner}/{repo}/issues/<child-number>/dependencies/blocked_by -F issue_id=<blocker-database-id>
+```
+
+The frontier query dual-reads: a ticket is blocked when it carries dependency edges **or** a `blocked` label (recipe: the setup skill's tracker-discipline reference). The division of labor: **edges are authoritative wherever the blocker is a tracker ticket** (wire the edge; closing the blocker un-blocks the child with no label flip); **the `blocked` label** is the human-readable mirror and the only expressible form for non-ticket blockers — vendor gates, scheduling gates, pending adjudications. A purely edge-backed ticket does **not** carry the mirror label — a stale label would hold it blocked after its edges clear, defeating the self-unblocking; the label rides only while a non-ticket blocker exists and comes off when that blocker resolves.
+
+## Map maintenance and close
+
+- Each decided ticket: record the decision on the ticket, check it off in the map with a one-line pointer, and let the decision reshape the still-open clusters.
+- At the map-done condition (§The map doc carries two ledgers): close the parent ticket, and spec/file the build work normally — the map's decisions are the primary sources the build specs link back to.

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: prototype
+description: Build throwaway prototype code that answers a design question — UI variants on a live route, or a terminal UI over a pure logic module. Use when a question is "how should this look / behave / feel in action" and discussion or static artifacts cannot settle it.
+---
+
+# Prototype
+
+A prototype is throwaway code that answers a question. It is the expensive-fidelity tool: simple frames resolve in discussion, and questions answerable from existing screenshots or artifacts resolve from those — reach for a prototype the moment the question is "I need to see/feel this in action." It runs two ways: as the engine of a `prototype` ticket inside a decision map (see the decision-map skill), and standalone for UI-heavy or state-model-heavy work outside any map.
+
+## Pick the branch
+
+- "How should it **look / behave on screen**?" → [references/UI.md](references/UI.md) — three structurally different variants mounted on the live route.
+- "Does this **logic / state model feel right**?" → [references/LOGIC.md](references/LOGIC.md) — a lightweight terminal UI over a pure candidate module.
+
+## Bindings (both branches)
+
+- **All prototype code lives on a throwaway `prototype/<name>` branch** cut from the default branch — variants, switcher, terminal shell, everything. It never merges; the branch is the reference artifact, kept until the winner has shipped.
+- **The verdict is the deliverable**: record on the driving ticket which variant won / what the logic answer was, and **why** — that comment is the primary-source pointer the implementing spec links back to, with the branch name for the code.
+- **The winner is re-implemented through a normal change** (tests plus whatever verification discipline the repo's binding doc names), using the prototype branch as reference. Promoting prototype code as-is skips the discipline the real change exists for — start fresh and copy judiciously.
+- **Prototype branches are exempt from the repo's test-first or coverage rules** — that is the point of a throwaway branch, and the exemption is named in the binding doc's precedence section so agents never deadlock between this skill and a resident test law. The exemption ends the moment re-implementation starts.
+- Iterate in-session: react to each variant/run, give concrete feedback, let the next variant encode it. The richness of the recorded design decisions is the point, not the first render.
+
+## Done when (checkable)
+
+- The driving ticket carries the verdict comment (winner + why + `prototype/<name>` branch name).
+- The prototype branch holds the final iteration, pushed.
+- The working branch you return to is clean of prototype code (`git status` shows none of it outside the prototype branch).
+- A follow-on implementation path exists: either the implementing work item is named on the ticket, or the verdict states why none is filed yet.

--- a/skills/prototype/references/LOGIC.md
+++ b/skills/prototype/references/LOGIC.md
@@ -1,0 +1,13 @@
+# Logic prototype branch
+
+Answer "does this state model / logic feel right" by building a tiny interactive terminal app that pushes a candidate machine through the cases that are hard to reason about on paper.
+
+## Build
+
+1. **The candidate module is PURE** — pure-domain discipline from birth: no I/O, no database, no clock reads inside the logic; in-memory state only; explicit inputs, explicit transitions, typed refusals. Write it as if it will lift into the repo's domain layer, because the validated version will.
+2. **The terminal shell imports the module; nothing flows back.** The shell is disposable (a readline/keypress loop is enough): it renders the machine's state, offers its transitions, and lets you drive edge sequences interactively — an event landing mid-transition, a refusal after a partial step, an out-of-order input. All experiment code stays on the `prototype/<name>` branch.
+3. **Chase the paper-hard cases.** Script the sequences the discussion could not settle and drive them live; when a transition surprises you, that surprise is the finding — record it.
+
+## After validation
+
+The validated reducer/machine lifts into the repo's domain layer **through a normal change**, where real tests and the repo's invariant discipline pin it (the prototype's terminal runs are design evidence, not test coverage). The prototype branch stays as the reference for that work. Then return to [SKILL.md](../SKILL.md) "Done when".

--- a/skills/prototype/references/UI.md
+++ b/skills/prototype/references/UI.md
@@ -1,0 +1,19 @@
+# UI prototype branch
+
+Answer "how should it look / behave" by mounting **three structurally different variants on the LIVE route** and letting the decider react to real renders over real data.
+
+## Build
+
+1. **Live route first.** Mount the variants on the actual route behind a `?variant=` query param — real shell, real data, real navigation. This is the honest representation of how the code will work; a throwaway route is the last resort, only when the live route structurally cannot host the experiment.
+2. **Three variants, structurally different.** Each variant encodes a different layout / information hierarchy — a different answer to the design question. Recolors and spacing tweaks are iteration feedback, never a variant. Name them A/B/C; iteration mints D, E… encoding the feedback so far.
+3. **Floating switcher pill**, dev-gated: render it only in development builds, floating over the page, showing the active variant, with `←`/`→` cycling variants. The default (no `?variant=`) renders the route exactly as the default branch does.
+4. **Variants are READ-ONLY.** Every control that would mutate points at a stub (local state, a no-op handler with a visible "prototype" affordance) — never at a real writer. The question is layout and behavior; real mutations belong to the real implementation.
+5. Use the repo's shared design system inside every variant — the question is structure, and off-system styling makes the winner unshippable as observed.
+
+## Visual-regression baselines stay clean
+
+If the repo runs visual-regression baselines, they must never snapshot a variant: variants are `?variant=`-param-gated and no baseline spec passes that param, so baselines see the default route only. Keep it that way — add no prototype spec files, and leave the visual suite untouched. If a baseline changes on the prototype branch, the default render leaked variant code: fix the gate.
+
+## Iterate
+
+Walk each variant with the decider (or record a walkthrough for async reaction). Collect concrete reactions ("search box from A, layout from C"), encode them into the next variant, repeat until one render answers the question. Then return to [SKILL.md](../SKILL.md) "Done when".

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: research
+description: Run an autonomous research lane against primary sources, ending in a cited findings file linked from the driving ticket — and, when the missing facts are human-held, a questionnaire. Use for investigations of vendor materials, regulations, upstream repos, recorded calls, or any fact-finding that should run fire-and-report.
+---
+
+# Research
+
+A research lane runs **autonomously** (fire-and-report): it investigates against primary sources — vendor materials, regulations, upstream repos, recorded calls, live systems you have access to — and ends in a **cited findings file** linked from the driving ticket. It runs two ways: as a `research` ticket inside a decision map (see the decision-map skill), and standalone for any investigation worth a recorded answer.
+
+## Contract
+
+1. **Primary sources only.** Read the actual material — the vendor doc, the upstream code, the regulation text, the recording. Secondary summaries are leads, not evidence.
+2. **The deliverable is a findings file**, tracked in the repo's docs (default `docs/research/<topic>.md`, or the findings home the team-workflow binding doc names). Material that is PII-bearing or otherwise local-only goes in a git-ignored location instead — the findings file there is still linked from the ticket by path.
+3. **Findings cite their sources inline.** A claim without a source is a hypothesis and is labeled as one. Distinguish clearly: what the source says, what you infer, what remains unknown.
+4. **Link the findings file from the ticket** and summarize the feature-level answers in a ticket comment, so downstream decision rounds can cite it without opening the file.
+5. Multiple research lanes may run in parallel — they share no state beyond the tracker.
+
+## When the facts are human-held
+
+When a research lane hits facts only an external human holds (a vendor contact, a partner engineer, a pilot user), it does not stall or guess — it ends with the **questionnaire terminal move**: [references/questionnaire.md](references/questionnaire.md).
+
+## Done when (checkable)
+
+- The findings file exists at the named location, every claim cited or labeled a hypothesis.
+- The driving ticket links the file and carries the feature-level summary.
+- Any human-held gaps are covered by an emitted questionnaire (per the terminal move), not by silent assumptions.

--- a/skills/research/references/questionnaire.md
+++ b/skills/research/references/questionnaire.md
@@ -1,0 +1,18 @@
+# The questionnaire terminal move
+
+When a research lane hits facts only an external human holds, it ends by emitting a questionnaire file — `docs/research/questionnaire-<topic>.md` (or a git-ignored location when the content is PII-adjacent) — linked from the driving ticket.
+
+**Craft rule: grill the SEND, not the subject.** Before drafting a single question, settle with the decider who the questionnaire goes to and what is needed back. A perfect question list aimed at the wrong recipient is wasted; the recipient and the decision the answers feed determine everything about the questions.
+
+## The file's shape
+
+1. **Header**: purpose + how the answers will be used.
+2. **One-paragraph context** for the recipient — enough to answer well, no more.
+3. **Sections ordered most-important-first** — async means assume one pass; if the recipient answers only the first section, that section must be the one that mattered.
+4. **One idea per question**, with an answer stub beneath each.
+5. **"Partial answers and 'I don't know' are useful"** stated up front — an honest gap beats a guessed answer.
+6. **A closing catch-all**: "anything we didn't ask about that we should have?"
+
+## After emitting
+
+The research lane is done — sending the questionnaire and chasing answers is the decider's (or the ticket owner's) real-world move, recorded back on the ticket when the answers land.

--- a/skills/router/SKILL.md
+++ b/skills/router/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: router
+description: Entry point for the team-workflow pack — names every pack skill and when to reach for it. Use when unsure which team-workflow skill applies, or to orient a new session/repo on what the pack offers.
+---
+
+# Team-workflow router
+
+One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development — decision-making before building, throwaway prototyping, autonomous research, and tracker hygiene that keeps parallel sessions from colliding. Everything repo-specific lives in one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
+
+**First run in a repo? Run `setup` before anything else.** The other skills read the bindings it seeds.
+
+## The skills
+
+| Skill | Reach for it when |
+| --- | --- |
+| [setup](../setup/SKILL.md) | Installing the pack into a repo, or refreshing its bindings. Once-per-repo interview: confirms the tracker, verify commands, the decider, and the binding-doc home; seeds the binding doc and templates; re-runs are idempotent diffs, never overwrites. |
+| [decision-map](../decision-map/SKILL.md) | The work is genuinely foggy — open questions gate each other and nobody can spec it in one sitting. Charts a map (destination, clusters, two ledgers), files gate-decision tickets, and runs briefed decision rounds with the decider. Not for work you could already spec: a map with nothing undecided is overhead. |
+| [prototype](../prototype/SKILL.md) | The question is "how should this look / behave / feel in action" and discussion or static artifacts can't settle it. Throwaway code on a `prototype/<name>` branch — UI variants on the live route, or a terminal UI over a pure logic module; the verdict is the deliverable and the winner is re-implemented properly. |
+| [research](../research/SKILL.md) | A question is answerable from primary sources and should run fire-and-report. Autonomous investigation ending in a cited findings file — and a questionnaire when the missing facts are human-held. |
+
+## Not skills, but in the pack
+
+- **Tracker discipline** — the claim / frontier / blocking recipes and the issue-as-spec shape live in [setup's references](../setup/references/tracker-discipline.md) and get bound to the repo via the binding doc. There is nothing to invoke; sessions follow the recipes.
+- **Templates** — work-item spec, lane brief, and session handoff are templates the setup skill seeds into the consuming repo (handoff is deliberately a template, not a skill — repos often have their own wrap-up convention).
+
+## Review discipline: the meta-rule
+
+The pack ships no review checklist, on purpose. The rule that travels: **derive your own defect classes from your own defect history, and admit a class to the checklist only via a live reproduction** — a checklist imported from someone else's war record checks for their bugs, not yours. Start the repo's own list the first time a real defect escapes, and grow it only from evidence.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: setup
+description: Once-per-repo binding interview for the team-workflow pack — scan the repo, confirm the mandatory bindings (tracker, verify commands, decider, binding-doc home), seed the anchor binding doc and templates, and refresh idempotently on re-run. Use when installing the pack into a repo or updating an existing installation.
+---
+
+# Setup
+
+This skill binds the team-workflow pack to a specific repo, once, through an interview — and refreshes that binding on re-run. Everything the other pack skills call "the binding doc" is what this skill seeds. Nothing here rewrites the repo's CI or processes; it records how the pack composes with what is already there.
+
+**Posture: infer first, confirm everything.** Scan the repo before asking anything — the tracker in use, CI config, verify/test commands, existing agent-context files (CLAUDE.md, AGENTS.md, docs conventions), existing templates, and any config-distribution pipeline that syncs or ignores dotfiles. Present every inferred binding for confirmation; never silently assume one. Exactly two bindings always require a live human answer regardless of what the scan finds: **the decider** and **the binding-doc home**.
+
+## The four mandatory bindings
+
+1. **Tracker** — the repo + tracker in use, and the mapping onto the pack's tracker discipline: how claims are posted, how blocking is expressed, what the frontier query is. The pack is GitHub-Issues-first — the recipes in [references/tracker-discipline.md](references/tracker-discipline.md) use `gh` — but the tracker is a **named binding**, not an assumption baked into the skills: a repo on a different tracker writes a different tracker section in its binding doc, mapping the same discipline (machine-readable claims, dependency edges, a frontier query) onto its own tool. The skills stay unchanged.
+2. **Verify commands** — the exact commands that constitute "verified" in this repo (typecheck, lint, test, build, whatever the repo runs), recorded so every brief and template can name them instead of guessing.
+3. **The decider** — who adjudicates decisions in this repo. Always asked, never inferred. Every pack skill says "the decider"; this binding is where that role gets a name. A repo without a clear answer here is not ready for the pack's decision discipline — surface that honestly.
+4. **The binding-doc home** — where the anchor binding doc lives. Default: `docs/agents/team-workflow.md`. The home is **confirmed in the interview, never assumed**: repos with config-distribution pipelines (synced or git-ignored dotfile directories) can make the default location wrong in ways only a human knows — the binding doc must land somewhere tracked, un-synced, and visible to agents.
+
+**Optional bindings** (offer them; skip freely): label-vocabulary mapping (the repo's existing labels onto the pack's state/type vocabulary), domain-doc pointers (context docs agents should load), adopt-repo-templates vs seed-pack-templates (below), and a friction-log location.
+
+## What gets seeded
+
+- **One anchor binding doc** at the confirmed home, from [references/templates/binding-doc.md](references/templates/binding-doc.md). It carries the four mandatory bindings, any confirmed optional ones, and a **precedence/exemptions section** stating how the pack composes with resident rule systems — explicitly including the prototype skill's test-exemption (prototype branches are exempt from test-first/coverage law) so agents never deadlock between pack rules and repo rules. Resident rules win unless the exemptions section says otherwise.
+- **Templates**, seeded into the consuming repo's own convention locations **only on confirmation** — and only where the repo doesn't already have an equivalent it prefers to keep (the adopt-vs-seed optional binding):
+  - Issue/work-item spec: [references/templates/issue-slice-spec.md](references/templates/issue-slice-spec.md) (on GitHub: `.github/ISSUE_TEMPLATE/`).
+  - Lane brief shape: [references/templates/lane-brief.md](references/templates/lane-brief.md).
+  - Session handoff: [references/templates/handoff.md](references/templates/handoff.md) — a seeded template, not a skill; repos may already have their own handoff convention.
+
+## Re-run semantics: idempotent refresh
+
+Re-running setup **re-scans the repo, diffs against the existing binding doc, and proposes changes for confirmation** — never a blind overwrite, never a one-shot refusal. Bindings that still match are left untouched; drift (a changed verify command, a new tracker, a moved docs home) is presented as a diff for the human to accept or reject, one binding at a time.
+
+## Done when (checkable)
+
+- The binding doc exists at the confirmed home with all four mandatory bindings filled and the precedence/exemptions section present.
+- Confirmed templates are seeded at their confirmed locations; declined ones are recorded as declined in the binding doc (so a re-run doesn't re-ask from scratch).
+- The human confirmed every binding — including the inferred ones — and answered decider + home directly.

--- a/skills/setup/references/templates/binding-doc.md
+++ b/skills/setup/references/templates/binding-doc.md
@@ -1,0 +1,58 @@
+# Team workflow — repo bindings
+
+<!-- Seeded by the team-workflow pack's setup skill. Default home: docs/agents/team-workflow.md
+     (the home is confirmed at setup, never assumed). This doc is the single place the pack's
+     skills read repo-specific facts from; keep it current via a setup re-run (idempotent
+     refresh), not hand-drift. -->
+
+_Pack version: <pack version installed> · Last confirmed: <date>_
+
+## Tracker binding
+
+- **Tracker**: <e.g. GitHub Issues on `<owner>/<repo>`>
+- **Claim recipe**: <e.g. "the pack's tracker-discipline recipes as written" — or the repo's mapping of them onto its tracker>
+- **Frontier query**: <the exact command/query that lists grabbable items>
+- **Blocking**: <native dependency edges + `blocked` label, or the repo's equivalent dual-read>
+- **Label mapping** (optional): <repo labels ↔ pack vocabulary: needs-triage / ready-for-agent / ready-for-human / blocked + type labels>
+
+## Verify commands
+
+<!-- The exact commands that constitute "verified" here. Briefs and templates name these
+     instead of guessing. Tier them if the repo distinguishes blast radii. -->
+
+```bash
+<typecheck command>
+<lint command>
+<test command>
+<build command>
+```
+
+## The decider
+
+- **Decider**: <name/role — who adjudicates decisions in this repo>
+
+Every pack skill says "the decider"; this line is where the role resolves. Sessions brief decisions with recommendations and evidence; the decider answers them on the record.
+
+## Docs home
+
+- **Binding doc home**: <this file's confirmed location>
+- **Decision maps**: <where map docs live, e.g. `docs/<scope>-decision-map.md`>
+- **Research findings**: <where findings files live, e.g. `docs/research/`>
+- **Domain/context docs agents should load** (optional): <paths>
+
+## Precedence & exemptions
+
+How the pack composes with this repo's resident rule systems. Resident rules win unless an exemption below says otherwise.
+
+- **Prototype test-exemption**: code on `prototype/<name>` branches is exempt from the repo's test-first / coverage rules — prototype branches are throwaway by contract and never merge; the exemption ends the moment the winner's real implementation starts.
+- <other resident rules and how the pack defers to or composes with them>
+
+## Templates
+
+- Issue/work-item spec: <adopted repo's own | seeded at `<path>` | declined>
+- Lane brief: <adopted | seeded at `<path>` | declined>
+- Handoff: <adopted | seeded at `<path>` | declined>
+
+## Friction log (optional)
+
+- <where pack friction gets recorded, e.g. a dedicated tracker item>

--- a/skills/setup/references/templates/handoff.md
+++ b/skills/setup/references/templates/handoff.md
@@ -1,0 +1,32 @@
+# Session handoff template
+
+<!-- A seeded TEMPLATE, not a skill. Written at session wrap-up (conventionally to an
+     untracked, auto-loaded location like .claude/handoff.md, or wherever the repo's
+     binding doc names) so a fresh session resumes without re-explanation. Overwrite on
+     each wrap-up — it is "where we are right now", never a running log. The tracker and
+     the repo's tracked docs remain the durable record; the handoff is only the hot pointer. -->
+
+# Handoff — <short task name>
+_Updated: <date> · Branch: <branch>_
+
+## STATE
+
+<2–4 sentences: exactly where things stand right now.>
+
+## DONE (this session)
+
+- <what actually shipped/changed, with file paths>
+
+## NEXT
+
+<!-- THE STALE-NEXT RULE: NEXT points at the tracker query, never enumerates items.
+     The work queue lives on the tracker; a handoff that lists specific item numbers
+     goes stale the moment any other session claims one, and a session that starts
+     from that stale list collides with the claimer. Reading a handoff never
+     authorizes starting an item — the claim recipe always runs. -->
+
+1. Run the frontier query (see the team-workflow binding doc) and claim from it.
+
+## GOTCHAS / DON'T-REPEAT
+
+- <traps, dead ends already ruled out, things that look right but aren't>

--- a/skills/setup/references/templates/issue-slice-spec.md
+++ b/skills/setup/references/templates/issue-slice-spec.md
@@ -1,0 +1,34 @@
+---
+name: Work-item spec
+about: A PR-sized build slice — the item body is the spec and the brief source
+labels: slice
+---
+
+<!-- Issue-as-spec: this body IS the spec. The implementing brief adds standing constraints
+     and mechanics, never a second copy of the requirements. On GitHub, seed this file into
+     .github/ISSUE_TEMPLATE/; on another tracker, map the same sections onto its template. -->
+
+## Destination
+
+<!-- What exists when this is done, in one paragraph. The spec is the destination; the
+     acceptance criteria below are how we know we arrived. -->
+
+## Plan source
+
+<!-- The roadmap/plan line or recorded decision this slice implements — link the primary
+     source so review doesn't relitigate it. -->
+
+## Acceptance criteria
+
+<!-- Checkboxed, verifiable statements. These seed review and any live-probe checklist. -->
+
+- [ ] …
+
+## Verification
+
+<!-- Which of the repo's verify commands (see the team-workflow binding doc) this slice
+     must pass, plus any slice-specific probes. -->
+
+## Out of scope
+
+<!-- What this slice deliberately does not do, so review doesn't relitigate it. -->

--- a/skills/setup/references/templates/lane-brief.md
+++ b/skills/setup/references/templates/lane-brief.md
@@ -1,0 +1,43 @@
+# Lane brief template
+
+How a tracked work item becomes a working brief for the session (human or agent) implementing it. The item is the spec — the brief adds only standing constraints and lane mechanics, **never a second copy of the requirements**. A brief that paraphrases the spec creates two sources of truth that drift; a brief that pastes it verbatim cannot.
+
+## Before generating the brief
+
+1. Pick the item from the frontier (the binding doc's frontier query — it dual-reads dependency edges and the `blocked` label).
+2. Claim it per the claim recipe (read-before-write; a live `Lane-start` refuses you).
+3. Branch off the default branch; note anything the lane must pin at start (sequence numbers, environment facts) so parallel lanes can't collide on them.
+4. Decide the verification set from the binding doc's verify commands (and the repo's tiering, if any) — name it in the brief so "done" is defined before work starts.
+
+## The brief
+
+```markdown
+# Lane brief — item #<N>: <title>
+
+## Spec
+The spec is item #<N> (body pasted below verbatim — do not reinterpret; deviations go in
+the summary's "Deviations" section, and deviations from a recorded decision go back to
+the decider, never silently into the work).
+<item body, verbatim>
+
+## Required reading (load before writing code)
+- <the repo's domain/context docs, per the binding doc>
+- <the team-workflow binding doc itself>
+
+## Standing constraints (every lane)
+- Verification: <the named verify commands for this item>.
+- Check every verification command's own exit code — piped or filtered output is not
+  evidence (a pipeline reports the last command's status, so `<cmd> | tail` reads green
+  whenever `tail` does).
+- Commit discipline: checkpoint commits on the lane branch, short imperative subjects;
+  merging is the reviewer/integrator's move, not the lane's.
+- <the repo's own standing constraints, from the binding doc's precedence section>
+
+## Output contract
+Write a summary containing:
+1. What landed (by file).
+2. Verification you ran (commands + results verbatim).
+3. Deviations from the spec + open questions.
+The summary posts back to item #<N> as a comment — write it for that audience; the
+tracker comment is the durable record.
+```

--- a/skills/setup/references/tracker-discipline.md
+++ b/skills/setup/references/tracker-discipline.md
@@ -1,0 +1,74 @@
+# Tracker discipline — the portable recipes
+
+The pack's collision defenses, written GitHub-Issues-first (`gh` commands throughout). The tracker itself is a **named binding**: a repo on a different tracker maps these same recipes — machine-readable claims, dependency edges, a frontier query, issue-as-spec — onto its own tool in its binding doc; the recipes' logic is the export, not the tool.
+
+The core discipline: **one session per work item, and the claim is legible to machines.** Two agents (or an agent and a human) silently building the same item is the failure class every recipe below exists to prevent — an assignee field alone cannot distinguish two sessions sharing one account, so claims are carried in comment markers a scanner can read.
+
+## Issue-as-spec
+
+The work item's body IS the spec: destination, acceptance criteria, out-of-scope — written once, on the tracker, before any code. The implementing brief adds standing constraints and mechanics, never a second copy of the requirements; the implementing PR carries `Closes #N`; the work summary posts back to the item as a comment, making the tracker the durable record. Discovered-but-unplanned work gets filed as a new item, not smuggled into the current one.
+
+## Claim recipe (read-before-write)
+
+Claiming is a read-modify-write with the read mandatory:
+
+1. **Read the item's comments first.** A claim is LIVE when the latest comment matching
+   `Lane-start: workspace=<name> branch=<branch>`
+   has no later `Lane-start-retracted: workspace=<same-name>` marker after it (a later `Lane-start` supersedes an earlier one — takeover chains post a new one).
+2. **A live claim refuses your claim.** No external pointer — a handoff note, a stale to-do list, a plan doc — ever overrides a live Lane-start. Those pointers go stale the moment anyone else claims; the tracker comment is the truth.
+3. **On clear: claim atomically.** Set yourself assignee AND post the marker in one pass:
+
+   ```bash
+   gh issue edit <N> --add-assignee "@me"
+   gh issue comment <N> --body "Lane-start: workspace=<name> branch=<branch>"
+   ```
+
+   `<name>` is a machine-matchable token identifying your working copy (worktree, clone, or machine+dir) — the retraction scanner matches on it literally, so pick something unique and reuse it exactly.
+4. **Releasing your OWN claim** posts the machine-recognized marker and unassigns:
+
+   ```bash
+   gh issue comment <N> --body "Lane-start-retracted: workspace=<name>"
+   gh issue edit <N> --remove-assignee "@me"
+   ```
+
+   Prose retractions ("I'm dropping this one") are invisible to a scanner unless they contain the literal workspace token — always post the marker.
+5. **Taking over a DEAD lane** requires recorded evidence of death, and death is hard to prove: an agent session can be alive but between turns, invisible to every process probe — "no processes running + no commits" is NOT death evidence. Before a takeover: read the item's recent comments for liveness (progress notes, a summary in flight), check for active sessions on the machines involved, and wait out quiet phases. Only then post a superseding claim that records the takeover:
+
+   ```bash
+   gh issue comment <N> --body "Lane-start: workspace=<name> branch=<branch> (takeover: <evidence the prior lane is dead>; prior workspace=<old-name>)"
+   ```
+6. **Suspect claims**: an assignee with no live Lane-start comment is a suspect claim — check for running sessions before treating the item as free.
+
+Also on the claimer, before any of the above: check for other active sessions already working the same surface — a running session beats an unclaimed item. After claiming, make the session/workspace carry the item number (a fresh, item-named working copy; a recycled name makes session lists lie to the next reader).
+
+## Frontier recipe (dual-read)
+
+The frontier is the set of grabbable items: ready-labeled, unassigned, and **not blocked — read blocking two ways**: native dependency edges OR a `blocked` label. A query that checks only the label misses edge-blocked items; one that checks only edges misses non-ticket blockers.
+
+```bash
+# One JSON object per open issue, with the dependency summary the plain issue list omits:
+gh api 'repos/{owner}/{repo}/issues?state=open&per_page=100' --paginate --jq '.[]
+  | select(has("pull_request") | not)
+  | {number, title,
+     labels: [.labels[].name],
+     assignees: [.assignees[].login],
+     blockedBy: (.issue_dependencies_summary.blocked_by // 0)}'
+```
+
+Grabbable = has the ready label (per your label binding) AND `assignees == []` AND `blockedBy == 0` AND no `blocked` label. When the frontier is empty, report WHY (all claimed vs. triage stalled vs. everything blocked) — an empty answer with no breakdown sends people guessing.
+
+## Blocking edges
+
+Wire blocked-on-a-ticket work as a **native dependency edge** so the frontier un-blocks itself the moment the blocker closes:
+
+```bash
+# -F issue_id takes the blocker's DATABASE id — not its #number, not its node_id:
+gh api repos/{owner}/{repo}/issues/<blocker-number> --jq .id
+gh api repos/{owner}/{repo}/issues/<child-number>/dependencies/blocked_by -F issue_id=<that-id>
+```
+
+Division of labor: **edges are authoritative wherever the blocker is a tracker item** (no label flip needed when it closes); the **`blocked` label** is the human-readable mirror and the only expressible form for non-ticket blockers (vendor gates, scheduling, pending adjudications). A purely edge-backed item does NOT also carry the label — a stale label would hold it blocked after its edges clear. The label rides only while a non-ticket blocker exists and comes off when that blocker resolves.
+
+## State and type labels (the vocabulary binding maps these)
+
+The pack's reference vocabulary — map your repo's existing labels onto it in the binding doc rather than renaming your labels: state = `needs-triage` (all inbound; verify/reproduce before promoting) → `ready-for-agent` / `ready-for-human`, plus `blocked`; type labels tag the kind of work (build slice, bug, decision, process) and can drive per-type verification tiers if the repo wants them.

--- a/skills/team-workflow/CHANGELOG.md
+++ b/skills/team-workflow/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog — team-workflow (pack)
+
+All notable changes to the **team-workflow pack** are documented here. The pack versions as a
+unit — **one pack = one version**: a single pack-scoped tag `team-workflow/vX.Y.Z` covers all
+pack skills together (see [`RELEASING.md`](../../RELEASING.md)), and the plugin version in
+[`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json) mirrors the latest
+pack tag. Individual pack skills do not carry their own changelogs or tags.
+
+This file lives at `skills/team-workflow/CHANGELOG.md` deliberately: the release workflow
+derives the changelog path from the tag prefix, so a `team-workflow/vX.Y.Z` tag resolves here
+with no workflow changes.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+<!-- At release time, rename the heading below to `## [v1.0.0] - YYYY-MM-DD — v1 pack` and add a
+     fresh empty `## [Unreleased]` above it, per RELEASING.md. -->
+
+## [Unreleased]
+
+### Added
+
+- Initial release of the **team-workflow** pack: a portable discipline for tracked,
+  multi-session, agent-assisted development, shipped as five skills that travel together.
+  - **router** — the pack's single entry point: names every pack skill and when to reach
+    for it, plus the review meta-rule (derive your own defect classes from your own defect
+    history; admit a class only via live reproduction).
+  - **setup** — once-per-repo binding interview: confirms the tracker, verify commands,
+    the decider, and the binding-doc home; seeds the anchor binding doc and templates;
+    re-runs are idempotent diffs, never overwrites.
+  - **decision-map** — chart and work decision maps for genuinely foggy efforts:
+    destination-first, gate-decision tickets, four ticket types, two ledgers, and briefed
+    decision rounds adjudicated by the decider (full protocol in `references/protocol.md`).
+  - **prototype** — throwaway prototype code that answers a design question: UI variants on
+    a live route, or a terminal UI over a pure logic module; the verdict is the deliverable
+    and the winner is re-implemented properly.
+  - **research** — autonomous fire-and-report investigation against primary sources, ending
+    in a cited findings file — and a questionnaire when the missing facts are human-held.
+- Tracker discipline as portable recipes (claim, frontier, blocking edges, issue-as-spec)
+  in the setup skill's references, bound per-repo through the seeded binding doc.
+- Seeded templates: binding doc, work-item spec, lane brief, and session handoff.
+- Distribution: the repo's `.claude-plugin/marketplace.json` hosts the pack as one plugin
+  carrying all five skills; a clone/symlink path is documented in the repo README for
+  non-plugin consumers.
+- CI freshness check: every skill directory is claimed in the router/marketplace roster and
+  every router entry resolves, so the router cannot silently rot as skills are added.

--- a/skills/team-workflow/CHANGELOG.md
+++ b/skills/team-workflow/CHANGELOG.md
@@ -12,10 +12,9 @@ with no workflow changes.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-<!-- At release time, rename the heading below to `## [v1.0.0] - YYYY-MM-DD — v1 pack` and add a
-     fresh empty `## [Unreleased]` above it, per RELEASING.md. -->
-
 ## [Unreleased]
+
+## [v1.0.0] - 2026-07-31 — v1 pack
 
 ### Added
 


### PR DESCRIPTION
The **team-workflow** pack: five skills that travel together (router, setup, decision-map, prototype, research) plus pack-level distribution — marketplace manifest, pack CHANGELOG with pack-scoped `team-workflow/vX.Y.Z` tags, RELEASING pack clause, README install paths, and a router-freshness CI check.

**Scrub record (pre-publication gate):** first-reader walk (20 files line-by-line, five grep sweeps, zero violations) + clean-context second reader with checklist-only brief: **VERDICT CLEAN**. Full auditable record: timharris707/loanmeld#543. Release authorized by the repo owner 2026-07-31 (pre-push read waived on the record; second reader as final gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)