### PR TITLE
Scrub absolute local paths from example run metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ catalog into the repository root because release automation and multi-skill path
 
 ## Validation
 
-When a skill is Codex-compatible, validate it with the local skill validator before publishing changes.
-Pull requests must also pass `.github/workflows/ci.yml`, including Python compilation, shell-mock
-syntax checks, and the complete advisory-board test suite.
+When a skill is Codex-compatible, check its `agents/openai.yaml` adapter against the SKILL.md before
+publishing changes. Pull requests must also pass `.github/workflows/ci.yml`, including Python
+compilation, shell-mock syntax checks, router freshness, and the complete advisory-board test suite.
 
 ## Releases
 

--- a/examples/side-project-go-full-time-review/run-metadata.md
+++ b/examples/side-project-go-full-time-review/run-metadata.md
@@ -15,7 +15,7 @@ Lens preset: business-decision
 ## Source
 
 Access method: single source packet
-Source: /Users/timharris/projects/skills/.claude/worktrees/marketing-refresh/examples/side-project-go-full-time-review/proposal.md (sha256:15ac5d99ef4cd3d42aafd524e6ee3e185ee6b44b980d82e3e65f97d1196d9d2c)
+Source: examples/side-project-go-full-time-review/proposal.md (sha256:15ac5d99ef4cd3d42aafd524e6ee3e185ee6b44b980d82e3e65f97d1196d9d2c)
 Sensitivity & handling: public
 
 ## Egress approval

--- a/examples/side-project-go-full-time-review/run-recipe.yaml
+++ b/examples/side-project-go-full-time-review/run-recipe.yaml
@@ -10,7 +10,7 @@ max_rounds: 3
 cross_reading: summaries
 lens: business-decision
 output: full-handoff
-out_dir: /Users/timharris/projects/skills/.claude/worktrees/marketing-refresh/examples/side-project-go-full-time-review
+out_dir: examples/side-project-go-full-time-review
 
 # prompt template (bump/hash changes when the egressed prompt shape changes)
 prompt_template: advisory-board/round1@2
@@ -24,7 +24,7 @@ synthesizer_template_sha256: 96a8427ffa40c9068ff97853bd2e34144ac41abf04bd0642869
 
 # source
 source_kind: path
-source_ref: /Users/timharris/projects/skills/.claude/worktrees/marketing-refresh/examples/side-project-go-full-time-review/proposal.md
+source_ref: examples/side-project-go-full-time-review/proposal.md
 source_bytes: 1918
 source_lines: 27
 source_sha256: 15ac5d99ef4cd3d42aafd524e6ee3e185ee6b44b980d82e3e65f97d1196d9d2c


### PR DESCRIPTION
Two LOW findings from a 2026-08-02 pre-download audit of the public repo (full C5-checklist sweep of the team-workflow pack came back clean — these were the only residuals, both outside skill content):

1. **Absolute local paths** — the side-project example's `run-metadata.md` (1 line) and `run-recipe.yaml` (2 lines) recorded `/Users/timharris/projects/skills/.claude/worktrees/...` paths, exposing the local worktree layout. Now repo-relative; `sha256` values are content hashes and are unchanged.
2. **Dangling CONTRIBUTING pointer** — the Validation section told contributors to run a "local skill validator" that doesn't exist anywhere in the repo. Now points at the real checks: the `agents/openai.yaml` adapter review and the CI suite (including router freshness).

No skill content changed; no release/tag needed (fixes are outside `skills/team-workflow/`). Trivial-docs class per the repo's review convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)