### PR TITLE
advisory-board v1.17.0: modes, mandatory guided intake, red-team lens, Fable seat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "advisory-board",
       "source": "./",
       "strict": false,
-      "version": "1.16.0",
+      "version": "1.17.0",
       "description": "Convene a board of frontier AI models — Claude, Codex, Gemini, and Grok — that each review the same decision independently, debate across rounds, and hand back one clear recommendation.",
       "license": "MIT",
       "skills": [

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -7,7 +7,16 @@ cut as **skill-scoped semver tags** `advisory-board/vX.Y.Z` (see [`RELEASING.md`
 The skill follows SemVer; its artifact schemas (for example `advisory-board/verdict@N`) are
 versioned separately and do not replace the skill release version.
 
-## [Unreleased]
+## [v1.17.0] - 2026-08-07 — Modes, guided intake, and the Fable seat
+
+### Added
+- **Modes** (`references/modes.md`): the board's interaction topology is now a named, user-chosen axis, sharing vocabulary with panely.ai — **Formal Board Review** (the existing Round Protocol, now named; the default and the only conductor-driven mode), **Roundtable** (collaborative, shared transcript, optional moderator), and **Competitive** (pitch → critique → blind vote). The two new topologies ship as hand-runnable protocols with prompt skeletons and artifact sets; `run_board.py --mode` support is a tracked follow-up. Neither produces a `verdict.json` or feeds a gate.
+- **`red-team` lens preset** — every seat hostile by assignment (correctness attacker, ambiguity attacker, security & data-handling attacker, unimagined-failure hunter), for stress-testing artifacts before staking something on them; pairs with `--repo` for `path:line` attacks. Mirrored in `references/lens-presets.md` and the conductor's `LENS_PRESETS`.
+
+### Changed
+- **The intake is now a mandatory guided wizard** (`references/intake-interview.md`, rewritten): doctor probes every seat first and broken seats get an explicit fix-now (consent-gated) / continue-without / abort choice; the user's stated goal drives a mode recommendation the user confirms; seats (2–10 of the GO providers, "latest frontier of each" shortcut), reasoning depth, rounds, and output are all chosen on the record. "Use defaults" collapses to a single confirm-summary card — never to zero questions — and data-handling consent remains separate and unwaivable. A new Must Not line makes launching an unconfirmed run a violation.
+- **Claude seat targets `fable`** — Anthropic's maintained alias for Fable 5 (Mythos-class, above Opus), at `--effort max`; `opus` is the ordered fallback preflight proposes (never silently applies) where `fable` doesn't resolve.
+- **Board ceiling raised from ~5 to 10 seats**, with the lens rule refined: the same lens on two different providers is a valid cross-model pairing; only same-provider-same-lens wastes a seat. Past a preset's lens count the intake proposes distinct additional lenses for confirmation, and big/deep boards get a cost warning up front.
 
 ### Fixed
 - Grok seat now works against current Grok CLI releases. xAI removed `--no-auto-update` (by 0.2.111) and retired the `grok-build` alias, so every Grok run failed on an unknown flag and an unresolvable model. The adapter drops the flag and selects `grok-4.5`, which `grok models` reports as the only model and the CLI default. All other flags the seat depends on — `-p`, `--effort`, `--output-format`, `--permission-mode plan`, `--sandbox read-only`, `--no-memory`, `--no-subagents` — re-verified against CLI 0.2.117 on 2026-08-05.

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: advisory-board
-description: Convene a multi-model advisory board (a round table) where subscription-backed Claude, Codex, Gemini, and Grok CLIs each review the same material independently, debate across rounds by reading one another's findings, and converge on a single working handoff. Use when the user asks for an advisory board, round table, or panel; a multi-model or multi-provider review; a skilled debate among models; an adversarial review of a plan, design, architecture, document, decision, or strategy; an Anthropic/OpenAI/Google/xAI cross-check; or a consensus handoff from several frontier models.
+description: Convene a multi-model advisory board where subscription-backed Claude, Codex, Gemini, and Grok CLIs review the same material in one of three modes — Formal Board Review (independent first round, rebuttal, structured verdict), Roundtable (collaborative judgment and synthesis), or Competitive (rival proposals, critique, and voting) — opening with a mandatory guided intake that settles mode, seats, lenses, and effort with the user before anything runs. Use when the user asks for an advisory board, round table, panel, or idea tournament; a multi-model or multi-provider review; a skilled debate among models; an adversarial review or red-team of a plan, design, architecture, skill, document, decision, or strategy; an Anthropic/OpenAI/Google/xAI cross-check; or a consensus handoff from several frontier models.
 ---
 
 # Advisory Board
 
-Bring an idea, problem, plan, or architecture to a board of frontier models sitting in different roles. Each reviews it independently, then they read and challenge each other across one or more rounds, and you leave with the strongest conclusion the board can reach together and a clean takeaway — not three disconnected opinions.
+Bring an idea, problem, plan, or architecture to a board of frontier models sitting in different roles. The board runs in one of three **modes** — the interaction topology chosen with the user at intake (`references/modes.md`): **Formal Board Review** (the default: independent first round, rebuttal, structured verdict — the protocol this document defines), **Roundtable** (collaborative, shared transcript, optional moderator), or **Competitive** (pitch → critique → blind vote). Whatever the mode, you leave with the strongest conclusion the board can reach together and a clean takeaway — not disconnected opinions.
 
 ## Must Not
 
@@ -17,6 +17,7 @@ Hard rules, collected here so they are never missed (each is elaborated in conte
 - **Never skip the data-handling disclosure** for non-public material — not even when the user says "use defaults." Disclose what leaves the machine and to whom, and get a go-ahead, before any external seat runs (`references/data-handling.md`).
 - **Never present a degraded or dropped seat as a full board** — label it on the seat card and in `verdict.json` (`dropped: true`); a board needs at least two seats that actually ran.
 - **Never print or store secrets** — keys, tokens, cookies, or private environment values — in prompts, packets, artifacts, logs, or metadata.
+- **Never launch a run the user hasn't confirmed.** The guided intake (`references/intake-interview.md`) is mandatory: mode, seats, lenses, effort, rounds, and output are the user's choices, made on the record. "Use defaults" collapses the intake to a single confirm-summary card — never to zero questions.
 
 ## Core Defaults
 
@@ -27,30 +28,33 @@ Hard rules, collected here so they are never missed (each is elaborated in conte
 - Writing artifacts into the reviewed project is itself a write, even on a read-only review: do that only when the user asks or agrees, prefer a dedicated `advisory-board/<timestamp>/` (or `docs/advisory-board/<timestamp>/`) folder, and never write into a tracked git tree without naming the location first.
 - One flag sets the whole cost/depth posture: **`--tier quick|standard|deep`**. `quick` — 1 round, `summaries` cross-reading, reduced per-seat reasoning (claude `high`, codex/grok `medium`; model selectors never change, and seats without an effort knob are untouched). `standard` — today's defaults, a deliberate no-op. `deep` — 3 rounds, `full` cross-reading at the registry's max-tier reasoning (codex stays at `xhigh`; grok stays `high`). The tier is a **base**: explicit flags (`--rounds`, `--cross-reading`) always override it, and `run-recipe.yaml` records the resolved selectors and effort values. Provider-maintained aliases/defaults deliberately re-resolve on a later run; `--model seat=id` is the exact-pin escape hatch. Four frontier models at high reasoning across several rounds can take minutes and meaningful tokens — flag a large run before launching it; `run_board.py run … --dry-run` prints a best-effort estimate. After the run, `run-metadata.md` records what each seat CLI actually reported, where known.
 
-## Upfront Choices
+## Modes
 
-Optionally open with the intake interview (`references/intake-interview.md`) — a short structured Q&A, using the `grilling` or `grill-with-docs` skills as the engine when available — to settle the run. Otherwise ask only for whatever the user hasn't already given:
+The three topologies, their mechanics, hand-runnable protocols for the two the conductor doesn't drive yet, and the intent→mode recommendation table live in `references/modes.md`. In brief: **Formal Board Review** is this document's Round Protocol and everything the conductor, verdict chain, and gate support — the default. **Roundtable** and **Competitive** run by hand via the portable fallback, produce their own artifact sets, and never feed `verdict.json` or a gate. The mode is settled at intake, with the user.
 
-1. Source material: file(s), repo, URL, or goal to review.
-2. Rounds: `1`, `2`, `3`, or `auto` (default `2`; `auto` adapts — see Round Protocol).
-3. Cross-reading: `none`, `summaries`, or `full` (default `summaries`).
-4. Output: `quick verdict`, `full handoff`, or `implementation sequence` (default `full handoff`).
-5. Lens preset: the seat lineup's focus, from `references/lens-presets.md` (default: inferred from the material, falling back to `software-architecture`).
-6. Sensitivity: can the material go to external providers? (`references/data-handling.md` — may force a local-only board.)
-7. Board: seats and size, from `references/board-composition.md` (default: four seats — Claude, Codex, Gemini, Grok).
+## Guided Intake (mandatory)
 
-If the user says "use defaults", stop asking the *optional* setup questions and run with the defaults — with one exception. The data-handling check (choice 6) is mandatory: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`). "Use defaults" settles the optional choices; it never waives that consent.
+Every run opens with the wizard in `references/intake-interview.md` — presented as selection cards like the `grilling` skill's rounds, recommendation first. The sequence, in order:
+
+1. **Doctor first** — probe every registered seat (`run_board.py doctor`); report per-seat GO/NO-GO in plain terms; for each broken seat offer fix-now (installs/updates only with an explicit yes; auth is always the user's hands), continue-without, or abort. Never offer a seat you haven't confirmed.
+2. **Goal → mode** — hear the goal in the user's words, recommend a mode (and lens preset) from `references/modes.md` §Choosing a mode, and let the user pick from all three.
+3. **Seats** — any 2–10 of the GO providers ("latest frontier of each" is the shortcut); show the seat→provider→lens table before launch; warn on cost for big or deep boards.
+4. **Reasoning depth** — Highest available (default) / Standard / Quick via `--tier`; per-seat overrides on request.
+5. **Rounds and output** — with defaults marked.
+6. **Confirm-summary** — the resolved plan as one card; nothing launches without this yes.
+
+"Use defaults" jumps straight to step 6 with everything resolved to defaults — it never skips the confirmation, and it never waives data-handling consent: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`).
 
 ## Model Lineup
 
 Target the strongest reasoning model each provider offers **at run time**. Defaults use provider-maintained selectors so new frontier releases do not require a skill edit; explicit `--model seat=id` overrides pin exact IDs.
 
-- Claude seat: Anthropic's maintained `opus` alias (latest Opus) at `--effort max`.
+- Claude seat: Anthropic's maintained `fable` alias (Fable 5 — the Mythos-class tier above Opus, the strongest generally available Anthropic model) at `--effort max`. Where `fable` doesn't resolve (older CLI or account), preflight proposes the `opus` fallback — never applies it silently.
 - Codex seat: the Codex CLI's recommended model (no exact model pin) with `model_reasoning_effort="xhigh"`.
 - Gemini seat: Google's maintained `pro` alias (latest highest-reasoning Pro model) with the CLI's highest available thinking level.
 - Grok seat: `grok-4.5` through the official `grok` CLI at `--effort high`, the highest Grok 4.5 level. xAI retired the `grok-build` alias; `grok models` lists `grok-4.5` alone (verified on CLI 0.2.117, 2026-08-05).
 
-The selector (`opus`, `pro`, `grok-4.5`, or Codex `auto`) and the model that actually answered are separate provenance fields. If a CLI cannot report the resolved ID, record `unknown` rather than pretending. Use an exact `--model` override for an eval or replay that must not float.
+The selector (`fable`, `pro`, `grok-4.5`, or Codex `auto`) and the model that actually answered are separate provenance fields. If a CLI cannot report the resolved ID, record `unknown` rather than pretending. Use an exact `--model` override for an eval or replay that must not float.
 
 Preflight — run `references/preflight.md` before launching: for each seat, check the CLI is present, auth is active (subscription-backed where possible), the requested model resolves, and a one-token smoke ping returns. Proceed only with at least two seats GO; label any degraded or dropped seat in the handoff. In summary:
 
@@ -65,7 +69,7 @@ Preflight — run `references/preflight.md` before launching: for each seat, che
 
 ## Seats
 
-Give each seat a distinct lens so the board covers more ground than any single reviewer, and match the lenses to the subject. Pick a ready-made lens set from `references/lens-presets.md` — `software-architecture` (default), `product-strategy`, `research-paper`, `legal-contract`, `business-decision`, `writing-editing`, `stakeholder-panel` (convene "the room this decision would face") — or compose your own. For software and technical work, the default split:
+Give each seat its own angle so the board covers more ground than any single reviewer, and match the lenses to the subject. Pick a ready-made lens set from `references/lens-presets.md` — `software-architecture` (default), `product-strategy`, `research-paper`, `legal-contract`, `business-decision`, `writing-editing`, `red-team` (every seat hostile — the stress-test preset), `stakeholder-panel` (convene "the room this decision would face") — or compose your own. The same lens on two different providers is a valid cross-model pairing; only same-provider-same-lens wastes a seat. For software and technical work, the default split:
 
 - Claude: architecture, systems, and adversarial design review.
 - Codex: repo-grounded implementation, migration, testing, and execution.
@@ -76,7 +80,7 @@ For non-software subjects (strategy, research, writing, business, policy), assig
 
 Every seat still answers the full brief; the lens reduces blind spots, it doesn't narrow responsibility.
 
-The board defaults to four seats but isn't fixed at four — for sizing (2–5), the same provider in multiple seats (`--board claude,claude,codex` auto-numbers, or `--board econ=claude,risk=claude` aliases — each seat takes its own lens via a repeated `--lens id=…`), a human or local-model seat, an **Antigravity** seat, and minimal "works with what you have" lineups, see `references/board-composition.md`.
+The board defaults to four seats but isn't fixed at four — for sizing (2–10), the same provider in multiple seats (`--board claude,claude,codex` auto-numbers, or `--board econ=claude,risk=claude` aliases — each seat takes its own lens via a repeated `--lens id=…`), a human or local-model seat, an **Antigravity** seat, and minimal "works with what you have" lineups, see `references/board-composition.md`.
 
 ## Data Handling
 
@@ -93,6 +97,8 @@ In **gate mode** (`--repo` on a gate-bearing run), the safety policy is **read X
 **Caveat — what "verified against the repo" does and doesn't mean (§9).** A `verified` stamp means the **receipt resolves** — the cited `path:line` exists and the quoted text is there — **not** that the inference drawn from it is sound. The gate catches fabrication, not grounded-but-wrong reasoning. Two limits follow and must be stated honestly: (1) a **poisoned repo** can make a wrong claim cite a real line, so `verified` on an attacker-controlled tree is not trust; and (2) because the snapshot is **cleaned up after the run**, later re-verification points `--source` at the **live repo**, so a citation that was real at approval can refute later if the tree drifted — `verified` is a statement about the snapshot at approval time, not a standing guarantee. This system also does **not** physically confine a seat's reads to the snapshot — codex's read-only sandbox can read files outside its working directory (R9) — so the snapshot bounds what is **consented to / hashed / verified against**, not what a seat can read; exfil is blocked by D4's network isolation, not by read-confinement.
 
 ## Round Protocol
+
+This section defines **Formal Board Review** — the default mode and the only one the conductor drives end-to-end. Roundtable and Competitive replace it with their own phase structures (`references/modes.md`).
 
 **Rubric-first scoring (`--rubric`, optional — v1.15).** Before round 1, the board can agree its own weighted criteria and then score every round against them, so the verdict is backed by a comparable number as well as prose. Two mechanically-checked passes run first:
 
@@ -177,7 +183,7 @@ Prefer read-only modes. Confirm every flag against the installed CLI (`<cli> --h
 Claude seat:
 
 ```
-claude -p "<seat prompt>" --model opus --effort max --permission-mode plan
+claude -p "<seat prompt>" --model fable --effort max --permission-mode plan
 ```
 
 `-p` runs non-interactively; `--permission-mode plan` keeps it read-only. `--effort max` requests the deepest reasoning the installed build exposes. On long analytic prompts, plan mode can make the seat return a plan-style *summary* (and even claim it wrote a file) instead of the full review — so append the `{{CLAUDE_OUTPUT_OVERRIDE}}` block from `references/prompt-templates.md` verbatim to the Claude seat's prompt, and treat a short or plan-shaped artifact as a degraded seat to re-run.

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -15,7 +15,7 @@ Hard rules, collected here so they are never missed (each is elaborated in conte
 - **Never write artifacts into a tracked git tree** without naming the location first; default to the persistent runs root (`~/.advisory-board/runs/<slug>-<date>/`), or a throwaway `/tmp/advisory-board-*` folder with `--ephemeral`.
 - **Never substitute a model silently** — if a requested model is unavailable, use the nearest same-provider frontier model and say so.
 - **Never skip the data-handling disclosure** for non-public material — not even when the user says "use defaults." Disclose what leaves the machine and to whom, and get a go-ahead, before any external seat runs (`references/data-handling.md`).
-- **Never present a degraded or dropped seat as a full board** — label it on the seat card and in `verdict.json` (`dropped: true`); a board needs at least two seats that actually ran.
+- **Never present a degraded or dropped seat as a full board** — label it on the seat card and in `verdict.json` (`dropped: true`) on a Formal Board Review run; Roundtable and Competitive, which emit no `verdict.json`, record it in `run-metadata.md` and name it in `synthesis.md`/`results.md` (`references/modes.md`). A board needs at least two seats that actually ran.
 - **Never print or store secrets** — keys, tokens, cookies, or private environment values — in prompts, packets, artifacts, logs, or metadata.
 - **Never launch a run the user hasn't confirmed.** The guided intake (`references/intake-interview.md`) is mandatory: mode, seats, lenses, effort, rounds, and output are the user's choices, made on the record. "Use defaults" collapses the intake to a single confirm-summary card — never to zero questions.
 

--- a/skills/decide/advisory-board/references/board-composition.md
+++ b/skills/decide/advisory-board/references/board-composition.md
@@ -4,14 +4,14 @@ The default board is four seats — Claude, Codex, Gemini, Grok. That's a defaul
 
 ## Size
 
-- **Minimum: 2 seats.** A board needs at least two independent voices; one model reviewing itself is not a board. Below two GO seats at preflight, stop.
+- **Minimum: 2 seats.** A board needs at least two independent voices; one model reviewing itself is not a board. Below two GO seats at preflight, stop. (A board that *starts* with two or more and loses seats mid-run may finish smaller, labeled — see SKILL.md's degradation rule.)
 - **Default: 4.** One frontier seat each from Anthropic, OpenAI, Google, and xAI.
-- **Up to ~5.** Add seats for high-stakes or broad subjects. Past five, rounds get expensive and the synthesis gets noisy — prefer sharper lenses over more seats.
+- **Maximum: 10.** Add seats for high-stakes or broad subjects — duplicate providers with different lenses, or the same lens across different providers for a cross-model comparison on one axis. Cost scales as seats × rounds at high effort: flag a big board before launching and use `--dry-run` for the estimate. Past the chosen preset's lens count, the intake proposes distinct additional lenses for the user to confirm (`references/intake-interview.md` §Step 3).
 
 ## Composition
 
 - **Any provider in any seat.** Lenses come from `references/lens-presets.md`; assign them to whatever models you have.
-- **Same provider twice is allowed** — e.g. two Claude seats with different lenses (architecture vs. security). Repeat the provider in `--board` (see *Naming & targeting* below). Note it in provenance; two seats on the same model are less independent than two different models.
+- **Same provider twice is allowed** — e.g. two Claude seats with different lenses (architecture vs. security). Repeat the provider in `--board` (see *Naming & targeting* below). Note it in provenance; two seats on the same model are less independent than two different models. The inverse also holds: the same **lens** on two different providers is a valid, often valuable pairing (one axis, cross-model); only same-provider-same-lens is a wasted seat.
 - **A human seat** is valid: capture the person's review as that seat's `round-*/` artifact and let the board read it like any other.
 - **A local/offline seat** is valid and is the lever for sensitive material — see `references/data-handling.md`. The `ollama` seat is registered and runnable: `--board claude,ollama` (or any lineup), with `--model ollama=<model>` to pick a pulled model (`ollama list`). It drives a local model headless (`ollama run <model>`, prompt on stdin), counts as `provider: local` — so it **never egresses** (excluded from the egress manifest and the disclosure) and needs no account. That on-machine-only property is exactly why a local board is the lever for must-not-leave material.
 - **An Antigravity seat** (`--board claude,codex,antigravity`) is registered as Google's agent-first successor to gemini-cli, which was sunset for consumer tiers on 2026-06-18. The `antigravity` seat drives the `agy` CLI headless (`agy -p --model "<display name>" --sandbox`). Two cautions, both reflected in the adapter: pin an **exact** model display name from `agy models` (an unknown name is *silently substituted*, never rejected), and treat it as networked like gemini (an agentic harness whose web/grounding isn't removable). Keep gemini available while your gemini auth still works (enterprise / paid API key); prefer antigravity going forward.
@@ -27,7 +27,7 @@ Each `--board` entry is a bare `provider` or an `alias=provider`. Every seat get
 
 Target a specific seat by its id:
 
-- **Model** — `--model risk=claude-opus-4-7` (or `--model claude#2=…`). A bare provider name still works when that provider appears once.
+- **Model** — `--model risk=claude-fable-5` (or `--model claude#2=…`). A bare provider name still works when that provider appears once.
 - **Lens** — `--lens` is repeatable. A bare token sets the **board** lens (the verdict's vocabulary + the default per-seat focus set); `id=lens` gives one seat its own focus — a free-form string (`--lens risk="Downside & tail risk"`) or a preset name, which uses that preset's primary focus. Seats you don't override keep the positional default, so a same-provider board already gets distinct lenses for free.
 
 A malformed board fails loudly — duplicate aliases, an unknown provider, or an override aimed at a seat that isn't on the board all stop the run with a clear message rather than silently dropping a seat. A run's exact composition (ids, per-seat models and lenses) round-trips through `--from-recipe`.

--- a/skills/decide/advisory-board/references/intake-interview.md
+++ b/skills/decide/advisory-board/references/intake-interview.md
@@ -24,6 +24,8 @@ The stated goal also settles the lens preset recommendation (`references/lens-pr
 
 Offer the GO providers. **"Latest frontier of each"** is the one-tap shortcut; any subset of 2–10 seats is valid (never 1 — one model reviewing alone is not a board).
 
+One GO provider is not a dead end: to reach the two-seat minimum, offer the documented fallbacks — the same provider in multiple seats with different lenses, a local `ollama` seat (never egresses), or a human seat (`references/board-composition.md`).
+
 Before launch, show the full **seat → provider → lens** table:
 
 - Up to the preset's lens count, lenses auto-assign positionally.

--- a/skills/decide/advisory-board/references/intake-interview.md
+++ b/skills/decide/advisory-board/references/intake-interview.md
@@ -1,22 +1,53 @@
-# Intake Interview
+# Guided Intake — the wizard
 
-Instead of running on static defaults, open a board with a short structured interview so the run fits the user's intent and material. This is optional — if the user says "use defaults," skip it and run.
+Every board run opens with this intake. It is **mandatory**: the run's shape — mode, seats, lenses, effort, rounds, output — is chosen by the user on the record, never by the agent on the user's behalf. The one fast path is `use defaults`, which collapses the questions into a single confirm-summary card (step 6); it never skips confirmation, and it never waives data-handling consent.
 
-## Engine
+Present choices the way the `grilling` skill does: choice-shaped questions as selection cards with your recommendation first and marked `(Recommended)`, at most four cards per round; open questions as ❓/➡️ text. Where cards aren't available, ask the same questions as numbered text.
 
-If the `grilling` or `grill-with-docs` skills are available, use one as the interview engine — they're built for exactly this kind of focused, adversarial Q&A. Otherwise run the question flow below directly. Ask only what you can't already infer from the request or the material; don't interrogate.
+## Step 1 — Doctor first
 
-## What to settle
+Run `run_board.py doctor` (or the manual preflight, `references/preflight.md`) before proposing anything. Never offer the user a seat you have not confirmed is GO today.
 
-1. **Source** — what's under review (files, repo @ commit, URL, or a goal)? Is it complete, or is context missing?
-2. **Stakes** — quick gut-check or high-stakes decision? Drives rounds and seat count.
-3. **Sensitivity** — can this material go to external providers? (→ `references/data-handling.md`; may force local-only.)
-4. **Subject & lens preset** — which preset fits (`references/lens-presets.md`), or custom lenses?
-5. **Board** — default four seats, or resize / recompose (`references/board-composition.md`)? What's actually installed?
-6. **Rounds & cross-reading** — `1` / `2` / `3` / `auto`; `none` / `summaries` / `full`.
-7. **Output** — quick verdict, full handoff, implementation sequence; plus any derived format (PR comment, Slack, gate `verdict.json`)?
-8. **Decision owner** — who reads the result, and what would make it actionable for them?
+Report per-seat status in plain terms — `grok: installed but not logged in`, `gemini: CLI missing` — and for each broken seat offer exactly three choices:
 
-## Close
+- **Fix it now** — with the user's yes, run the install/update via `run_board.py toolchain --install/--update`. Authentication is always the user's hands: print the auth command, wait, then re-probe. Never install or update anything without a yes on the card.
+- **Continue without it** — the board proceeds smaller; the missing seat is named in the run plan.
+- **Abort** — stop cleanly.
 
-Play back the resulting run plan in one or two lines — board, rounds, cross-reading, sensitivity handling, output — and confirm before spending tokens. Then run preflight (`references/preflight.md`).
+## Step 2 — Goal, then mode
+
+Ask for the goal in the user's own words (❓ text, not a card), then classify it into an intent and recommend a mode from the table in `references/modes.md` §Choosing a mode. Show the recommendation as a card with the other two modes and their one-liners beside it — the user picks; a goal never silently implies a mode.
+
+The stated goal also settles the lens preset recommendation (`references/lens-presets.md`) and, when it names a repo or code, whether to offer `--repo` grounding.
+
+## Step 3 — Seats
+
+Offer the GO providers. **"Latest frontier of each"** is the one-tap shortcut; any subset of 2–10 seats is valid (never 1 — one model reviewing alone is not a board).
+
+Before launch, show the full **seat → provider → lens** table:
+
+- Up to the preset's lens count, lenses auto-assign positionally.
+- Past that, propose distinct additional lenses (drawn from other presets or composed per `references/lens-presets.md` §Custom lenses) for the user to accept or edit.
+- The same lens on two **different** providers is allowed and often the point — a cross-model comparison on one axis. The same provider carrying the same lens twice is not; make each duplicate-provider seat differ by lens.
+- Warn on cost before a big board: seats × rounds at high effort is the multiplier, and a 10-seat deep run takes serious time and tokens (`--dry-run` estimates).
+
+## Step 4 — Reasoning depth
+
+One card: **Highest available** (the default — Claude `fable` at `max`, Codex `xhigh`, Gemini highest thinking, Grok `high`) / **Standard** / **Quick**, resolved through the `--tier` machinery (`SKILL.md` §Core Defaults). Note that any single seat can be overridden on request — don't table every seat unless asked.
+
+## Step 5 — Rounds and output
+
+Rounds (`1`/`2`/`3`/`auto` — Formal Board Review only; the other modes fix their own phases), cross-reading, and output shape (`quick verdict` / `full handoff` / `implementation sequence`), each with the default marked.
+
+## Step 6 — Confirm-summary, then consent
+
+Play back the fully resolved plan as one card the user approves before anything runs: mode, seats with lenses, effort, rounds, output, and where artifacts land. **Nothing launches without this yes.** `use defaults` jumps straight here with everything resolved to defaults and doctor's findings applied.
+
+Data-handling consent (`references/data-handling.md`) is separate and unwaivable: for non-public material, disclose what leaves the machine and to whom, and get the explicit go-ahead — `use defaults` and the confirm-summary never cover it.
+
+## Done when
+
+- Doctor ran and every offered seat was GO (or the user chose fix/continue/abort per broken seat).
+- The user picked the mode from a recommendation card — the agent never selected it for them.
+- The seat→provider→lens table was shown and confirmed; effort, rounds, and output each got an explicit answer or the confirmed default.
+- The confirm-summary got a yes, and data-handling consent (where required) got its own yes.

--- a/skills/decide/advisory-board/references/lens-presets.md
+++ b/skills/decide/advisory-board/references/lens-presets.md
@@ -4,6 +4,8 @@ A seat's lens is a **role assignment, not a model**. Any provider can sit in any
 
 Every seat still answers the full brief. The lens reduces blind spots; it doesn't narrow responsibility.
 
+Two seats may share a lens **when they sit on different providers** — that's a cross-model comparison on one axis, and often the point of a bigger board. The same provider carrying the same lens twice adds nothing; give each duplicate-provider seat its own lens.
+
 ## How to use
 
 1. Choose the preset closest to the material (default: `software-architecture`), or compose your own lenses.
@@ -50,6 +52,13 @@ Running via `run_board.py`, the board preset is `--lens <preset>` (it sets the v
 - **Clarity & style** — concision, flow, precision, tone for the audience.
 - **Audience & impact** — does it land, what is missing, what a skeptic seizes on.
 - **Adversarial editor** — test the argument against hostile readings and synthesize the strongest revision.
+
+### `red-team`
+Every seat is hostile by assignment — the preset for stress-testing an artifact (a skill, spec, plan, or document) before you stake something on it. Pair with `--repo` when the artifact lives in a codebase so attacks cite `path:line`.
+- **Correctness attacker** — find the input, state, or sequence that makes it wrong; construct the failing case, don't gesture at it.
+- **Ambiguity attacker** — read it the way a reasonable executor would get it wrong: instructions two readers would follow differently, contradictions, undefined edge behavior.
+- **Security & data-handling attacker** — what leaks, what escalates, what a malicious input or poisoned dependency reaches; secrets, PII, and consent paths first.
+- **Unimagined-failure hunter** — the failure class the author's framing excludes: wrong assumptions about the environment, scale, users, or time.
 
 ### `stakeholder-panel`
 "The room this decision would face" — three distinct stakeholder archetypes, one per seat, in a fixed **seat-order binding**:

--- a/skills/decide/advisory-board/references/modes.md
+++ b/skills/decide/advisory-board/references/modes.md
@@ -41,7 +41,7 @@ Everyone sees everything; the value is accumulation, not independence.
 
 Three fixed phases; the output is a ranked field of ideas, not a consensus.
 
-**Minimum three seats.** With two, each voter has exactly one eligible pitch (its own is excluded), so every tally is 1–1 by construction. The intake refuses a two-seat Competitive run and offers a third seat or Formal Board Review instead.
+**Minimum three seats — through the pitch phase.** With two pitches, each voter has exactly one eligible pitch (its own is excluded), so every tally is 1–1 by construction. The intake refuses a two-seat Competitive run and offers a third seat or Formal Board Review instead; and if drops leave fewer than three pitches in the field at the end of the pitch phase, stop and report rather than vote. A seat that drops *after* pitching leaves its pitch votable, so the run continues — its missing critique and vote are stated in `results.md`.
 
 **Mechanics.**
 

--- a/skills/decide/advisory-board/references/modes.md
+++ b/skills/decide/advisory-board/references/modes.md
@@ -33,13 +33,15 @@ Everyone sees everything; the value is accumulation, not independence.
 
 4. After the last round, the moderator (or you) writes the synthesis: where the panel converged, the strongest unresolved disagreement, and the recommendation — labeled as a roundtable synthesis, not a formal verdict.
 
-**Artifacts.** `turn-<round>-<order>-<seat>.md` per contribution, `synthesis.md` at the end, and `run-metadata.md` as always. A roundtable produces no `verdict.json` — it is a conversation record, not a gate input.
+**Artifacts.** `turn-<round>-<order>-<seat>.md` per contribution, `synthesis.md` at the end, and `run-metadata.md` as always. A seat that drops mid-run is recorded in `run-metadata.md` (status: dropped) and named in `synthesis.md` — the smaller panel is never presented as full. A roundtable produces no `verdict.json` — it is a conversation record, not a gate input.
 
 **Honesty rule.** A roundtable's agreement is social by construction — later seats read earlier ones. Never present roundtable convergence as independent corroboration; that property belongs to Formal Board Review round 1 only.
 
 ## Competitive
 
 Three fixed phases; the output is a ranked field of ideas, not a consensus.
+
+**Minimum three seats.** With two, each voter has exactly one eligible pitch (its own is excluded), so every tally is 1–1 by construction. The intake refuses a two-seat Competitive run and offers a third seat or Formal Board Review instead.
 
 **Mechanics.**
 
@@ -49,7 +51,7 @@ Three fixed phases; the output is a ranked field of ideas, not a consensus.
 
 **Run it by hand:** phase 1 prompts carry only the brief + lens; phase 2 prompts carry the brief + all pitches; phase 3 prompts carry the brief, pitches, and critiques — but no votes. Collect votes before revealing any.
 
-**Artifacts.** `pitch-<seat>.md`, `critique-<seat>.md`, `vote-<seat>.md`, and `results.md` (the tally, the winning pitch, and the strongest surviving objections to it). No `verdict.json`.
+**Artifacts.** `pitch-<seat>.md`, `critique-<seat>.md`, `vote-<seat>.md`, and `results.md` (the tally, the winning pitch, and the strongest surviving objections to it). A seat that drops mid-run is recorded in `run-metadata.md` (status: dropped) and named in `results.md` — its pitch stays in the field, its missing votes are stated, never imputed. No `verdict.json`.
 
 **Variant.** Vote on individual *ideas* rather than whole pitches when pitches each contain several separable options; say which variant ran in `results.md`.
 

--- a/skills/decide/advisory-board/references/modes.md
+++ b/skills/decide/advisory-board/references/modes.md
@@ -1,0 +1,68 @@
+# Board Modes
+
+A **mode** is the board's interaction topology — who sees whom, in what order, and how the run ends. It is orthogonal to every other axis: any mode composes with any board size, lens preset, tier, or output shape. The vocabulary is shared with panely.ai, so one set of names covers both products.
+
+| Mode | One-liner | Reach for it when |
+| --- | --- | --- |
+| **Formal Board Review** (default) | Independent first round, rebuttal, and a structured verdict. | The stakes are real and you want positions formed *before* anyone can anchor anyone else — plan reviews, red-teams, go/no-go calls. |
+| **Roundtable** | Collaborative judgment and synthesis. | You want the models building on each other — diagnosis, planning, everyday decisions where cross-pollination beats isolation. |
+| **Competitive** | Rival proposals, critique, and voting. | You want *options*, not a verdict — ideation, naming, alternative designs, "pitch me three ways to do this." |
+
+The guided intake recommends a mode from the user's stated goal (`references/intake-interview.md`) and the user confirms it — a mode is always chosen on the record, never assumed.
+
+## Formal Board Review
+
+The skill's core protocol, defined once in `SKILL.md` §Round Protocol and fully supported by the conductor (`run_board.py`): every seat reviews the source packet blind in round 1, reads the board packet and rebuts in round 2, optionally converges in round 3 while preserving dissent, and a neutral synthesizer writes the handoff with a `ship`/`caution`/`block` verdict. Nothing about it changes by having a name; the name exists so the intake can offer it beside the other two.
+
+## Roundtable
+
+Everyone sees everything; the value is accumulation, not independence.
+
+**Mechanics.** Seats speak in a fixed order, one at a time, for N rounds (default 2). Every seat's prompt carries the full transcript so far — the source packet plus every prior contribution, attributed by seat. An optional **moderator** seat opens the session by framing the agenda (it then leaves the turn order) and closes it by writing the synthesis; without one, the orchestrator synthesizes.
+
+**Run it by hand** (the conductor does not drive this topology yet — run each seat as its own CLI subprocess per `SKILL.md` §CLI Execution Notes):
+
+1. Build the source packet as for any run; data-handling consent applies unchanged.
+2. If a moderator is set, prompt it first: frame the question, name the 2–4 sub-questions the panel should cover, take no position.
+3. Each round, prompt seats in order. Seat prompt skeleton:
+
+   > You are one voice at a roundtable of AI advisors. Role emphasis: {{LENS}}.
+   > The question: {{SOURCE PACKET}}
+   > The conversation so far: {{TRANSCRIPT — every prior turn, attributed}}
+   > Add what is missing: agree or push back on specific prior points by name, bring evidence no one has brought, and advance the group toward an answer. Do not restate what has been said. End with `POSITION: <one sentence>`.
+
+4. After the last round, the moderator (or you) writes the synthesis: where the panel converged, the strongest unresolved disagreement, and the recommendation — labeled as a roundtable synthesis, not a formal verdict.
+
+**Artifacts.** `turn-<round>-<order>-<seat>.md` per contribution, `synthesis.md` at the end, and `run-metadata.md` as always. A roundtable produces no `verdict.json` — it is a conversation record, not a gate input.
+
+**Honesty rule.** A roundtable's agreement is social by construction — later seats read earlier ones. Never present roundtable convergence as independent corroboration; that property belongs to Formal Board Review round 1 only.
+
+## Competitive
+
+Three fixed phases; the output is a ranked field of ideas, not a consensus.
+
+**Mechanics.**
+
+1. **Pitch** — each seat, blind to the others, pitches its strongest proposal for the brief (with its reasoning and the strongest objection it anticipates).
+2. **Critique** — each seat reads all pitches and stress-tests the others *by name*: what breaks, what is derivative, what survives. A seat does not defend its own pitch in this phase.
+3. **Vote** — each seat votes for the best proposal **excluding its own**, with one paragraph of reasoning. Votes are blind: no seat sees another's vote before casting. Tally decides the winner; ties are reported as ties.
+
+**Run it by hand:** phase 1 prompts carry only the brief + lens; phase 2 prompts carry the brief + all pitches; phase 3 prompts carry the brief, pitches, and critiques — but no votes. Collect votes before revealing any.
+
+**Artifacts.** `pitch-<seat>.md`, `critique-<seat>.md`, `vote-<seat>.md`, and `results.md` (the tally, the winning pitch, and the strongest surviving objections to it). No `verdict.json`.
+
+**Variant.** Vote on individual *ideas* rather than whole pitches when pitches each contain several separable options; say which variant ran in `results.md`.
+
+## Choosing a mode
+
+The intake maps the user's goal to a recommendation — always shown as a recommendation the user confirms, never auto-applied:
+
+| Intent (what the user wants) | Recommended mode | Default lens preset |
+| --- | --- | --- |
+| **Decision** — help me decide between real stakes | Formal Board Review | by subject (`business-decision`, `software-architecture`, …) |
+| **Stress-test** — attack this plan / design / draft | Formal Board Review | `red-team` for hostile review, else by subject |
+| **Compare** — weigh these named options against each other | Formal Board Review | by subject |
+| **Ideation** — generate and rank alternatives | Competitive | by subject |
+| **Explore** — think this through with me, no verdict needed | Roundtable | by subject |
+
+When the goal straddles intents, recommend the mode matching the *deliverable* the user described (a verdict → formal; a shortlist → competitive; understanding → roundtable) and say why.

--- a/skills/decide/advisory-board/references/preflight.md
+++ b/skills/decide/advisory-board/references/preflight.md
@@ -31,7 +31,7 @@ A board needs at least two independent voices. Rather than dead-ending, prefligh
 
 So a user who only has one provider (say, only Anthropic) is never stuck: they can run a same-provider multi-lens board or add a local/human seat, and the skill says so instead of just refusing.
 
-**Default selectors float; explicit model IDs stay pinned.** The default board uses provider-maintained selectors (`opus`, `pro`, or the CLI's recommended/default model) so new frontier releases can be adopted without a skill update. An explicit `--model <seat>=<id>` remains an exact pin. If an exact pin no longer resolves, preflight may propose a same-provider fallback; it never silently rewrites the user's pin.
+**Default selectors float; explicit model IDs stay pinned.** The default board uses provider-maintained selectors (`fable`, `pro`, or the CLI's recommended/default model) so new frontier releases can be adopted without a skill update. An explicit `--model <seat>=<id>` remains an exact pin. If an exact pin no longer resolves, preflight may propose a same-provider fallback; it never silently rewrites the user's pin.
 
 ## What to check, per seat
 

--- a/skills/decide/advisory-board/references/run-metadata-template.md
+++ b/skills/decide/advisory-board/references/run-metadata-template.md
@@ -14,7 +14,7 @@ Tier: <only when --tier was given — the tier name plus the base values it set;
 
 | Seat   | Lens          | Model requested | Model that answered | Reasoning/effort | Auth mode    | Status            |
 | ------ | ------------- | --------------- | ------------------- | ---------------- | ------------ | ----------------- |
-| Claude | architecture  | opus            | <id returned>       | max              | subscription | ran               |
+| Claude | architecture  | fable           | <id returned>       | max              | subscription | ran               |
 | Codex  | impl/testing  | auto            | <id returned>       | xhigh            | subscription | ran               |
 | Gemini | product/ops   | pro             | <id returned>       | HIGH             | subscription | dropped @ round 2 |
 | Grok   | challenger    | grok-4.5        | <id returned>       | high             | subscription | ran               |

--- a/skills/decide/advisory-board/scripts/_conductor/constants.py
+++ b/skills/decide/advisory-board/scripts/_conductor/constants.py
@@ -112,7 +112,7 @@ LENS_PRESETS = {
     "red-team": [
         "Correctness attacker — find the input, state, or sequence that makes it wrong; construct the failing case",
         "Ambiguity attacker — instructions two reasonable readers would execute differently, contradictions, undefined edge behavior",
-        "Security & data-handling attacker — what leaks, what escalates, what a malicious input reaches; secrets, PII, and consent paths first",
+        "Security & data-handling attacker — what leaks, what escalates, what a malicious input or poisoned dependency reaches; secrets, PII, and consent paths first",
         "Unimagined-failure hunter — the failure class the author's framing excludes: wrong assumptions about environment, scale, users, or time",
     ],
     # stakeholder-panel (v1.15 P4 / D20): "the room this decision would face" — three

--- a/skills/decide/advisory-board/scripts/_conductor/constants.py
+++ b/skills/decide/advisory-board/scripts/_conductor/constants.py
@@ -106,6 +106,15 @@ LENS_PRESETS = {
         "Audience & impact — does it land, what is missing, what a skeptic seizes on",
         "Adversarial editor — test the argument against hostile readings and synthesize the strongest revision",
     ],
+    # red-team (v1.17): every seat hostile by assignment — the stress-test preset
+    # for artifacts (skills, specs, plans, docs). Pairs with --repo so attacks
+    # cite path:line. Positional like every preset; smaller boards take the prefix.
+    "red-team": [
+        "Correctness attacker — find the input, state, or sequence that makes it wrong; construct the failing case",
+        "Ambiguity attacker — instructions two reasonable readers would execute differently, contradictions, undefined edge behavior",
+        "Security & data-handling attacker — what leaks, what escalates, what a malicious input reaches; secrets, PII, and consent paths first",
+        "Unimagined-failure hunter — the failure class the author's framing excludes: wrong assumptions about environment, scale, users, or time",
+    ],
     # stakeholder-panel (v1.15 P4 / D20): "the room this decision would face" — three
     # DISTINCT stakeholder archetypes, one per seat, in this SEAT-ORDER binding:
     #   seat 1 → the decision owner / executive who must answer for the outcome,

--- a/skills/decide/advisory-board/scripts/_conductor/registry.py
+++ b/skills/decide/advisory-board/scripts/_conductor/registry.py
@@ -532,9 +532,13 @@ def model_not_found(result: "SpawnResult", *, include_stdout: bool = False) -> b
 REGISTRY: dict = {
     "claude": SeatAdapter(
         name="claude",
-        # Anthropic documents `opus` as an alias for the latest Opus model. Use
-        # the maintained alias so a fresh run advances with the provider.
-        default_model="opus",
+        # Anthropic's maintained `fable` alias selects Fable 5, the Mythos-class
+        # tier above Opus — the strongest generally available Anthropic model
+        # (v1.17). `opus` is the ordered fallback preflight PROBES + PROPOSES
+        # (never silently applies) on builds/accounts where `fable` doesn't
+        # resolve. Maintained aliases keep a fresh run advancing with the
+        # provider.
+        default_model="fable",
         provider="Anthropic",
         default_reasoning="max",   # forwarded via --effort; deepest level the CLI exposes
         build_argv=claude_argv,
@@ -553,7 +557,7 @@ REGISTRY: dict = {
         auth_hint="run `claude` once and sign in (Claude subscription, or set ANTHROPIC_API_KEY)",
         pkg_label="npm @anthropic-ai/claude-code",
         flags_verified_version="2.1.191",   # --model/--effort/--permission-mode plan verified here
-        fallback_models=(),
+        fallback_models=("opus",),   # proposed (never silently applied) where `fable` doesn't resolve
     ),
     "codex": SeatAdapter(
         name="codex",

--- a/skills/decide/advisory-board/tests/test_run_board.py
+++ b/skills/decide/advisory-board/tests/test_run_board.py
@@ -115,11 +115,12 @@ class TestRegistry(unittest.TestCase):
                          {"claude", "codex", "gemini", "grok", "antigravity", "ollama"})
 
     def test_claude_seat_model_lineup(self):
-        # `opus` is Anthropic's provider-maintained latest-Opus alias.
+        # `fable` is Anthropic's maintained alias for Fable 5 (Mythos tier,
+        # above Opus); `opus` is the ordered fallback preflight proposes.
         a = rb.REGISTRY["claude"]
-        self.assertEqual(a.default_model, "opus")
+        self.assertEqual(a.default_model, "fable")
         self.assertEqual(a.default_reasoning, "max")
-        self.assertEqual(a.fallback_models, ())
+        self.assertEqual(a.fallback_models, ("opus",))
 
     def test_antigravity_flags(self):
         a = rb.REGISTRY["antigravity"]
@@ -146,13 +147,13 @@ class TestRegistry(unittest.TestCase):
         self.assertNotIn("--bare", argv)  # --bare would break subscription auth
 
     def test_claude_default_model_and_max_effort(self):
-        # The Claude seat runs the latest-Opus alias at max effort.
+        # The Claude seat runs the Fable alias at max effort.
         a = rb.REGISTRY["claude"]
-        self.assertEqual(a.default_model, "opus")
+        self.assertEqual(a.default_model, "fable")
         self.assertEqual(a.default_reasoning, "max")
         argv = a.build_argv(a.default_model, "PROMPT", reasoning=a.default_reasoning, network=False)
         self.assertEqual(argv[argv.index("--effort") + 1], "max")
-        self.assertIn("opus", argv)
+        self.assertIn("fable", argv)
 
     def test_claude_advisory_allows_network(self):
         a = rb.REGISTRY["claude"]
@@ -331,7 +332,7 @@ class TestConfig(EnvMixin):
         c = _config(model=["codex=gpt-5.6"])
         models = {s.name: s.model for s in c.board}
         self.assertEqual(models["codex"], "gpt-5.6")
-        self.assertEqual(models["claude"], "opus")
+        self.assertEqual(models["claude"], "fable")
 
     def test_board_subset(self):
         c = _config(board="claude,gemini")
@@ -862,7 +863,7 @@ class TestRunFlow(EnvMixin):
             raw = fh.read()
         self.assertIn("packet-hash", raw)
         self.assertIn("source-hash", raw)
-        self.assertIn("model-answered  : opus", raw)
+        self.assertIn("model-answered  : fable", raw)
 
     def test_preflight_gates_before_egress(self):
         # Two seats down -> NO-GO -> must stop BEFORE writing any egress manifest,
@@ -2218,7 +2219,7 @@ class TestRound1FanOut(EnvMixin):
         self.assertTrue(all(r.usable for r in results))
         self.assertTrue(all(r.attempts == 1 for r in results))
         answered = {r.seat: r.model_answered for r in results}
-        self.assertEqual(answered["claude"], "opus")
+        self.assertEqual(answered["claude"], "fable")
         self.assertIsNone(answered["codex"])
         self.assertEqual(answered["gemini"], "pro")
 


### PR DESCRIPTION
## What

The grilled advisory-board improvements, every decision the decider's on the record:

- **Modes** (`references/modes.md`) — the interaction topology is now a named, user-chosen axis, vocabulary shared with panely.ai: **Formal Board Review** (the existing Round Protocol, finally named; default and only conductor-driven mode), **Roundtable** (collaborative, shared transcript, optional moderator), **Competitive** (pitch → critique → blind vote). Both new topologies are hand-runnable with prompt skeletons and artifact sets; neither feeds `verdict.json` or a gate. `run_board.py --mode` is a tracked follow-up.
- **Mandatory guided intake** (`references/intake-interview.md`, rewritten) — doctor probes every seat first; broken seats get fix-now (consent-gated installs, auth always the user's hands) / continue-without / abort; the stated goal drives a mode recommendation the user confirms; seats (2–10, 'latest frontier of each' shortcut), effort, rounds, output all chosen on the record. 'Use defaults' collapses to one confirm-summary card, never zero; data-handling consent stays separate and unwaivable. New Must Not line enforces it.
- **`red-team` lens preset** — correctness attacker / ambiguity attacker / security & data-handling attacker / unimagined-failure hunter; pairs with `--repo` for path:line attacks. Mirrored in the conductor's `LENS_PRESETS`.
- **Fable seat** — Claude seat default selector moves `opus` → `fable` (Fable 5, Mythos tier) at `--effort max`, with `opus` as the preflight-proposed (never silent) fallback.
- **Board ceiling 5 → 10** — same lens across different providers is a valid cross-model pairing; same-provider-same-lens is the only wasted seat. Cost warning + intake-proposed extra lenses past a preset's four.

Adversarial code review deliberately did **not** become a mode: the board stays a decision instrument; pre-merge review protocols stay with each repo. The first run of Formal Board Review + red-team + `--repo` will be a retrospective review of the ingest skill.

## Verification

- `python3 -m unittest discover -s tests -t tests` → 1663 OK (3 expectation updates for the fable selector)
- `scripts/check_router_freshness.py` → OK (13 skills)
- `scripts/check_site_disclosure.py` → OK (33 files, 91 terms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Formal Board Review, Roundtable, and Competitive interaction modes.
  - Added a mandatory six-step guided setup with configuration, consent, cost warnings, and launch confirmation.
  - Added the `red-team` lens preset for hostile, security-focused review.
  - Expanded advisory boards to support 2–10 seats.
  - Added cross-provider lens comparisons and improved seat-loss handling.
  - Updated Claude’s default model to `fable`, with `opus` as an automatic fallback.

- **Documentation**
  - Added guidance for modes, lens pairing, costs, model selection, and run configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->