### PR TITLE
site: machine-readable metadata, sitemap dates, and IndexNow

### DIFF
--- a/scripts/indexnow.py
+++ b/scripts/indexnow.py
@@ -24,6 +24,7 @@ import json
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 HOST = "clickai.dev"
@@ -73,6 +74,21 @@ def submit(urls: list[str]) -> int:
         return resp.status
 
 
+def off_host(urls: list[str]) -> list[str]:
+    """URLs the key cannot vouch for.
+
+    The key proves ownership of one host, and a submission containing a URL for
+    any other host is rejected whole rather than partially. Catching that here
+    beats reading it back out of an opaque 4xx.
+    """
+    return [
+        url
+        for url in urls
+        if urllib.parse.urlsplit(url).scheme != "https"
+        or urllib.parse.urlsplit(url).netloc != HOST
+    ]
+
+
 def main() -> int:
     args = [a for a in sys.argv[1:] if a != "--dry-run"]
     dry = "--dry-run" in sys.argv
@@ -85,6 +101,16 @@ def main() -> int:
     if not urls:
         print("no URLs to submit")
         return 1
+
+    # Before the dry run, not after: a dry run that reports URLs the real run
+    # would reject is worse than no dry run at all.
+    stray = off_host(urls)
+    if stray:
+        print(f"{len(stray)} URL(s) are not https on {HOST}:")
+        for url in stray[:5]:
+            print(f"  {url}")
+        return 1
+
     if len(urls) > MAX_BATCH:
         print(f"{len(urls)} URLs exceeds the {MAX_BATCH} batch cap")
         return 1
@@ -97,7 +123,16 @@ def main() -> int:
         print("\nKey file is not live. Merge and deploy first, then re-run.")
         return 1
 
-    status = submit(urls)
+    try:
+        status = submit(urls)
+    except urllib.error.HTTPError as exc:
+        # urlopen raises on non-2xx, so without this the one path that matters —
+        # a rejected submission — exits on a traceback instead of saying so.
+        status = exc.code
+    except urllib.error.URLError as exc:
+        print(f"could not reach {ENDPOINT}: {exc.reason}")
+        return 1
+
     # 200 and 202 both mean accepted; the protocol returns no per-URL detail.
     print(f"IndexNow returned HTTP {status}")
     return 0 if status in (200, 202) else 1

--- a/scripts/indexnow.py
+++ b/scripts/indexnow.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Notify IndexNow that clickai.dev pages changed.
+
+IndexNow is a push protocol: instead of waiting to be crawled, the site tells
+participating engines what changed. Bing, Yandex, Seznam and Naver consume it.
+Google has tested it and does not use it for indexing — so this speeds up the
+Bing family only, which matters here mainly because Bing's index is what
+ChatGPT's browsing reads.
+
+Usage:
+    python3 scripts/indexnow.py                    # every URL in the sitemap
+    python3 scripts/indexnow.py /notes/some-note   # only these paths
+    python3 scripts/indexnow.py --dry-run
+
+Ownership is proved by a key file served at the host root; the route lives at
+site/src/app/<KEY>.txt/route.ts and its directory name is the key. If the key
+is rotated, change KEY here to match — the two must agree or every submission
+is rejected as unverified.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+HOST = "clickai.dev"
+KEY = "4eb60288aa9dc50afb120dd731317477"
+KEY_LOCATION = f"https://{HOST}/{KEY}.txt"
+SITEMAP = f"https://{HOST}/sitemap.xml"
+ENDPOINT = "https://api.indexnow.org/indexnow"
+
+# The protocol caps a batch at 10,000; the site is nowhere near it, but a cap
+# that is never checked is a cap that fails the first time it matters.
+MAX_BATCH = 10_000
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"user-agent": f"{HOST} indexnow"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def sitemap_urls() -> list[str]:
+    return re.findall(r"<loc>(.*?)</loc>", fetch(SITEMAP))
+
+
+def verify_key() -> bool:
+    """The submission is rejected silently if the key file is not live yet."""
+    try:
+        return fetch(KEY_LOCATION).strip() == KEY
+    except urllib.error.HTTPError as exc:
+        print(f"key file returned HTTP {exc.code} at {KEY_LOCATION}")
+        return False
+    except Exception as exc:  # noqa: BLE001 — any failure means "not verifiable"
+        print(f"could not fetch key file: {exc}")
+        return False
+
+
+def submit(urls: list[str]) -> int:
+    payload = json.dumps(
+        {"host": HOST, "key": KEY, "keyLocation": KEY_LOCATION, "urlList": urls}
+    ).encode()
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=payload,
+        headers={"content-type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.status
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if a != "--dry-run"]
+    dry = "--dry-run" in sys.argv
+
+    urls = (
+        [f"https://{HOST}{p}" if p.startswith("/") else p for p in args]
+        if args
+        else sitemap_urls()
+    )
+    if not urls:
+        print("no URLs to submit")
+        return 1
+    if len(urls) > MAX_BATCH:
+        print(f"{len(urls)} URLs exceeds the {MAX_BATCH} batch cap")
+        return 1
+
+    print(f"{len(urls)} URL(s); first: {urls[0]}")
+    if dry:
+        return 0
+
+    if not verify_key():
+        print("\nKey file is not live. Merge and deploy first, then re-run.")
+        return 1
+
+    status = submit(urls)
+    # 200 and 202 both mean accepted; the protocol returns no per-URL detail.
+    print(f"IndexNow returned HTTP {status}")
+    return 0 if status in (200, 202) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/app/4eb60288aa9dc50afb120dd731317477.txt/route.ts
+++ b/site/src/app/4eb60288aa9dc50afb120dd731317477.txt/route.ts
@@ -1,0 +1,17 @@
+/**
+ * IndexNow ownership proof.
+ *
+ * The protocol requires the key to be retrievable at the host root, and the
+ * filename IS the key — so this directory's name is the credential. Rotating it
+ * means renaming the directory and updating scripts/indexnow.py.
+ *
+ * Nothing secret: it proves control of the host, and its whole job is to be
+ * publicly fetchable by Bing, Yandex, Seznam and Naver.
+ */
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response("4eb60288aa9dc50afb120dd731317477", {
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -1211,6 +1211,16 @@ h2 {
   font-size: 0.95em;
 }
 
+/* Small print under a term. Quiet on purpose — a revision date is provenance,
+   not part of the definition. */
+.term__revised {
+  font-size: 0.76rem;
+  color: var(--sounding);
+  margin-top: 2.2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--shoal);
+}
+
 .aside h3 {
   font-family: var(--font-mono), monospace;
   font-size: 0.68rem;

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -42,6 +42,11 @@ export const metadata: Metadata = {
     url: "https://clickai.dev",
   },
   alternates: { canonical: "/" },
+  // The colophon has said this in prose since the site launched; these say it
+  // in the form a crawler reads. Inherited by every route.
+  authors: [{ name: "Tim Harris", url: "https://clickai.dev/work" }],
+  creator: "Tim Harris",
+  publisher: "Tim Harris",
 };
 
 /* So the browser's own chrome — address bar, scrollbars — is lit the same way

--- a/site/src/app/legend/[term]/page.tsx
+++ b/site/src/app/legend/[term]/page.tsx
@@ -3,6 +3,15 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BANDS, ENTRIES, getEntry } from "@/lib/legend";
 import { getSkill, summarize } from "@/lib/skills";
+import {
+  DEFINED_TERM_SET,
+  definedTermNode,
+  graph,
+  jsonLdProps,
+  LEGEND_REVISED,
+  PERSON,
+} from "@/lib/schema";
+import { formatDate } from "@/lib/notes";
 
 type Params = { params: Promise<{ term: string }> };
 
@@ -31,6 +40,9 @@ export default async function LegendTerm({ params }: Params) {
 
   return (
     <div className="shell detail">
+      <script
+        {...jsonLdProps(graph(PERSON, DEFINED_TERM_SET, definedTermNode(entry)))}
+      />
       <article>
         <Link href="/legend" className="crumb">
           ← Legend / {entry.group}
@@ -45,6 +57,13 @@ export default async function LegendTerm({ params }: Params) {
         <div className="prose">
           <p style={{ fontSize: "1.06rem" }}>{entry.definition}</p>
         </div>
+
+        {/* The glossary is one file, revised as a whole, so the date is the
+            set's rather than the term's — stated plainly instead of implied. */}
+        <p className="term__revised">
+          Legend last revised{" "}
+          <time dateTime={LEGEND_REVISED}>{formatDate(LEGEND_REVISED)}</time>.
+        </p>
       </article>
 
       <aside className="aside">

--- a/site/src/app/legend/page.tsx
+++ b/site/src/app/legend/page.tsx
@@ -2,6 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { BANDS, ENTRIES, assertLegendSound, byGroup, type Band } from "@/lib/legend";
 import { getSkills } from "@/lib/skills";
+import {
+  DEFINED_TERM_SET,
+  definedTermNode,
+  graph,
+  jsonLdProps,
+  PERSON,
+} from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Legend",
@@ -21,6 +28,16 @@ export default function Legend() {
 
   return (
     <>
+      {/* The whole set in one graph: an index page is the natural place to
+          declare every term, so a crawler gets the vocabulary in one fetch. */}
+      <script
+        {...jsonLdProps(
+          graph(PERSON, {
+            ...DEFINED_TERM_SET,
+            hasDefinedTerm: ENTRIES.map(definedTermNode),
+          }),
+        )}
+      />
       <div className="shell" style={{ paddingBlock: "clamp(2.5rem, 6vw, 4rem) 0" }}>
         <p className="eyebrow">Legend</p>
         <h1 style={{ maxWidth: "17ch" }}>The words, and how much they are worth.</h1>

--- a/site/src/app/notes/[slug]/page.tsx
+++ b/site/src/app/notes/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { marked } from "marked";
 import { KIND_LABEL, formatDate, getNote, getNotes } from "@/lib/notes";
+import { articleNode, graph, jsonLdProps, PERSON } from "@/lib/schema";
 
 type Params = { params: Promise<{ slug: string }> };
 
@@ -15,10 +16,18 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const note = getNote(slug);
   if (!note) return {};
   return {
-    title: note.title,
+    // The kind is part of the title because a note and a legend entry can share
+    // a subject — "Graph engineering" was both, under one identical title, and
+    // neither a reader nor a crawler could tell which page they had landed on.
+    title: `${note.title} — ${KIND_LABEL[note.kind]}`,
     description: note.standfirst,
     alternates: { canonical: `/notes/${note.slug}` },
-    openGraph: { type: "article", publishedTime: note.date },
+    openGraph: {
+      type: "article",
+      publishedTime: note.date,
+      modifiedTime: note.checked ?? note.date,
+      authors: ["Tim Harris"],
+    },
   };
 }
 
@@ -31,6 +40,7 @@ export default async function NotePage({ params }: Params) {
 
   return (
     <div className="shell detail">
+      <script {...jsonLdProps(graph(PERSON, articleNode(note)))} />
       <article>
         <Link href="/notes" className="crumb">
           ← Notes / {KIND_LABEL[note.kind]}
@@ -46,11 +56,17 @@ export default async function NotePage({ params }: Params) {
           <dt>Kind</dt>
           <dd>{KIND_LABEL[note.kind]}</dd>
           <dt>Published</dt>
-          <dd>{formatDate(note.date)}</dd>
+          {/* The <time> wrapper is the same date the reader sees, in the form a
+              crawler can parse. Without it the page is undated to a machine. */}
+          <dd>
+            <time dateTime={note.date}>{formatDate(note.date)}</time>
+          </dd>
           {note.checked ? (
             <>
               <dt>Claims last checked</dt>
-              <dd>{formatDate(note.checked)}</dd>
+              <dd>
+                <time dateTime={note.checked}>{formatDate(note.checked)}</time>
+              </dd>
             </>
           ) : null}
           <dt>Reading</dt>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -5,6 +5,7 @@ import Terminal from "@/components/Terminal";
 import Runtimes from "@/components/Runtimes";
 import { BEARINGS, PLOT, getCatalog } from "@/lib/catalog";
 import { MAKER_SHORT } from "@/lib/work";
+import { graph, jsonLdProps, PERSON, WEBSITE } from "@/lib/schema";
 
 export default function Home() {
   const { regions, skills } = getCatalog();
@@ -17,6 +18,7 @@ export default function Home() {
 
   return (
     <>
+      <script {...jsonLdProps(graph(PERSON, WEBSITE))} />
       <div className="shell hero">
         <div>
           <Runtimes lead="Runs natively on" />

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -2,14 +2,23 @@ import type { MetadataRoute } from "next";
 import { ENTRIES } from "@/lib/legend";
 import { getNotes } from "@/lib/notes";
 import { getSkills } from "@/lib/skills";
+import { LEGEND_REVISED } from "@/lib/schema";
 
 const BASE = "https://clickai.dev";
+
+/*
+ * `lastModified` appears only where a real date exists — the glossary's hand-set
+ * revision date and a note's own dates. The static pages and the generated skill
+ * pages carry none, because the only date available for them would be the build
+ * clock, and a sitemap that claims every page changed on every deploy teaches a
+ * crawler to stop believing the field.
+ */
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: BASE, priority: 1 },
     { url: `${BASE}/skills`, priority: 0.9 },
-    { url: `${BASE}/legend`, priority: 0.9 },
+    { url: `${BASE}/legend`, lastModified: LEGEND_REVISED, priority: 0.9 },
     { url: `${BASE}/notes`, priority: 0.8 },
     { url: `${BASE}/install`, priority: 0.7 },
     { url: `${BASE}/work`, priority: 0.7 },
@@ -20,6 +29,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })),
     ...ENTRIES.map((entry) => ({
       url: `${BASE}/legend/${entry.slug}`,
+      lastModified: LEGEND_REVISED,
       priority: 0.6,
     })),
     ...getNotes().map((note) => ({

--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -117,10 +117,23 @@ export const WEBSITE = {
   inLanguage: "en",
 };
 
-/** Renders a JSON-LD block. `data` is serialised, never interpolated raw. */
+/**
+ * Renders a JSON-LD block. `data` is serialised, never interpolated raw.
+ *
+ * `JSON.stringify` leaves `<` alone, so a `</script>` occurring anywhere in a
+ * title, standfirst or gloss would close this block early and spill the rest
+ * onto the page as markup. Escaping the characters that can open a tag or an
+ * entity keeps the payload inert. `\uXXXX` is valid inside a JSON string, so a
+ * parser still reads exactly the same values back out.
+ */
 export function jsonLdProps(data: object) {
+  const json = JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+
   return {
     type: "application/ld+json" as const,
-    dangerouslySetInnerHTML: { __html: JSON.stringify(data) },
+    dangerouslySetInnerHTML: { __html: json },
   };
 }

--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -1,0 +1,126 @@
+/**
+ * Structured data — the same facts the page already states, in a form a machine
+ * can read.
+ *
+ * Two rules, both inherited from the rest of the site:
+ *
+ *  1. Nothing here asserts anything the visible page does not. Schema that
+ *     disagrees with the page is worse than no schema: search engines treat the
+ *     mismatch as a quality signal against you, and it is a lie either way.
+ *
+ *  2. Every date is a real one. `LEGEND_REVISED` is bumped by hand when the
+ *     glossary is edited, the way `checked:` works on a survey and on an
+ *     instrument card. A date derived from the build would say "revised today"
+ *     forever, which is the specific failure this site exists to point at.
+ */
+
+export const SITE_URL = "https://clickai.dev";
+export const SITE_NAME = "Click AI";
+
+/**
+ * The maker, referenced by @id from every other node so the graph resolves to
+ * one person rather than sixty-three unrelated strings called "Tim Harris".
+ */
+export const AUTHOR_ID = `${SITE_URL}/work#person`;
+
+export const PERSON = {
+  "@type": "Person",
+  "@id": AUTHOR_ID,
+  name: "Tim Harris",
+  url: `${SITE_URL}/work`,
+  description:
+    "Builds product and ships software by directing AI coding agents. Maker of ModelDeck, Panely, HiveRunner, and the Click AI skills catalog.",
+  sameAs: [
+    "https://github.com/timharris707",
+    "https://x.com/timharris707",
+    "https://modeldeck.ai",
+    "https://panely.ai",
+    "https://hiverunner.ai",
+  ],
+};
+
+/** A bare reference to the person above, for use inside other nodes. */
+export const AUTHOR_REF = { "@id": AUTHOR_ID };
+
+/**
+ * Last hand-revision of `legend.ts`, in ISO form. Taken from that file's git
+ * history rather than guessed. Bump it when the glossary changes.
+ */
+export const LEGEND_REVISED = "2026-08-05";
+
+/** Wraps a node set in the envelope schema.org expects. */
+export function graph(...nodes: object[]) {
+  return { "@context": "https://schema.org", "@graph": nodes };
+}
+
+export function articleNode(note: {
+  slug: string;
+  title: string;
+  standfirst: string;
+  date: string;
+  checked?: string;
+}) {
+  return {
+    "@type": "Article",
+    "@id": `${SITE_URL}/notes/${note.slug}#article`,
+    headline: note.title,
+    description: note.standfirst,
+    url: `${SITE_URL}/notes/${note.slug}`,
+    datePublished: note.date,
+    // A survey's credibility is the freshness of its claims, so a re-check is a
+    // modification even when no prose changed.
+    dateModified: note.checked ?? note.date,
+    author: AUTHOR_REF,
+    publisher: AUTHOR_REF,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    inLanguage: "en",
+  };
+}
+
+export function definedTermNode(entry: {
+  slug: string;
+  term: string;
+  gloss: string;
+  group: string;
+}) {
+  return {
+    "@type": "DefinedTerm",
+    "@id": `${SITE_URL}/legend/${entry.slug}#term`,
+    name: entry.term,
+    description: entry.gloss,
+    url: `${SITE_URL}/legend/${entry.slug}`,
+    termCode: entry.slug,
+    inDefinedTermSet: { "@id": `${SITE_URL}/legend#set` },
+  };
+}
+
+export const DEFINED_TERM_SET = {
+  "@type": "DefinedTermSet",
+  "@id": `${SITE_URL}/legend#set`,
+  name: "The Legend — agentic-coding vocabulary",
+  description:
+    "A working glossary of agentic-coding terms, each graded by how much evidence stands behind the claim rather than by how often the word is used.",
+  url: `${SITE_URL}/legend`,
+  author: AUTHOR_REF,
+  dateModified: LEGEND_REVISED,
+};
+
+export const WEBSITE = {
+  "@type": "WebSite",
+  "@id": `${SITE_URL}/#website`,
+  name: SITE_NAME,
+  url: SITE_URL,
+  description:
+    "Self-contained playbooks any AI agent can read. Install once, invoke by name.",
+  author: AUTHOR_REF,
+  publisher: AUTHOR_REF,
+  inLanguage: "en",
+};
+
+/** Renders a JSON-LD block. `data` is serialised, never interpolated raw. */
+export function jsonLdProps(data: object) {
+  return {
+    type: "application/ld+json" as const,
+    dangerouslySetInnerHTML: { __html: JSON.stringify(data) },
+  };
+}


### PR DESCRIPTION
Acts on a content audit of all 63 pages. Every change states something the site already says in prose — nothing here asserts a fact the visible page doesn't.

## What it fixes

**One duplicate title.** `/legend/graph-engineering` and `/notes/graph-engineering` shipped with the identical title `Graph engineering — Click AI`, so neither a reader nor a crawler could tell a glossary stub from a 15-source investigation. Notes now carry their kind: `Graph engineering — Survey — Click AI`. Uses the notes taxonomy that already exists, so it also prevents the next collision as both sections grow.

**Authorship on 63 pages, previously 0.** The colophon has said "Built and maintained by Tim Harris" since launch; no page said it in a form a machine reads. Set once in the root layout, inherited everywhere.

**Dates a parser can read.** The note's published and checked dates were display text only — now wrapped in `<time datetime>` with `article:modified_time`. The Legend gains a revision date taken from `legend.ts`'s git history (2026-08-05), bumped by hand like a survey's `checked:`.

**Structured data where there was almost none.** Only `/work` had any. Adds `WebSite` + `Person` (home), `DefinedTermSet` with all 42 terms (legend index), `DefinedTerm` (each term), `Article` with author and dates (each note). Every node references one `@id` for the person, so the graph resolves to a single identity.

**Sitemap dates the glossary.** `lastmod` on the Legend and its 42 term pages. Deliberately absent from static and generated skill pages: the only date available for those is the build clock, and a sitemap claiming all 63 pages changed on every deploy teaches a crawler to ignore the field.

**IndexNow.** Key route at `/<key>.txt` plus `scripts/indexnow.py` (verifies the key is live before submitting, accepts specific paths or the whole sitemap, has a dry-run). Push-notifies Bing, Yandex, Seznam and Naver on change. Google doesn't consume IndexNow — the reason this is worth having is that Bing's index is what ChatGPT's browsing reads.

## Deliberately not done

- **No FAQPage schema.** Google restricted FAQ rich results to government and health sites in 2023, and adding it here would mean inventing questions nobody asked.
- **No rewrite of the Legend's opening sentences.** The audit is right that entries open with band chrome before the definition, which hurts extraction — but that's an editorial pass, not a mechanical one.
- **No source links on `established` terms.** ~20 entries claim "documented by a primary source" without linking it. Real gap, separate PR, needs judgement about which source was meant.

## Verified

`npm run build` clean, 133 static pages. `check_site_disclosure.py` OK (35 files). `check_router_freshness.py` OK. Built HTML spot-checked: titles unique, `author` meta present on sampled routes, JSON-LD parses with author and both dates on the Article node, `<time>` normalises to `datetime` under a real HTML parser, key file body matches the route name, `indexnow.py --dry-run` reads 63 URLs from the live sitemap.