### PR TITLE
site: daylight is the default lamp

### DIFF
--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -12,8 +12,13 @@
    * Day and night are the same drawing under a different lamp, so every token
    * carries both values in one place — `light-dark()` keeps the palette a
    * single readable table instead of two that drift apart.
+   *
+   * `light` alone, not `light dark`: a chart is drawn to be read in daylight,
+   * so daylight is what a first-time visitor gets regardless of how their
+   * operating system is set. Night is a choice the reader makes with the lamp,
+   * and `[data-theme="dark"]` below is what honours it.
    */
-  color-scheme: light dark;
+  color-scheme: light;
 
   --paper: light-dark(#edf1f1, #0a1c22);      /* chart ground — cool, not cream */
   --beacon: light-dark(#f7f9f9, #0f262d);     /* raised surfaces */
@@ -298,15 +303,10 @@ pre {
   display: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .lamp__day {
-    display: none;
-  }
-
-  :root:not([data-theme="light"]) .lamp__night {
-    display: block;
-  }
-}
+/* No `prefers-color-scheme` rule here any more. The operating system no longer
+   decides which lamp is lit, so a glyph chosen from it would contradict the
+   page — a dark-OS reader on the daylight chart would be offered the moon they
+   are already looking at. Only an explicit pin flips the glyph now. */
 
 :root[data-theme="dark"] .lamp__day {
   display: none;

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -45,12 +45,11 @@ export const metadata: Metadata = {
 };
 
 /* So the browser's own chrome — address bar, scrollbars — is lit the same way
-   as the page it frames. */
+   as the page it frames. One value, not a media pair: the page itself no longer
+   follows the operating system, so chrome that did would disagree with it. The
+   pre-paint script and the lamp correct this when night is pinned. */
 export const viewport: Viewport = {
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#edf1f1" },
-    { media: "(prefers-color-scheme: dark)", color: "#0a1c22" },
-  ],
+  themeColor: "#edf1f1",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -67,12 +66,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/*
           Runs before the first paint. A pinned theme has to be on <html> in
           the opening frame; resolved any later and the page visibly flashes
-          the other lamp. Unset means the operating system decides, which CSS
-          already handles on its own.
+          the other lamp. Unset means daylight, which CSS already gives for
+          free — so this only has work to do when a reader has chosen night,
+          and it moves the browser chrome to match in the same frame.
         */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var t=localStorage.getItem("theme");if(t==="light"||t==="dark")document.documentElement.dataset.theme=t}catch(e){}`,
+            __html: `try{var t=localStorage.getItem("theme");if(t==="light"||t==="dark"){document.documentElement.dataset.theme=t;if(t==="dark"){var m=document.querySelector('meta[name="theme-color"]');if(m)m.setAttribute("content","#0a1c22")}}}catch(e){}`,
           }}
         />
 

--- a/site/src/components/ThemeToggle.tsx
+++ b/site/src/components/ThemeToggle.tsx
@@ -12,13 +12,16 @@
 export default function ThemeToggle() {
   function toggle() {
     const root = document.documentElement;
-    const pinned = root.dataset.theme;
-    const lit =
-      pinned === "dark" ||
-      (pinned !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-    const next = lit ? "light" : "dark";
+    // Unset means daylight now, so the operating system is no longer consulted:
+    // only an explicit pin can mean dark, which makes this a plain flip.
+    const next = root.dataset.theme === "dark" ? "light" : "dark";
 
     root.dataset.theme = next;
+    // Browser chrome is lit from the same switch. The meta tag ships with the
+    // daylight value, so it only needs correcting when night is chosen.
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", next === "dark" ? "#0a1c22" : "#edf1f1");
     try {
       localStorage.setItem("theme", next);
     } catch {


### PR DESCRIPTION
First-time visitors get the light chart regardless of their OS setting. Night stays one click away and still persists across sessions.

## What changed

- `color-scheme: light dark` → `light` on `:root`. The `light-dark()` token table needs no other edit — `[data-theme="dark"]` already re-resolves the whole palette.
- Dropped the `prefers-color-scheme` rule that picked the lamp glyph. With the OS out of the decision, it would have offered a dark-OS reader the moon they were already looking at.
- `ThemeToggle` no longer consults `matchMedia` — unset means daylight, so the toggle is a plain flip.
- `themeColor` is one value instead of a media pair, since chrome that followed the OS would now disagree with the page. The pre-paint script moves it to the night value in the same frame when dark is pinned, so there is no flash of mismatched browser chrome.

## Verified

Build clean. Rendered under `--force-dark-mode` (a dark-OS reader) and the page still comes up light. Disclosure check OK.