### PR TITLE
Auto-release: a version bump on main is the release decision

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,150 @@
+name: auto-release
+
+# Releasing used to be a manual tag push after merge, and it kept getting
+# missed — four unreleased versions were found on 2026-08-07 alone (#115).
+# This workflow makes the version bump itself the release decision: whenever
+# a push to main touches the marketplace manifest (or the workflow is
+# dispatched by hand to reconcile), every plugin whose `<name>/v<version>`
+# tag or release is missing gets an annotated tag cut at that commit (if
+# needed) and a GitHub release published from its changelog section, via the
+# same release-core.yml the manual tag-push path uses.
+#
+# Ordering matters: detect VALIDATES every needed changelog section (via
+# scripts/changelog_section.py, the same code release-core publishes with)
+# before any tag is cut. A bumped version with a missing/empty section fails
+# the run red on main with nothing tagged — so fixing the changelog and
+# re-triggering (dispatch, or the re-run button) retries cleanly instead of
+# leaving an orphaned tag the next scan would skip forever.
+#
+# Tags created here use GITHUB_TOKEN, whose pushes deliberately fire no
+# tag-push workflows (no recursion); that is why the release job calls
+# release-core.yml directly instead of relying on release.yml.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".claude-plugin/marketplace.json"
+  workflow_dispatch:
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    # The branches filter only applies to push; gate dispatches off-main too.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      work: ${{ steps.scan.outputs.work }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Scan marketplace versions against tags and releases
+        id: scan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin
+          gh release list --limit 1000 --json tagName --jq '.[].tagName' > released.txt
+          python3 - <<'PY' > work.json
+          import json
+          import re
+          import subprocess
+          import sys
+
+          plugins = json.load(open(".claude-plugin/marketplace.json"))["plugins"]
+          released = set(open("released.txt").read().split())
+          work = []
+          bad = []
+          for p in plugins:
+              name, version = p["name"], p["version"]
+              # Same shape release-core validates; refuse to tag anything else.
+              if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", name):
+                  raise SystemExit(f"plugin name {name!r} is not tag-safe")
+              if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+                  raise SystemExit(f"plugin {name} version {version!r} is not MAJOR.MINOR.PATCH")
+              tag = f"{name}/v{version}"
+              tag_exists = subprocess.run(
+                  ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+                  capture_output=True,
+              ).returncode == 0
+              if tag_exists and tag in released:
+                  continue
+              # Validate the changelog section NOW, before anything is tagged:
+              # a red run with nothing tagged retries cleanly; a pushed tag
+              # with no publishable notes would be skipped by every future
+              # scan. Same script release-core publishes with.
+              check = subprocess.run(
+                  ["python3", "scripts/changelog_section.py", name, f"v{version}"],
+                  capture_output=True,
+                  text=True,
+              )
+              if check.returncode != 0:
+                  bad.append(check.stderr.strip() or f"{tag}: changelog validation failed")
+                  continue
+              work.append(tag)
+          if bad:
+              for line in bad:
+                  print(f"::error::{line}", file=sys.stderr)
+              raise SystemExit("refusing to tag: fix the changelog section(s) and re-run")
+          print(json.dumps(work))
+          PY
+          echo "work=$(cat work.json)" >> "$GITHUB_OUTPUT"
+          echo "Tags/releases to reconcile: $(cat work.json)"
+
+  tag:
+    needs: detect
+    if: needs.detect.outputs.work != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Cut missing annotated tags at this commit
+        env:
+          WORK: ${{ needs.detect.outputs.work }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --force --tags origin
+          printf '%s' "$WORK" | python3 -c 'import json,sys; print("\n".join(json.load(sys.stdin)))' |
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            # Reconciliation entries (tag exists, release missing) and races
+            # with a concurrent manual push both land here; skip, don't fail.
+            if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "::notice::$tag already exists; leaving it in place"
+              continue
+            fi
+            skill="${tag%/*}"
+            version="${tag##*/}"
+            git tag -a "$tag" -m "$skill $version (auto-release on merge)" "$GITHUB_SHA"
+            git push origin "refs/tags/$tag"
+            echo "::notice::cut $tag at $GITHUB_SHA"
+          done
+
+  release:
+    needs: [detect, tag]
+    if: needs.detect.outputs.work != '[]'
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.detect.outputs.work) }}
+      fail-fast: false
+      max-parallel: 1
+    uses: ./.github/workflows/release-core.yml
+    with:
+      tag: ${{ matrix.tag }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -131,8 +131,21 @@ jobs:
             skill="${tag%/*}"
             version="${tag##*/}"
             git tag -a "$tag" -m "$skill $version (auto-release on merge)" "$GITHUB_SHA"
-            git push origin "refs/tags/$tag"
-            echo "::notice::cut $tag at $GITHUB_SHA"
+            if git push origin "refs/tags/$tag"; then
+              echo "::notice::cut $tag at $GITHUB_SHA"
+              continue
+            fi
+            # A manual push can create the remote tag between our existence
+            # check and this push. Adopt the winner (release-core validates
+            # its annotation and main ancestry); any other push failure is
+            # still fatal.
+            if git fetch --force origin "refs/tags/$tag:refs/tags/$tag" &&
+               git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "::notice::$tag was pushed concurrently; leaving it in place"
+              continue
+            fi
+            echo "::error::failed to push $tag" >&2
+            exit 1
           done
 
   release:

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,127 @@
+name: release-core
+
+# The single implementation of "publish a GitHub release from a skill-scoped
+# version tag". Called from two places:
+#   - release.yml      — a human (or session) pushes <skill>/vX.Y.Z manually
+#   - auto-release.yml — a version bump lands on main and the tag was cut there
+# Tags pushed with GITHUB_TOKEN never fire tag-push workflows, which is why the
+# auto path must call this core directly instead of relying on release.yml.
+#
+# Tag format:  <skill>/vX.Y.Z   e.g.  advisory-board/v0.5.0
+# Release body: that skill's mandatory CHANGELOG.md section for the version,
+#               found at skills/<bucket>/<skill>/CHANGELOG.md or, for a pack,
+#               packs/<pack>/CHANGELOG.md — resolved, not hard-coded, so moving
+#               a skill between buckets never breaks its release.
+# A missing or empty section fails the release. See RELEASING.md.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "The skill-scoped version tag to release, e.g. ingest/v1.1.0"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Derive + VALIDATE skill/version from the tag. The tag arrives as a
+      # workflow_call input (safe); downstream steps read these via env, never
+      # via ${{ }} inside a run block, so a crafted tag name can't inject into
+      # the shell.
+      - name: Resolve tag, skill, and version
+        id: meta
+        env:
+          REF_NAME: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="$REF_NAME"
+          skill="${tag%/*}"        # advisory-board/v0.5.0 -> advisory-board
+          version="${tag##*/}"     # advisory-board/v0.5.0 -> v0.5.0
+          if ! printf '%s' "$skill" | grep -Eq '^[a-z0-9][a-z0-9._-]*$'; then
+            echo "::error::tag '$tag' has an unexpected skill segment '$skill'" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::tag '$tag' is not <skill>/vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          # The auto path pushes the tag moments before calling this workflow,
+          # so a fetch-depth:0 checkout may still predate it. Fetch explicitly.
+          git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+          if [ "$(git cat-file -t "$tag")" != "tag" ]; then
+            echo "::error::$tag must be an annotated tag" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$tag^{commit}" origin/main; then
+            echo "::error::$tag does not point to a commit on origin/main" >&2
+            exit 1
+          fi
+          {
+            echo "tag=$tag"
+            echo "skill=$skill"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from the changelog
+        id: notes
+        env:
+          SKILL: ${{ steps.meta.outputs.skill }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Resolution (exactly one changelog, section present exactly once,
+          # non-empty) lives in the shared script — the same code the
+          # auto-release detect job validates with before any tag is cut.
+          python3 scripts/changelog_section.py "$SKILL" "$VERSION" > notes.md
+
+      - name: Publish release from changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          SKILL: ${{ steps.meta.outputs.skill }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          verify_existing_release() {
+            EXPECTED_NAME="$SKILL $VERSION" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          release = json.loads(Path("existing-release.json").read_text())
+          expected_name = os.environ["EXPECTED_NAME"]
+          expected_body = Path("notes.md").read_text()
+          if release.get("name") != expected_name:
+              raise SystemExit(
+                  f"existing release title mismatch: {release.get('name')!r} != {expected_name!r}"
+              )
+          if release.get("body") != expected_body:
+              raise SystemExit("existing release body does not match the changelog section")
+          PY
+          }
+
+          if gh release view "$TAG" --json name,body > existing-release.json 2>/dev/null; then
+            verify_existing_release
+            echo "::notice::release $TAG already exists with the expected title and notes"
+            exit 0
+          fi
+
+          if gh release create "$TAG" \
+              --title "$SKILL $VERSION" \
+              --notes-file notes.md \
+              --verify-tag; then
+            exit 0
+          fi
+
+          # A duplicated tag event can race between the initial existence check
+          # and creation. Accept that race only when the winning release is exact.
+          gh release view "$TAG" --json name,body > existing-release.json
+          verify_existing_release
+          echo "::notice::a concurrent run created $TAG with the expected title and notes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
 name: release
 
-# Publish a GitHub release whenever a skill-scoped version tag is pushed.
-#
-# Tag format:  <skill>/vX.Y.Z   e.g.  advisory-board/v0.5.0
-# Release body: that skill's mandatory CHANGELOG.md section for the version,
-#               found at skills/<bucket>/<skill>/CHANGELOG.md or, for a pack,
-#               packs/<pack>/CHANGELOG.md — resolved, not hard-coded, so moving
-#               a skill between buckets never breaks its release.
-# A missing or empty section fails the release. See RELEASING.md.
+# Publish a GitHub release whenever a skill-scoped version tag is pushed
+# manually. The release logic itself lives in release-core.yml (one place);
+# auto-release.yml calls the same core when a version bump lands on main.
+# See RELEASING.md.
 
 on:
   push:
@@ -23,132 +19,6 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      # Derive + VALIDATE skill/version from the tag. GITHUB_REF_NAME is an env
-      # var (safe); downstream steps read these via env, never via ${{ }} inside a
-      # run block, so a crafted tag name can't inject into the shell.
-      - name: Resolve tag, skill, and version
-        id: meta
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          tag="$REF_NAME"
-          skill="${tag%/*}"        # advisory-board/v0.5.0 -> advisory-board
-          version="${tag##*/}"     # advisory-board/v0.5.0 -> v0.5.0
-          if ! printf '%s' "$skill" | grep -Eq '^[a-z0-9][a-z0-9._-]*$'; then
-            echo "::error::tag '$tag' has an unexpected skill segment '$skill'" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::tag '$tag' is not <skill>/vMAJOR.MINOR.PATCH" >&2
-            exit 1
-          fi
-          if [ "$(git cat-file -t "$tag")" != "tag" ]; then
-            echo "::error::$tag must be an annotated tag" >&2
-            exit 1
-          fi
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$tag^{commit}" origin/main; then
-            echo "::error::$tag does not point to a commit on origin/main" >&2
-            exit 1
-          fi
-          # Skills live in buckets (skills/<bucket>/<skill>/) and packs carry
-          # their changelog at packs/<pack>/. Resolve rather than hard-code, so
-          # moving a skill between buckets never breaks its release. Exactly one
-          # match is required: two would make the release notes ambiguous.
-          found=$(
-            find skills packs -mindepth 1 -maxdepth 2 -type d -name "$skill" \
-              -exec test -f '{}/CHANGELOG.md' \; -print 2>/dev/null | sort
-          )
-          count=$(printf '%s' "$found" | grep -c . || true)
-          if [ "$count" -eq 0 ]; then
-            echo "::error::no CHANGELOG.md found for '$skill' under skills/*/ or packs/" >&2
-            exit 1
-          fi
-          if [ "$count" -gt 1 ]; then
-            echo "::error::'$skill' has more than one CHANGELOG.md: $(printf '%s' "$found" | tr '\n' ' ')" >&2
-            exit 1
-          fi
-          {
-            echo "tag=$tag"
-            echo "skill=$skill"
-            echo "version=$version"
-            echo "changelog=$found/CHANGELOG.md"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Extract release notes from the changelog
-        id: notes
-        env:
-          CHANGELOG: ${{ steps.meta.outputs.changelog }}
-          VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          set -euo pipefail
-          if [ ! -f "$CHANGELOG" ]; then
-            echo "::error::missing changelog: $CHANGELOG" >&2
-            exit 1
-          fi
-          awk -v ver="$VERSION" '
-            { sub(/\r$/, "") }                                # tolerate CRLF
-            {
-              heading = "## [" ver "]"
-              exact = ($0 == heading || index($0, heading " ") == 1)
-            }
-            exact                           { capture = 1; next }
-            capture && /^## \[/            { exit }
-            capture                        { print }
-          ' "$CHANGELOG" > notes.md
-          if ! grep -q '[^[:space:]]' notes.md; then
-            echo "::error::missing or empty '## [$VERSION]' section in $CHANGELOG" >&2
-            exit 1
-          fi
-
-      - name: Publish release from changelog
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.meta.outputs.tag }}
-          SKILL: ${{ steps.meta.outputs.skill }}
-          VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          set -euo pipefail
-          verify_existing_release() {
-            EXPECTED_NAME="$SKILL $VERSION" python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          release = json.loads(Path("existing-release.json").read_text())
-          expected_name = os.environ["EXPECTED_NAME"]
-          expected_body = Path("notes.md").read_text()
-          if release.get("name") != expected_name:
-              raise SystemExit(
-                  f"existing release title mismatch: {release.get('name')!r} != {expected_name!r}"
-              )
-          if release.get("body") != expected_body:
-              raise SystemExit("existing release body does not match the changelog section")
-          PY
-          }
-
-          if gh release view "$TAG" --json name,body > existing-release.json 2>/dev/null; then
-            verify_existing_release
-            echo "::notice::release $TAG already exists with the expected title and notes"
-            exit 0
-          fi
-
-          if gh release create "$TAG" \
-              --title "$SKILL $VERSION" \
-              --notes-file notes.md \
-              --verify-tag; then
-            exit 0
-          fi
-
-          # A duplicated tag event can race between the initial existence check
-          # and creation. Accept that race only when the winning release is exact.
-          gh release view "$TAG" --json name,body > existing-release.json
-          verify_existing_release
-          echo "::notice::a concurrent run created $TAG with the expected title and notes"
+    uses: ./.github/workflows/release-core.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,21 @@
 # Releasing
 
 This repo ships its skills as **GitHub releases** cut from **skill-scoped, annotated git tags**.
-Pushing a version tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
-which publishes the release automatically — you never run `gh release create` by hand.
+
+**The normal path is automatic.** When a PR that bumps a plugin `version` in
+[`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) merges to `main`,
+[`.github/workflows/auto-release.yml`](.github/workflows/auto-release.yml) cuts the missing
+`<name>/vX.Y.Z` annotated tag at the merge commit and publishes the release from the changelog
+section — the version bump in the reviewed PR *is* the release decision. Changelog sections are
+validated **before** anything is tagged: a bumped version with a missing/empty section fails the
+run red with nothing tagged, so fixing the changelog and re-triggering retries cleanly. The
+workflow can also be **dispatched by hand** (Actions → auto-release → Run workflow) to reconcile:
+it scans every plugin for a missing tag *or* a missing release and heals both. (This exists
+because the manual tag-after-merge step was missed four times in one day — see #115.)
+
+Pushing a version tag by hand still works and triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml); both paths run the same
+[`release-core.yml`](.github/workflows/release-core.yml). You never run `gh release create` by hand.
 
 ## Conventions
 
@@ -42,7 +55,11 @@ A milestone PR carries its own changelog entry so the release is ready the momen
 
 ## Cutting a release
 
-After the milestone PR has **merged to `main`**:
+**Normally: nothing to do.** Merge the milestone PR with its version bump and changelog section;
+`auto-release` cuts the tag and publishes within a minute or two. Confirm on the **Releases** page.
+
+**Manually** (a retroactive tag on an older commit, or a repo state auto-release can't infer) —
+after the milestone PR has **merged to `main`**:
 
 ```bash
 git fetch origin
@@ -78,7 +95,21 @@ git tag -d advisory-board/v0.5.0                      # remove the local tag
 
 ## Mechanism
 
-[`.github/workflows/release.yml`](.github/workflows/release.yml) runs on any pushed tag matching
-`*/v*.*.*`. It validates the tag shape, requires an annotated tag reachable from `origin/main`,
-reads the mandatory `skills/<skill>/CHANGELOG.md` section, and calls `gh release create` with
-`contents: write` permission (the only scope it needs).
+The release logic lives once, in
+[`.github/workflows/release-core.yml`](.github/workflows/release-core.yml) (`workflow_call`): it
+validates the tag shape, requires an annotated tag reachable from `origin/main`, reads the
+mandatory changelog section, and calls `gh release create` with `contents: write` permission (the
+only scope it needs). Two callers:
+
+- [`release.yml`](.github/workflows/release.yml) — any manually pushed tag matching `*/v*.*.*`.
+- [`auto-release.yml`](.github/workflows/auto-release.yml) — pushes to `main` touching the
+  marketplace manifest, plus manual dispatch (main only): scans every plugin's `version` for a
+  missing tag *or* missing release, validates each needed changelog section via the shared script
+  **before** cutting anything, then cuts missing annotated tags at the current commit and calls
+  the core per tag. Tags it pushes use `GITHUB_TOKEN`, whose pushes fire no tag-push workflows —
+  that is why it calls the core directly (a concurrent manual push of the same tag is safe: the
+  tag job skips existing tags, and the core accepts an existing release only on a byte-exact
+  title/body match). A retroactive tag on an old commit whose changelog lacks the section will
+  fail the core; create that release manually from the current changelog section
+  (`gh release create <tag> --notes-file …`), or delete the tag and let a dispatch re-cut it at
+  current main.

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Resolve a skill's changelog and print one version's release-notes section.
+
+The single implementation shared by the release workflows: auto-release's
+detect job validates sections with it BEFORE any tag is cut, and
+release-core extracts the release body with it. One copy, so what detect
+approves is exactly what the release publishes — two drifting copies would
+re-create the tag-first-validate-later wedge this exists to prevent (#115).
+
+Usage: changelog_section.py <skill> <vX.Y.Z>
+
+Rules (each violation exits non-zero with one line on stderr):
+  - exactly one changelog dir may match: skills/<bucket>/<skill>/CHANGELOG.md
+    or packs/<skill>/CHANGELOG.md — zero or two+ both fail rather than guess
+  - the "## [vX.Y.Z]" heading must appear exactly once — a duplicated heading
+    would silently merge or truncate sections, so it fails instead
+  - the section body must be non-empty
+
+Prints the section body to stdout on success. Standard library only.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def die(msg: str) -> None:
+    print(f"changelog_section: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        die("usage: changelog_section.py <skill> <vX.Y.Z>")
+    skill, version = sys.argv[1], sys.argv[2]
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", skill):
+        die(f"unexpected skill segment {skill!r}")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", version):
+        die(f"version {version!r} is not vMAJOR.MINOR.PATCH")
+
+    root = Path(__file__).resolve().parent.parent
+    candidates = sorted(
+        p
+        for pattern in (f"skills/*/{skill}/CHANGELOG.md", f"packs/{skill}/CHANGELOG.md")
+        for p in root.glob(pattern)
+    )
+    if not candidates:
+        die(f"no CHANGELOG.md found for '{skill}' under skills/*/ or packs/")
+    if len(candidates) > 1:
+        die(f"'{skill}' has more than one CHANGELOG.md: {[str(p) for p in candidates]}")
+    changelog = candidates[0]
+
+    heading = f"## [{version}]"
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    starts = [
+        i
+        for i, line in enumerate(lines)
+        if line.rstrip("\r") == heading or line.rstrip("\r").startswith(heading + " ")
+    ]
+    if not starts:
+        die(f"missing '## [{version}]' section in {changelog}")
+    if len(starts) > 1:
+        die(f"'## [{version}]' appears {len(starts)} times in {changelog}")
+
+    # Body = every line after the heading up to the next section heading,
+    # kept verbatim (matching the release bodies published to date) so the
+    # already-exists verification in release-core stays byte-exact.
+    body: list[str] = []
+    for line in lines[starts[0] + 1 :]:
+        if line.rstrip("\r").startswith("## ["):
+            break
+        body.append(line.rstrip("\r"))
+    section = "\n".join(body)
+    if not section.strip():
+        die(f"empty '## [{version}]' section in {changelog}")
+    print(section)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — writing-for-agents
+
+All notable changes to the **writing-for-agents** skill. Versioned as a
+standalone plugin (`writing-for-agents/vX.Y.Z`); this file is the source for
+its release notes.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [v1.0.0] - 2026-08-05
+
+### Added
+
+- Initial release: the reference for writing and pruning documents an agent
+  consumes — a SKILL.md, an AGENTS.md or CLAUDE.md, a reference reached by a
+  pointer. Context pointers, the two loads (always-loaded vs reached-for), the
+  information hierarchy, leading words, and the no-op test. Shipped in PR #97
+  as the standard the rest of this catalog is written against.


### PR DESCRIPTION
Closes #115.

## What

Releasing was a manual tag push after merge — missed four times on 2026-08-07 alone. Now the version bump in a reviewed PR *is* the release decision:

- **`release-core.yml`** (new, `workflow_call`) — the single implementation: validate the skill-scoped tag, extract the changelog section, publish. `release.yml` becomes a thin tag-push caller, so manual tags work unchanged.
- **`auto-release.yml`** (new) — on pushes to `main` touching `.claude-plugin/marketplace.json`, plus manual `workflow_dispatch` (main-gated): reconciles every plugin whose tag **or** release is missing. Changelog sections are validated **before** any tag is cut — a bumped version with a missing section is a red run with nothing tagged, never an orphaned tag future scans would silently skip.
- **`scripts/changelog_section.py`** (new) — the shared resolver/extractor both detect and release-core call, so what detect approves is byte-for-byte what gets published (verified byte-exact against the live `ingest/v1.1.0` release body). Fails loudly on zero/duplicate changelogs, duplicate version headings, and empty sections.
- **`writing-for-agents/CHANGELOG.md`** (new) — the one still-unreleased plugin becomes releasable. **Acceptance test: after merge, dispatch auto-release once; it must cut `writing-for-agents/v1.0.0` and publish its release.**
- `RELEASING.md` rewritten around the automatic path.

## Adversarial review (pilot of the new team-workflow skill, run pre-commit)

**Composition:** three isolated finders — correctness, security lens (chosen: CI workflow with tag-push rights), spec axis vs #115 — then an independent skeptic pass on all six findings above NIT. All six CONFIRMED; all fixed in this commit:

| # | Rank | Finding (skeptic-confirmed) | Disposition |
|---|---|---|---|
| 1 | MAJOR | Tag was cut **before** changelog validation — a missing section orphaned the tag and every future scan skipped it ("loud red" only once, then silent) | Fixed: detect validates every needed section via the shared script before the tag job runs |
| 2 | MAJOR→minor | Merging this PR alone released nothing (no marketplace.json change → paths filter never fires); writing-for-agents stayed unreleased with no in-diff path | Fixed: `workflow_dispatch` reconciliation; post-merge dispatch is the acceptance test |
| 3 | MINOR | detect scanned tags, not releases — a tag-without-release from a partial failure was invisible to future runs | Fixed: detect reconciles missing releases too |
| 4 | MINOR | Empty-matrix safety was only transitive through the `tag` job's skip | Fixed: explicit `if` on the `release` job |
| 5 | MINOR | Duplicate version headings were silently merged/truncated by the awk extractor (proven) | Fixed: shared script fails on duplicate headings |
| 6 | MINOR | Workflow-level `contents: write` gave the read-only detect job a write token | Fixed: job-level permissions (detect: read) |

The spec axis also caught a process failure outside the diff: **issue #115 had been filed with an empty body** (a failed `--label` flag aborted the first create; the retry lost the body). Restored on the issue with a note.

**Clean bill (checked and found correct):** no `${{ }}` inside any `run:` block — all context values via `env`; marketplace name/version regex-validated before reaching any shell, `GITHUB_OUTPUT`, or `git` argv; fork/PR surface closed (push-to-main + tag-push + same-repo `workflow_call` only, no `pull_request_target`); actions SHA-pinned consistently; annotated-tag + ancestor-of-main checks retained; idempotent re-runs (tag skip-if-exists, byte-exact existing-release verification); no workflow recursion (GITHUB_TOKEN tag pushes fire no tag-push workflows — the stated reason the auto path calls the core directly); `actionlint` clean per the correctness finder; detect scan run against the real repo returns exactly `["writing-for-agents/v1.0.0"]`.

## Verification (local)

- All three workflow YAMLs parse; detect logic run verbatim against real repo state → `work: ["writing-for-agents/v1.0.0"], bad: []`.
- `changelog_section.py`: correct extraction for writing-for-agents v1.0.0 and ingest v1.1.0 (byte-exact vs the live release body); loud failures proven for missing skill, missing section, duplicate headings.