### PR TITLE
ingest v1.2.0: derived items, hardened cleanup sweep, and the executable lifetime rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,7 +46,7 @@
       "name": "ingest",
       "source": "./",
       "strict": false,
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Turn a video, recording, voice memo, or media URL into an evidence packet — authoritative whisper transcript, timestamped frames, manifest — plus a routing recommendation. Six intents behind a mandatory purpose gate; the pipeline script is resumable and encodes the hard-won gotchas.",
       "license": "MIT",
       "skills": [

--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **ingest** skill. Versioned as a standalone plugin
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [v1.2.0] - 2026-08-07 — Packets that know their work and offer their own cleanup
 
 ### Added
 

--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -32,9 +32,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   follows the v1.1.0 ownership rules: by manifest ledger, ingest-created files
   only, foreign files left in place, unmarked directories refused. SKILL.md's
   Retention paragraph now describes the mechanism as real rather than pending.
-- **25 new tests** (60 total) covering link idempotence and ownership, resolution states
-  (gh mocked — the suite still never touches the network), sweep verdicts,
-  and offer-only ledger deletion.
+- **Adversarial-review hardening of the sweep**, applied before merge: item
+  ids reach a resolution command as data — a quoted positional argument,
+  never spliced into the shell — and `link` refuses ids carrying whitespace,
+  control characters, or shell metacharacters; a partial deletion (foreign
+  files, a failed unlink, a symlink where the ledger recorded a file) keeps
+  the packet's marker and manifest so it stays sweepable instead of orphaned,
+  under its own exit code (5); `--delete` is bounded to the swept `--home`,
+  processes every target, and exits with the worst outcome; resolution-check
+  crashes, hand-edited manifest entries, and one packet's failure degrade to
+  `unknown` instead of aborting the report; `--check-cmd` without `{id}` is
+  refused (a blanket exit 0 would resolve everything); ids are rendered
+  escaped in every report line; and `gh` joined `doctor`'s tool roster.
+- **46 new tests** (81 total) covering link idempotence and ownership,
+  resolution states, sweep verdicts, offer-only ledger deletion, and a
+  regression pin for every review finding — including a real-/bin/sh
+  injection test and a subprocess mock that can RAISE, not just fail
+  politely. The suite still never touches the network.
 
 ## [v1.1.0] - 2026-08-07 — Packets that cannot lie about their source
 

--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -44,7 +44,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `unknown` instead of aborting the report; `--check-cmd` without `{id}` is
   refused (a blanket exit 0 would resolve everything); ids are rendered
   escaped in every report line; and `gh` joined `doctor`'s tool roster.
-- **46 new tests** (81 total) covering link idempotence and ownership,
+- **49 new tests** (84 total) covering link idempotence and ownership,
   resolution states, sweep verdicts, offer-only ledger deletion, and a
   regression pin for every review finding — including a real-/bin/sh
   injection test and a subprocess mock that can RAISE, not just fail

--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -15,8 +15,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optionally trash. Cleanup is only ever *offered*; the decider accepts or
   declines, and deletion stays within the v1.1.0 ownership rules
   (ingest-created files only, adopted directories refused). The manifest
-  derived-items link and the cleanup pass (issue #116 items 2–3) are out of
-  scope pending a grilling.
+  derived-items link and the cleanup sweep that make the offer executable
+  landed separately (below), after the items 2–3 grilling.
+- **Derived-items links and the cleanup sweep** (designed with Tim, 2026-08-08,
+  issue #116 items 2–3): the manifest gains a `derived_items` list, appended
+  at filing time by whoever files tickets from the packet (`ingest.py link
+  --out DIR --item owner/repo#N` — written at creation, never reconstructed),
+  and `ingest.py sweep --home DIR` checks each packet's derived work for
+  resolution and *offers* deletion of fully-resolved packets, as the closing
+  step of any run and on demand. Resolution is GitHub-first (`gh`: issue/PR
+  closed); other trackers resolve via the binding doc's resolution-check
+  command (`--check-cmd`, exit 0 resolved / 1 open); with no binding the sweep
+  lists the packet for the decider instead of guessing, and a packet with no
+  recorded derived items is never treated as resolved. Deletion happens only
+  when the decider takes the offer (`--delete`), re-checks resolution, and
+  follows the v1.1.0 ownership rules: by manifest ledger, ingest-created files
+  only, foreign files left in place, unmarked directories refused. SKILL.md's
+  Retention paragraph now describes the mechanism as real rather than pending.
+- **25 new tests** (60 total) covering link idempotence and ownership, resolution states
+  (gh mocked — the suite still never touches the network), sweep verdicts,
+  and offer-only ledger deletion.
 
 ## [v1.1.0] - 2026-08-07 — Packets that cannot lie about their source
 

--- a/skills/investigate/ingest/SKILL.md
+++ b/skills/investigate/ingest/SKILL.md
@@ -35,7 +35,7 @@ Run it in the background — transcription takes minutes. To decide whether a UR
 
 **A run directory holds exactly one source.** The run is fingerprinted by input, intent, and processing options; pointing a *different* run at a finished packet's directory is refused rather than resumed, because the finished stages belong to the other source. Same arguments, same directory resumes — that is what makes a failed transcription cheap to retry. Give each source a fresh `--out`.
 
-The run directory: the team-workflow binding doc's git-ignored reference home when one names it, else `~/.ingest/<slug>-<date>/`. It must be a new or ingest-created directory — the script refuses to adopt a folder it did not make, because retention deletes inside it. With the script unavailable, the same pipeline runs by hand — commands, ordering, and the gotchas the script encodes are in [references/pipeline.md](references/pipeline.md).
+The run directory: the team-workflow binding doc's git-ignored reference home when one names it, else `~/.ingest/<slug>-<date>/`. It must be a new or ingest-created directory — the script refuses to adopt a folder it did not make, because retention deletes inside it. The parent directory that holds run directories — the binding doc's reference home when named, else `~/.ingest/` — is the **output home**: the cleanup sweep's `--home` takes exactly that, and scans one level deep. With the script unavailable, the same pipeline runs by hand — commands, ordering, and the gotchas the script encodes are in [references/pipeline.md](references/pipeline.md).
 
 ## Read, then look
 
@@ -60,7 +60,7 @@ The run dir is the archive, and the rule is what can't be re-fetched stays: a lo
 
 **A URL is not a promise.** Signed, expiring, private, and geo-limited links all look like ordinary URLs, and the discard is irreversible — pass `--keep-media` whenever the source might not still be there tomorrow.
 
-**A packet lives as long as the work it spawned.** A packet is neither permanent evidence nor throwaway scratch: its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash: the skill may *offer* cleanup, and the decider takes or declines the offer — nothing is deleted unasked, and any deletion follows the same ownership rules as the run itself (only ingest-created files, never an adopted directory). The mechanism is the manifest's `derived_items` list plus the sweep below: the filing session records what the packet spawned, and the sweep checks resolution and makes the offer. This lifetime rule governs the packet's files after a completed run; it is separate from the automatic discard of downloaded URL media above, which happens at run time under its own flag.
+**A packet lives as long as the work it spawned.** A packet is neither permanent evidence nor throwaway scratch: its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash: the skill may *offer* cleanup, and the decider takes or declines it, on the offer-only and ownership terms stated once in the sweep section below. The mechanism is the manifest's `derived_items` list plus that sweep: the filing session records what the packet spawned, and the sweep checks resolution and makes the offer. This lifetime rule governs the packet's files after a completed run; it is separate from the automatic discard of downloaded URL media above, which happens at run time under its own flag.
 
 ### Derived items and the cleanup sweep
 
@@ -77,7 +77,7 @@ python3 scripts/ingest.py sweep --home <output-home>          # report + offers,
 python3 scripts/ingest.py sweep --home <output-home> --delete <packet-dir>   # the decider took the offer
 ```
 
-The sweep looks one level deep under `--home` and recognizes packets by their `.ingest-run` marker, never by name — which also means a packet directory that was moved or copied elsewhere stays sweepable, and any deletion stays bounded to that subtree.
+`--home` is the output home defined under "Run the pipeline"; the sweep looks one level deep beneath it and recognizes packets by their `.ingest-run` marker, never by name — which also means a packet directory that was moved or copied elsewhere stays sweepable, and any deletion stays bounded to that subtree.
 
 Resolution is GitHub-first: an `owner/repo#number` item is resolved when `gh` reports the issue or PR closed. Any other tracker resolves only through the resolution-check command named in the repo's binding doc, passed as `--check-cmd`. The template must contain a literal `{id}` (refused without it — a fixed command would resolve everything); the id is handed to the command as a shell positional argument, never spliced into the command text; exit 0 means resolved, exit 1 means open, and any other exit means unknown. Where no binding exists the sweep does not guess — it lists those packets, and packets with no recorded derived items, as the decider's to settle.
 

--- a/skills/investigate/ingest/SKILL.md
+++ b/skills/investigate/ingest/SKILL.md
@@ -60,7 +60,26 @@ The run dir is the archive, and the rule is what can't be re-fetched stays: a lo
 
 **A URL is not a promise.** Signed, expiring, private, and geo-limited links all look like ordinary URLs, and the discard is irreversible — pass `--keep-media` whenever the source might not still be there tomorrow.
 
-**A packet lives as long as the work it spawned.** A packet is neither permanent evidence nor throwaway scratch: its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash: the skill may *offer* cleanup, and the decider takes or declines the offer — nothing is deleted unasked, and any deletion follows the same ownership rules as the run itself (only ingest-created files, never an adopted directory). This is the standing policy, not yet a step the skill can execute: offering cleanup requires knowing which work items derive from the packet and when they resolved, and no manifest field records that yet — until that mechanism ships, cleanup happens only when the decider initiates it. This lifetime rule governs the packet's files after a completed run; it is separate from the automatic discard of downloaded URL media above, which happens at run time under its own flag.
+**A packet lives as long as the work it spawned.** A packet is neither permanent evidence nor throwaway scratch: its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash: the skill may *offer* cleanup, and the decider takes or declines the offer — nothing is deleted unasked, and any deletion follows the same ownership rules as the run itself (only ingest-created files, never an adopted directory). The mechanism is the manifest's `derived_items` list plus the sweep below: the filing session records what the packet spawned, and the sweep checks resolution and makes the offer. This lifetime rule governs the packet's files after a completed run; it is separate from the automatic discard of downloaded URL media above, which happens at run time under its own flag.
+
+### Derived items and the cleanup sweep
+
+The link is written at filing time, never reconstructed: whoever files tickets from the packet — the invoking session, when [to-tickets](../../run/to-tickets/SKILL.md) runs off the recommendation — appends each filed item to the packet's manifest the moment it exists:
+
+```bash
+python3 scripts/ingest.py link --out <run-dir> --item owner/repo#123 [--item ...]
+```
+
+The sweep reads those links back and checks whether the work has resolved — as the closing step of any run (after the routing recommendation, sweep the output home and relay any offers to the decider) and on demand, whenever the decider asks what can go:
+
+```bash
+python3 scripts/ingest.py sweep --home <output-home>          # report + offers, deletes nothing
+python3 scripts/ingest.py sweep --home <output-home> --delete <packet-dir>   # the decider took the offer
+```
+
+Resolution is GitHub-first: an `owner/repo#number` item is resolved when `gh` reports the issue or PR closed. Any other tracker resolves only through the resolution-check command named in the repo's binding doc, passed as `--check-cmd` (exit 0 resolved, exit 1 open). Where no binding exists the sweep does not guess — it lists those packets, and packets with no recorded derived items, as the decider's to settle.
+
+The sweep's report **is** the offer: fully-resolved packets are named as eligible, and nothing is deleted until the decider takes the offer and `--delete` is run — which re-checks resolution and then deletes by ledger under the run's own ownership rules (manifest-recorded files only, foreign files left in place, a directory without the `.ingest-run` marker refused outright).
 
 ## Done when (checkable — verify each line before reporting complete)
 
@@ -70,6 +89,7 @@ The run dir is the archive, and the rule is what can't be re-fetched stays: a lo
 - The whole transcript was read, and a frame was opened at every reaction and every load-bearing claim.
 - Every takeaway in the recommendation carries a route and, where the transcript supports it, a timestamp.
 - Anything quoted came from the whisper transcript, with the caption preview used for triage only.
+- The closing sweep ran over the output home; any cleanup offers were relayed to the decider, and nothing was deleted without the decider taking one.
 - Nothing was filed, claimed, or built, and nothing from the run dir was committed.
 
 ## Hard guardrails

--- a/skills/investigate/ingest/SKILL.md
+++ b/skills/investigate/ingest/SKILL.md
@@ -49,7 +49,7 @@ The packet is evidence; this step is the judgment, and it belongs to the session
 
 End with the takeaways ranked and each one routed — as a recommendation, in the language of the table above:
 
-- **Tracker-shaped** items name the issue they'd update or the item they'd become, with the binding doc's labels. No binding doc bound: say so, and route in prose.
+- **Tracker-shaped** items name the issue they'd update or the item they'd become, with the binding doc's labels. No binding doc bound: say so, and route in prose. Hand the filing session its follow-through in the same breath: the exact `python3 scripts/ingest.py link --out <run-dir> --item owner/repo#N` command to run for each item it files, so the packet's derived-items ledger is written at filing time.
 - **Undecided-shaped** items name the open questions; offer a [grilling](../../decide/grilling/SKILL.md) session rather than answers.
 - **Decider-shaped** items (pricing, partnerships, strategy) are listed for discussion, never resolved.
 - A `call` run whose stated purpose asks for it also drafts the thank-you/recap email — saved to the run dir, put on the clipboard as plain text, never sent.
@@ -77,9 +77,11 @@ python3 scripts/ingest.py sweep --home <output-home>          # report + offers,
 python3 scripts/ingest.py sweep --home <output-home> --delete <packet-dir>   # the decider took the offer
 ```
 
-Resolution is GitHub-first: an `owner/repo#number` item is resolved when `gh` reports the issue or PR closed. Any other tracker resolves only through the resolution-check command named in the repo's binding doc, passed as `--check-cmd` (exit 0 resolved, exit 1 open). Where no binding exists the sweep does not guess — it lists those packets, and packets with no recorded derived items, as the decider's to settle.
+The sweep looks one level deep under `--home` and recognizes packets by their `.ingest-run` marker, never by name — which also means a packet directory that was moved or copied elsewhere stays sweepable, and any deletion stays bounded to that subtree.
 
-The sweep's report **is** the offer: fully-resolved packets are named as eligible, and nothing is deleted until the decider takes the offer and `--delete` is run — which re-checks resolution and then deletes by ledger under the run's own ownership rules (manifest-recorded files only, foreign files left in place, a directory without the `.ingest-run` marker refused outright).
+Resolution is GitHub-first: an `owner/repo#number` item is resolved when `gh` reports the issue or PR closed. Any other tracker resolves only through the resolution-check command named in the repo's binding doc, passed as `--check-cmd`. The template must contain a literal `{id}` (refused without it — a fixed command would resolve everything); the id is handed to the command as a shell positional argument, never spliced into the command text; exit 0 means resolved, exit 1 means open, and any other exit means unknown. Where no binding exists the sweep does not guess — it lists those packets, and packets with no recorded derived items, as the decider's to settle.
+
+The sweep's report **is** the offer: fully-resolved packets are named as eligible, and nothing is deleted until the decider takes the offer and `--delete` is run — which re-checks resolution and then deletes by ledger under the run's own ownership rules (manifest-recorded files only, foreign files left in place, a directory without the `.ingest-run` marker refused outright). A packet that cannot be fully removed — a saved recap email, anything ingest did not create — keeps its marker and manifest, so it remains visible to the next sweep instead of becoming an orphan.
 
 ## Done when (checkable — verify each line before reporting complete)
 
@@ -87,7 +89,7 @@ The sweep's report **is** the offer: fully-resolved packets are named as eligibl
 - The run reported `packet complete`: every stage carries a status of `ok` or `skipped` and every artifact it claims exists and is non-empty. (The script re-checks this from disk before saying so, and refuses to say it otherwise.)
 - The transcript covers the recording: the run's validation compares its last timestamp against the probed duration and fails the packet on an unexplained gap, so a clean `packet complete` is the check. Trailing silence and a declared `no_speech` packet are legitimate and pass.
 - The whole transcript was read, and a frame was opened at every reaction and every load-bearing claim.
-- Every takeaway in the recommendation carries a route and, where the transcript supports it, a timestamp.
+- Every takeaway in the recommendation carries a route and, where the transcript supports it, a timestamp — and every tracker-shaped one carries the `link` command for the filing session to run at filing time.
 - Anything quoted came from the whisper transcript, with the caption preview used for triage only.
 - The closing sweep ran over the output home; any cleanup offers were relayed to the decider, and nothing was deleted without the decider taking one.
 - Nothing was filed, claimed, or built, and nothing from the run dir was committed.

--- a/skills/investigate/ingest/scripts/ingest.py
+++ b/skills/investigate/ingest/scripts/ingest.py
@@ -37,8 +37,12 @@ Usage:
   ingest.py preview --url URL --out DIR
   ingest.py run --input PATH_OR_URL --intent INTENT --goal "why" --out DIR
                 [--no-frames] [--keep-media] [--ladder SECONDS]
+  ingest.py link --out DIR --item OWNER/REPO#N [--item ...]
+  ingest.py sweep --home DIR [--check-cmd CMD] [--delete PACKET_DIR ...]
 
-Exit codes: 0 ok · 1 stage failed · 2 bad arguments · 3 missing tools
+Exit codes: 0 ok · 1 stage failed (or sweep --delete refused: unresolved)
+             2 bad arguments (or a directory ingest does not own)
+             3 missing tools
              4 identity mismatch (refused to mix sources in one packet)
 """
 
@@ -73,6 +77,11 @@ MAX_EXTRA_FRAMES = 240
 MIN_LOOP_REPEATS = 3
 MIN_LOOP_SPAN_S = 20
 EXIT_IDENTITY_MISMATCH = 4
+RUN_MARKER = ".ingest-run"
+# A GitHub-shaped derived-item id: owner/repo#number. Anything else belongs
+# to another tracker and resolves only through a binding-doc command — the
+# sweep never guesses what an id it cannot read means.
+GH_ITEM_RE = re.compile(r"^([\w.-]+/[\w.-]+)#(\d+)$")
 
 
 def log(msg: str) -> None:
@@ -148,6 +157,7 @@ class Manifest:
                 self.path.rename(self.path.with_suffix(".json.corrupt"))
         self.data.setdefault("stages", {})
         self.data.setdefault("frames", [])
+        self.data.setdefault("derived_items", [])
 
     def save(self) -> None:
         tmp = self.path.with_suffix(".json.tmp")
@@ -219,7 +229,7 @@ def claim_out_dir(out_dir: Path) -> None:
     """A run directory is tool-owned. Adopting a directory this script did not
     create is refused — retention deletes files inside it later, and a stray
     --out must never put a user's own folder in that path."""
-    marker = out_dir / ".ingest-run"
+    marker = out_dir / RUN_MARKER
     if out_dir.exists() and any(out_dir.iterdir()) and not marker.exists():
         die(
             f"{out_dir} is not empty and was not created by ingest.\n"
@@ -795,6 +805,235 @@ def transcript_coverage_problems(manifest: Manifest) -> list:
     return []
 
 
+# -------------------------------------------------- derived items & sweep ---
+#
+# A packet lives as long as the work it spawned. The filing session records
+# what that work IS (link, at filing time — written at creation, never
+# reconstructed); the sweep later checks whether it has all resolved and
+# OFFERS deletion. Nothing here deletes unasked: the report is the offer, and
+# --delete is the decider taking it.
+
+
+def require_packet(out_dir: Path) -> Path:
+    """A link or sweep target must be a directory ingest created — the same
+    ownership rule the run itself enforces, because both end in deletion."""
+    if not out_dir.is_dir():
+        die(f"{out_dir} is not a directory", 2)
+    if not (out_dir / RUN_MARKER).exists():
+        die(
+            f"{out_dir} was not created by ingest (no {RUN_MARKER} marker).\n"
+            "Refusing to touch it: retention only ever operates on the tool's "
+            "own run directories.",
+            2,
+        )
+    return out_dir
+
+
+def cmd_link(args) -> None:
+    """Append derived work items to the packet's manifest. Idempotent: an id
+    already recorded is kept with its original date, not duplicated."""
+    out_dir = require_packet(Path(args.out).expanduser())
+    manifest = Manifest(out_dir)
+    known = {d.get("id") for d in manifest.data["derived_items"]}
+    today = time.strftime("%Y-%m-%d")
+    added = 0
+    for item in args.item:
+        item = item.strip()
+        if not item:
+            continue
+        if item in known:
+            log(f"already recorded: {item}")
+            continue
+        if not GH_ITEM_RE.match(item):
+            # Not fatal — other trackers are legitimate — but say what it
+            # means: this id will need a binding-doc command to resolve.
+            log(
+                f"note: {item} is not owner/repo#number — the sweep will "
+                "need the binding doc's resolution command (--check-cmd) "
+                "to resolve it"
+            )
+        manifest.data["derived_items"].append({"id": item, "added": today})
+        known.add(item)
+        added += 1
+    manifest.save()
+    log(
+        f"derived items recorded: {added} new, "
+        f"{len(manifest.data['derived_items'])} total in {manifest.path}"
+    )
+
+
+def check_item_resolution(item_id: str, check_cmd: str | None = None) -> tuple:
+    """One derived item's terminal state: ('resolved'|'open'|'unknown', why).
+
+    GitHub-first: owner/repo#number resolves via gh — the issues endpoint
+    covers PRs too, and resolution means state == closed. Any other id runs
+    the binding doc's resolution command (exit 0 resolved, 1 open); with no
+    binding the answer is unknown, and unknown is the decider's to settle —
+    never guessed.
+    """
+    m = GH_ITEM_RE.match(item_id)
+    if m:
+        r = run_cmd(
+            ["gh", "api", f"repos/{m.group(1)}/issues/{m.group(2)}",
+             "--jq", ".state"],
+            timeout=60,
+        )
+        if r.returncode != 0:
+            reason = (r.stderr or "").strip().splitlines()
+            return ("unknown", f"gh failed: {reason[-1] if reason else f'exit {r.returncode}'}")
+        state = r.stdout.strip()
+        return ("resolved", state) if state == "closed" else ("open", state)
+    if check_cmd:
+        r = run_cmd(["/bin/sh", "-c", check_cmd.replace("{id}", item_id)],
+                    timeout=120)
+        if r.returncode == 0:
+            return ("resolved", "binding-doc check: exit 0")
+        if r.returncode == 1:
+            return ("open", "binding-doc check: exit 1")
+        return ("unknown", f"binding-doc check failed: exit {r.returncode}")
+    return ("unknown", "no binding for this tracker — ask the decider")
+
+
+def sweep_packet(out_dir: Path, check_cmd: str | None = None) -> dict:
+    """One packet's report. Verdicts:
+      resolved — every derived item terminal: deletion may be OFFERED
+      open     — work still live: the packet stays, no question to ask
+      unknown  — at least one id the sweep cannot read: the decider's call
+      unlinked — nothing recorded: nothing proves a terminal state, so the
+                 sweep lists it rather than inventing one
+    """
+    manifest_path = out_dir / "manifest.json"
+    report = {"dir": out_dir, "items": [], "verdict": "unknown"}
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        report["note"] = "manifest missing or unreadable"
+        return report
+    items = data.get("derived_items") or []
+    if not items:
+        report["verdict"] = "unlinked"
+        return report
+    states = []
+    for rec in items:
+        state, why = check_item_resolution(rec.get("id", ""), check_cmd)
+        states.append(state)
+        report["items"].append(
+            {"id": rec.get("id"), "added": rec.get("added"),
+             "state": state, "why": why}
+        )
+    if "open" in states:
+        report["verdict"] = "open"
+    elif "unknown" in states:
+        report["verdict"] = "unknown"
+    else:
+        report["verdict"] = "resolved"
+    return report
+
+
+def find_packets(home: Path) -> list:
+    """Ingest-created run dirs under the output home — the marker decides
+    membership, never the directory name. A home that is itself a packet
+    (someone pointed --home at a run dir) sweeps as that one packet."""
+    if (home / RUN_MARKER).exists():
+        return [home]
+    return sorted(
+        p for p in home.iterdir()
+        if p.is_dir() and (p / RUN_MARKER).exists()
+    )
+
+
+def delete_packet(out_dir: Path, check_cmd: str | None = None) -> None:
+    """The decider took the offer. Resolution is RE-CHECKED here — an offer
+    can go stale between the sweep and the yes — and deletion follows the
+    ledger: manifest-recorded artifacts, listed frames, and ingest's own
+    bookkeeping files, each path refused unless it resolves inside the
+    packet. Anything else stays, and a non-empty directory is kept."""
+    out_dir = require_packet(out_dir)
+    report = sweep_packet(out_dir, check_cmd)
+    if report["verdict"] != "resolved":
+        detail = "; ".join(
+            f"{i['id']}: {i['state']}" for i in report["items"]
+        ) or report.get("note", "no derived items recorded")
+        die(
+            f"{out_dir}: derived work is not fully resolved "
+            f"(verdict: {report['verdict']} — {detail}).\n"
+            "Refusing to delete: a packet lives as long as the work it "
+            "spawned.",
+            1,
+        )
+    data = json.loads((out_dir / "manifest.json").read_text())
+    ledgered = set()
+    for rec in data.get("stages", {}).values():
+        ledgered.update(str(a) for a in rec.get("artifacts", []))
+    for frame in data.get("frames", []):
+        ledgered.add(str(out_dir / frame["file"]))
+    for own in ("manifest.json", "manifest.json.tmp", "manifest.json.corrupt",
+                RUN_MARKER):
+        ledgered.add(str(out_dir / own))
+    packet_root = out_dir.resolve()
+    removed = 0
+    for path in (Path(p) for p in sorted(ledgered)):
+        try:
+            resolved = path.resolve()
+            resolved.relative_to(packet_root)
+        except (OSError, ValueError):
+            log(f"note: ledger lists {path} outside the packet — not deleting")
+            continue
+        if resolved.is_file():
+            resolved.unlink()
+            removed += 1
+    # Prune the directories the deletions emptied, deepest first; a directory
+    # still holding anything was holding something ingest did not create.
+    for d in sorted((p for p in out_dir.rglob("*") if p.is_dir()),
+                    reverse=True):
+        if not any(d.iterdir()):
+            d.rmdir()
+    leftovers = [p for p in out_dir.rglob("*") if p.is_file()]
+    if leftovers:
+        log(
+            f"{out_dir}: removed {removed} ledgered file(s), but "
+            f"{len(leftovers)} file(s) ingest did not create remain — "
+            "directory kept"
+        )
+    else:
+        out_dir.rmdir()
+        log(f"packet deleted: {out_dir} ({removed} files)")
+
+
+def cmd_sweep(args) -> None:
+    home = Path(args.home).expanduser()
+    if args.delete:
+        for target in args.delete:
+            delete_packet(Path(target).expanduser(), args.check_cmd)
+        return
+    if not home.is_dir():
+        die(f"{home} is not a directory", 2)
+    packets = find_packets(home)
+    if not packets:
+        log(f"no ingest packets under {home}")
+        return
+    offers, ask = [], []
+    for packet in packets:
+        report = sweep_packet(packet, args.check_cmd)
+        log(f"packet {packet.name} — verdict: {report['verdict']}"
+            + (f" ({report['note']})" if report.get("note") else ""))
+        for item in report["items"]:
+            log(f"  {item['state']:8s} {item['id']} ({item['why']})")
+        if report["verdict"] == "resolved":
+            offers.append(packet)
+        elif report["verdict"] in ("unknown", "unlinked"):
+            ask.append((packet, report["verdict"]))
+    if offers:
+        log("OFFER — derived work fully resolved; the decider may take or "
+            "decline (nothing is deleted unasked):")
+        for packet in offers:
+            log(f"  ingest.py sweep --home {home} --delete {packet}")
+    if ask:
+        log("NEEDS THE DECIDER — the sweep does not guess:")
+        for packet, verdict in ask:
+            log(f"  {packet} ({'no derived items recorded' if verdict == 'unlinked' else 'unresolvable item(s) — no tracker binding or check failed'})")
+
+
 def cmd_run(args) -> None:
     if not doctor(quiet=True):
         die("missing tools — run `ingest.py doctor` for install commands", 3)
@@ -908,6 +1147,30 @@ def main(argv=None) -> None:
     rn.add_argument("--ladder", type=int, default=10,
                     help="ladder interval in seconds (default 10)")
 
+    lk = sub.add_parser(
+        "link",
+        help="record the work items filed from a packet, at filing time",
+    )
+    lk.add_argument("--out", required=True, help="the packet (run directory)")
+    lk.add_argument("--item", required=True, action="append",
+                    help="derived work item id — owner/repo#number for "
+                         "GitHub, the tracker's own id otherwise (repeatable)")
+
+    sw = sub.add_parser(
+        "sweep",
+        help="check derived-item resolution across packets; OFFER cleanup",
+    )
+    sw.add_argument("--home", required=True,
+                    help="the output home holding packets (or one packet dir)")
+    sw.add_argument("--check-cmd",
+                    help="resolution-check command from the repo's binding "
+                         "doc, for non-GitHub items; run via /bin/sh with "
+                         "{id} substituted; exit 0 = resolved, 1 = open")
+    sw.add_argument("--delete", action="append", default=[],
+                    help="delete this fully-resolved packet — the decider "
+                         "taking the offer, never the default (repeatable; "
+                         "resolution is re-checked first)")
+
     args = p.parse_args(argv)
     if args.cmd == "doctor":
         sys.exit(0 if doctor() else 3)
@@ -918,6 +1181,10 @@ def main(argv=None) -> None:
         sys.exit(0 if got else 1)
     elif args.cmd == "run":
         cmd_run(args)
+    elif args.cmd == "link":
+        cmd_link(args)
+    elif args.cmd == "sweep":
+        cmd_sweep(args)
 
 
 if __name__ == "__main__":

--- a/skills/investigate/ingest/scripts/ingest.py
+++ b/skills/investigate/ingest/scripts/ingest.py
@@ -40,16 +40,20 @@ Usage:
   ingest.py link --out DIR --item OWNER/REPO#N [--item ...]
   ingest.py sweep --home DIR [--check-cmd CMD] [--delete PACKET_DIR ...]
 
-Exit codes: 0 ok · 1 stage failed (or sweep --delete refused: unresolved)
-             2 bad arguments (or a directory ingest does not own)
+Exit codes: 0 ok · 1 stage failed, or sweep --delete refused (unresolved)
+             2 bad arguments, or a directory ingest does not own
              3 missing tools
              4 identity mismatch (refused to mix sources in one packet)
+             5 deletion incomplete — foreign or undeletable content remains;
+               the packet directory, marker, and manifest are KEPT so it
+               stays sweepable rather than orphaned
 """
 
 import argparse
 import hashlib
 import json
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -77,11 +81,18 @@ MAX_EXTRA_FRAMES = 240
 MIN_LOOP_REPEATS = 3
 MIN_LOOP_SPAN_S = 20
 EXIT_IDENTITY_MISMATCH = 4
+EXIT_DELETE_INCOMPLETE = 5
 RUN_MARKER = ".ingest-run"
 # A GitHub-shaped derived-item id: owner/repo#number. Anything else belongs
 # to another tracker and resolves only through a binding-doc command — the
-# sweep never guesses what an id it cannot read means.
-GH_ITEM_RE = re.compile(r"^([\w.-]+/[\w.-]+)#(\d+)$")
+# sweep never guesses what an id it cannot read means. Segments of '.' or
+# '..' are refused: they would ride into the gh API path as traversal.
+_ID_SEG = r"(?!\.\.?[/#])[\w.-]+"
+GH_ITEM_RE = re.compile(rf"^({_ID_SEG}/{_ID_SEG})#(\d+)$")
+# What link will record at all: ids are identifiers, not text. No whitespace,
+# no control characters, no shell metacharacters — an id that needs them is
+# an id that will later be handed to a resolution command and a log line.
+ITEM_ID_OK_RE = re.compile(r"^[A-Za-z0-9._/#-]+$")
 
 
 def log(msg: str) -> None:
@@ -107,6 +118,7 @@ TOOLS = {
     "ffprobe": "brew install ffmpeg",
     "yt-dlp": "brew install yt-dlp",
     "uvx": "brew install uv",
+    "gh": "brew install gh",   # the sweep's GitHub-first resolution checks
 }
 
 
@@ -831,29 +843,53 @@ def require_packet(out_dir: Path) -> Path:
 
 def cmd_link(args) -> None:
     """Append derived work items to the packet's manifest. Idempotent: an id
-    already recorded is kept with its original date, not duplicated."""
+    already recorded (case-insensitively — GitHub ids are) is kept with its
+    original date, not duplicated. Additive only: a manifest this command
+    cannot parse is refused rather than run through the corrupt-rename,
+    which would silently destroy the stage ledger."""
     out_dir = require_packet(Path(args.out).expanduser())
+    mpath = out_dir / "manifest.json"
+    if mpath.exists():
+        try:
+            json.loads(mpath.read_text())
+        except (OSError, json.JSONDecodeError):
+            die(
+                f"{mpath} is unreadable — refusing to link into a torn "
+                "manifest. Fix or re-run the packet first."
+            )
     manifest = Manifest(out_dir)
-    known = {d.get("id") for d in manifest.data["derived_items"]}
+    known = set()
+    for rec in manifest.data["derived_items"]:
+        rid = rec if isinstance(rec, str) else (rec or {}).get("id")
+        if isinstance(rid, str):
+            known.add(rid.lower())
     today = time.strftime("%Y-%m-%d")
     added = 0
     for item in args.item:
         item = item.strip()
         if not item:
             continue
-        if item in known:
-            log(f"already recorded: {item}")
+        if not ITEM_ID_OK_RE.match(item):
+            die(
+                f"refusing item id {json.dumps(item)} — ids are letters, "
+                "digits, and . _ / # - only (no whitespace, control "
+                "characters, or shell metacharacters: this id is later "
+                "handed to a resolution command and printed in reports)",
+                2,
+            )
+        if item.lower() in known:
+            log(f"already recorded: {json.dumps(item)}")
             continue
         if not GH_ITEM_RE.match(item):
             # Not fatal — other trackers are legitimate — but say what it
             # means: this id will need a binding-doc command to resolve.
             log(
-                f"note: {item} is not owner/repo#number — the sweep will "
-                "need the binding doc's resolution command (--check-cmd) "
-                "to resolve it"
+                f"note: {json.dumps(item)} is not owner/repo#number — the "
+                "sweep will need the binding doc's resolution command "
+                "(--check-cmd) to resolve it"
             )
         manifest.data["derived_items"].append({"id": item, "added": today})
-        known.add(item)
+        known.add(item.lower())
         added += 1
     manifest.save()
     log(
@@ -867,25 +903,48 @@ def check_item_resolution(item_id: str, check_cmd: str | None = None) -> tuple:
 
     GitHub-first: owner/repo#number resolves via gh — the issues endpoint
     covers PRs too, and resolution means state == closed. Any other id runs
-    the binding doc's resolution command (exit 0 resolved, 1 open); with no
-    binding the answer is unknown, and unknown is the decider's to settle —
-    never guessed.
+    the binding doc's resolution command (exit 0 resolved, 1 open, anything
+    else unknown); with no binding the answer is unknown, and unknown is the
+    decider's to settle — never guessed.
     """
     m = GH_ITEM_RE.match(item_id)
     if m:
-        r = run_cmd(
-            ["gh", "api", f"repos/{m.group(1)}/issues/{m.group(2)}",
-             "--jq", ".state"],
-            timeout=60,
-        )
+        try:
+            r = run_cmd(
+                ["gh", "api", f"repos/{m.group(1)}/issues/{m.group(2)}",
+                 "--jq", ".state"],
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            # gh missing, timing out, or unrunnable is a fact about this
+            # machine, not about the item — unknown, never resolved, and
+            # never a crash that takes the rest of the sweep with it.
+            return ("unknown", f"gh could not run: {e}")
         if r.returncode != 0:
             reason = (r.stderr or "").strip().splitlines()
             return ("unknown", f"gh failed: {reason[-1] if reason else f'exit {r.returncode}'}")
         state = r.stdout.strip()
         return ("resolved", state) if state == "closed" else ("open", state)
     if check_cmd:
-        r = run_cmd(["/bin/sh", "-c", check_cmd.replace("{id}", item_id)],
-                    timeout=120)
+        if "{id}" not in check_cmd:
+            die(
+                "--check-cmd must contain the {id} placeholder — a template "
+                "without it runs the same command for every item, and a "
+                "blanket exit 0 would mark everything resolved",
+                2,
+            )
+        # The id is DATA, never shell: it rides in as $1 and the template's
+        # {id} becomes a quoted positional reference. A hostile id in a
+        # hand-edited manifest cannot become syntax, and cannot forge a
+        # resolution by ending the command with `exit 0`.
+        try:
+            r = run_cmd(
+                ["/bin/sh", "-c", check_cmd.replace("{id}", '"$1"'),
+                 "sh", item_id],
+                timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            return ("unknown", f"binding-doc check could not run: {e}")
         if r.returncode == 0:
             return ("resolved", "binding-doc check: exit 0")
         if r.returncode == 1:
@@ -915,10 +974,23 @@ def sweep_packet(out_dir: Path, check_cmd: str | None = None) -> dict:
         return report
     states = []
     for rec in items:
-        state, why = check_item_resolution(rec.get("id", ""), check_cmd)
+        # The manifest is an input, not a fact: a hand-edited bare string is
+        # coerced, and anything else unreadable is reported as unknown
+        # rather than crashing the packet's report.
+        if isinstance(rec, str):
+            rec = {"id": rec}
+        rid = (rec or {}).get("id") if isinstance(rec, dict) else None
+        if not isinstance(rid, str) or not rid:
+            states.append("unknown")
+            report["items"].append(
+                {"id": repr(rec)[:80], "added": None, "state": "unknown",
+                 "why": "malformed derived_items entry — hand-edited?"}
+            )
+            continue
+        state, why = check_item_resolution(rid, check_cmd)
         states.append(state)
         report["items"].append(
-            {"id": rec.get("id"), "added": rec.get("added"),
+            {"id": rid, "added": rec.get("added"),
              "state": state, "why": why}
         )
     if "open" in states:
@@ -942,83 +1014,195 @@ def find_packets(home: Path) -> list:
     )
 
 
-def delete_packet(out_dir: Path, check_cmd: str | None = None) -> None:
-    """The decider took the offer. Resolution is RE-CHECKED here — an offer
-    can go stale between the sweep and the yes — and deletion follows the
-    ledger: manifest-recorded artifacts, listed frames, and ingest's own
-    bookkeeping files, each path refused unless it resolves inside the
-    packet. Anything else stays, and a non-empty directory is kept."""
-    out_dir = require_packet(out_dir)
+def delete_packet(out_dir: Path, check_cmd: str | None = None) -> int:
+    """The decider took the offer. Returns an exit-code-shaped outcome so a
+    multi-target --delete finishes every target and reports honestly:
+
+      0 deleted · 1 refused (derived work not fully resolved)
+      2 refused (not an ingest-created directory)
+      5 incomplete (foreign or undeletable content remains)
+
+    Resolution is RE-CHECKED here — an offer can go stale between the sweep
+    and the yes. Deletion follows the ledger: manifest-recorded artifacts and
+    listed frames, each path refused unless it resolves inside the packet,
+    and a ledgered path that turned into a symlink is left alone — the
+    ledger recorded a file, and a link in its place is not that file.
+
+    Bookkeeping (manifest, then the run marker LAST) goes only when the
+    directory is actually going away: a kept directory — foreign files, a
+    failed unlink — keeps its marker and manifest, so it stays visible to
+    the sweep instead of becoming an orphan nothing will ever offer again.
+    """
+    if not out_dir.is_dir() or not (out_dir / RUN_MARKER).exists():
+        log(
+            f"ERROR: {out_dir} was not created by ingest (no {RUN_MARKER} "
+            "marker) — refusing to touch it"
+        )
+        return 2
     report = sweep_packet(out_dir, check_cmd)
     if report["verdict"] != "resolved":
         detail = "; ".join(
-            f"{i['id']}: {i['state']}" for i in report["items"]
+            f"{json.dumps(str(i['id']))}: {i['state']}" for i in report["items"]
         ) or report.get("note", "no derived items recorded")
-        die(
-            f"{out_dir}: derived work is not fully resolved "
-            f"(verdict: {report['verdict']} — {detail}).\n"
-            "Refusing to delete: a packet lives as long as the work it "
-            "spawned.",
-            1,
+        log(
+            f"ERROR: {out_dir}: derived work is not fully resolved "
+            f"(verdict: {report['verdict']} — {detail}). Refusing to delete: "
+            "a packet lives as long as the work it spawned."
         )
-    data = json.loads((out_dir / "manifest.json").read_text())
+        return 1
+    try:
+        data = json.loads((out_dir / "manifest.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        log(f"ERROR: {out_dir}/manifest.json unreadable — refusing to "
+            "delete without the ledger")
+        return 2
+
+    bookkeeping = [
+        out_dir / "manifest.json.tmp",
+        out_dir / "manifest.json.corrupt",
+        out_dir / "manifest.json",
+        out_dir / RUN_MARKER,          # last: the marker is sweepability
+    ]
+    bookkeeping_strs = {str(b) for b in bookkeeping}
     ledgered = set()
     for rec in data.get("stages", {}).values():
         ledgered.update(str(a) for a in rec.get("artifacts", []))
     for frame in data.get("frames", []):
-        ledgered.add(str(out_dir / frame["file"]))
-    for own in ("manifest.json", "manifest.json.tmp", "manifest.json.corrupt",
-                RUN_MARKER):
-        ledgered.add(str(out_dir / own))
+        try:
+            ledgered.add(str(out_dir / frame["file"]))
+        except (TypeError, KeyError):
+            pass                       # malformed frame entry: nothing to delete
+    ledgered -= bookkeeping_strs
+
     packet_root = out_dir.resolve()
-    removed = 0
+    removed, trouble = 0, False
+    emptied_parents = set()
     for path in (Path(p) for p in sorted(ledgered)):
+        if path.is_symlink():
+            log(f"note: ledgered path {json.dumps(str(path))} is now a "
+                "symlink — left alone")
+            trouble = True
+            continue
         try:
             resolved = path.resolve()
             resolved.relative_to(packet_root)
         except (OSError, ValueError):
-            log(f"note: ledger lists {path} outside the packet — not deleting")
+            log(f"note: ledger lists {json.dumps(str(path))} outside the "
+                "packet — not deleting")
             continue
         if resolved.is_file():
-            resolved.unlink()
+            try:
+                resolved.unlink()
+            except OSError as e:
+                log(f"note: could not delete {json.dumps(str(resolved))}: {e}")
+                trouble = True
+                continue
             removed += 1
-    # Prune the directories the deletions emptied, deepest first; a directory
-    # still holding anything was holding something ingest did not create.
-    for d in sorted((p for p in out_dir.rglob("*") if p.is_dir()),
-                    reverse=True):
-        if not any(d.iterdir()):
-            d.rmdir()
-    leftovers = [p for p in out_dir.rglob("*") if p.is_file()]
-    if leftovers:
+            for parent in resolved.parents:
+                if parent == packet_root:
+                    break
+                emptied_parents.add(parent)
+
+    # Prune ONLY the directories this deletion emptied, deepest first. A
+    # pre-existing empty directory the decider made is not ours to remove,
+    # and a symlink to a directory is never rmdir material.
+    for d in sorted(emptied_parents, key=lambda p: len(p.parts), reverse=True):
+        if d.is_symlink() or not d.is_dir():
+            continue
+        try:
+            if not any(d.iterdir()):
+                d.rmdir()
+        except OSError:
+            trouble = True
+
+    # A leftover is anything still present that is not our bookkeeping —
+    # files, foreign directories, and symlinks (including dangling ones,
+    # which exist without being files).
+    leftovers = [
+        p for p in out_dir.rglob("*")
+        if (p.is_symlink() or p.exists()) and str(p) not in bookkeeping_strs
+    ]
+    if trouble or leftovers:
         log(
-            f"{out_dir}: removed {removed} ledgered file(s), but "
-            f"{len(leftovers)} file(s) ingest did not create remain — "
-            "directory kept"
+            f"{out_dir}: removed {removed} ledgered file(s); "
+            f"{len(leftovers)} item(s) ingest did not create (or could not "
+            "delete) remain — directory, marker, and manifest kept so the "
+            "packet stays sweepable"
         )
-    else:
+        return EXIT_DELETE_INCOMPLETE
+    for b in bookkeeping:
+        if b.is_symlink():
+            log(f"note: {json.dumps(str(b))} is a symlink — left alone, "
+                "packet kept")
+            return EXIT_DELETE_INCOMPLETE
+        try:
+            if b.is_file():
+                b.unlink()
+        except OSError as e:
+            # The marker is removed last, so a failure here leaves the
+            # packet marked and sweepable, never orphaned.
+            log(f"note: could not delete {json.dumps(str(b))}: {e} — "
+                "packet kept")
+            return EXIT_DELETE_INCOMPLETE
+    try:
         out_dir.rmdir()
-        log(f"packet deleted: {out_dir} ({removed} files)")
+    except OSError as e:
+        log(f"note: could not remove {out_dir}: {e}")
+        return EXIT_DELETE_INCOMPLETE
+    log(f"packet deleted: {out_dir} ({removed} files)")
+    return 0
 
 
 def cmd_sweep(args) -> None:
+    if args.check_cmd and "{id}" not in args.check_cmd:
+        die(
+            "--check-cmd must contain the {id} placeholder — a template "
+            "without it runs the same command for every item, and a blanket "
+            "exit 0 would mark everything resolved",
+            2,
+        )
     home = Path(args.home).expanduser()
-    if args.delete:
-        for target in args.delete:
-            delete_packet(Path(target).expanduser(), args.check_cmd)
-        return
     if not home.is_dir():
         die(f"{home} is not a directory", 2)
+    if args.delete:
+        # Every target is processed; the exit code is the worst outcome, so
+        # partial success is visible in the per-target lines and the summary
+        # while the process still reports the failure honestly.
+        home_root = home.resolve()
+        outcomes = []
+        for target in args.delete:
+            t = Path(target).expanduser()
+            try:
+                t.resolve().relative_to(home_root)
+            except (OSError, ValueError):
+                log(f"ERROR: {t} is not under {home} — refusing "
+                    "(--delete only takes packets from the swept home)")
+                outcomes.append((t, 2))
+                continue
+            outcomes.append((t, delete_packet(t, args.check_cmd)))
+        deleted = sum(1 for _, c in outcomes if c == 0)
+        log(f"deleted {deleted} of {len(outcomes)} target(s)")
+        sys.exit(max(c for _, c in outcomes))
     packets = find_packets(home)
     if not packets:
-        log(f"no ingest packets under {home}")
+        log(f"no ingest packets directly under {home} — the sweep looks "
+            "one level deep; point --home at the output home or at a packet")
         return
     offers, ask = [], []
     for packet in packets:
-        report = sweep_packet(packet, args.check_cmd)
+        try:
+            report = sweep_packet(packet, args.check_cmd)
+        except Exception as e:  # one packet's failure must not kill the report
+            log(f"packet {packet.name} — ERROR: {e.__class__.__name__}: {e}")
+            ask.append((packet, "unknown"))
+            continue
         log(f"packet {packet.name} — verdict: {report['verdict']}"
             + (f" ({report['note']})" if report.get("note") else ""))
         for item in report["items"]:
-            log(f"  {item['state']:8s} {item['id']} ({item['why']})")
+            # Ids come from a file on disk: rendered escaped, so a crafted id
+            # cannot forge report lines (an OFFER, another packet's verdict).
+            log(f"  {item['state']:8s} {json.dumps(str(item['id']))} "
+                f"({item['why']})")
         if report["verdict"] == "resolved":
             offers.append(packet)
         elif report["verdict"] in ("unknown", "unlinked"):
@@ -1026,8 +1210,13 @@ def cmd_sweep(args) -> None:
     if offers:
         log("OFFER — derived work fully resolved; the decider may take or "
             "decline (nothing is deleted unasked):")
+        script = str(Path(__file__).resolve())
         for packet in offers:
-            log(f"  ingest.py sweep --home {home} --delete {packet}")
+            argv = [sys.executable, script, "sweep",
+                    "--home", str(home), "--delete", str(packet)]
+            if args.check_cmd:
+                argv += ["--check-cmd", args.check_cmd]
+            log("  " + " ".join(shlex.quote(a) for a in argv))
     if ask:
         log("NEEDS THE DECIDER — the sweep does not guess:")
         for packet, verdict in ask:
@@ -1164,12 +1353,15 @@ def main(argv=None) -> None:
                     help="the output home holding packets (or one packet dir)")
     sw.add_argument("--check-cmd",
                     help="resolution-check command from the repo's binding "
-                         "doc, for non-GitHub items; run via /bin/sh with "
-                         "{id} substituted; exit 0 = resolved, 1 = open")
+                         "doc, for non-GitHub items; must contain a literal "
+                         "{id}, which is replaced by a quoted positional "
+                         "reference — the id is passed as data, never "
+                         "spliced into the shell; exit 0 = resolved, "
+                         "1 = open, anything else = unknown")
     sw.add_argument("--delete", action="append", default=[],
-                    help="delete this fully-resolved packet — the decider "
-                         "taking the offer, never the default (repeatable; "
-                         "resolution is re-checked first)")
+                    help="delete this fully-resolved packet under --home — "
+                         "the decider taking the offer, never the default "
+                         "(repeatable; resolution is re-checked first)")
 
     args = p.parse_args(argv)
     if args.cmd == "doctor":

--- a/skills/investigate/ingest/scripts/ingest.py
+++ b/skills/investigate/ingest/scripts/ingest.py
@@ -968,7 +968,15 @@ def sweep_packet(out_dir: Path, check_cmd: str | None = None) -> dict:
     except (OSError, json.JSONDecodeError):
         report["note"] = "manifest missing or unreadable"
         return report
-    items = data.get("derived_items") or []
+    items = data.get("derived_items")
+    if items is None:
+        items = []
+    if not isinstance(items, list):
+        # A hand-edited scalar here is damage, not absence: unknown — so a
+        # deletion built on it refuses — never "unlinked", and never a
+        # TypeError that turns --delete into a traceback.
+        report["note"] = "derived_items is not a list — hand-edited?"
+        return report                      # verdict stays "unknown"
     if not items:
         report["verdict"] = "unlinked"
         return report
@@ -1039,7 +1047,14 @@ def delete_packet(out_dir: Path, check_cmd: str | None = None) -> int:
             "marker) — refusing to touch it"
         )
         return 2
-    report = sweep_packet(out_dir, check_cmd)
+    try:
+        report = sweep_packet(out_dir, check_cmd)
+    except Exception as e:
+        # An assessment that cannot complete is a refusal, never a traceback:
+        # deletion without a verdict would be deletion without the offer.
+        log(f"ERROR: {out_dir}: could not assess resolution "
+            f"({e.__class__.__name__}: {e}) — refusing to delete")
+        return 1
     if report["verdict"] != "resolved":
         detail = "; ".join(
             f"{json.dumps(str(i['id']))}: {i['state']}" for i in report["items"]

--- a/skills/investigate/ingest/tests/test_ingest.py
+++ b/skills/investigate/ingest/tests/test_ingest.py
@@ -6,6 +6,7 @@ invariants are testable without ever invoking ffmpeg or whisper.
 
 Run:  python3 -m unittest discover -s tests -t tests
 """
+import contextlib
 import io
 import json
 import sys
@@ -397,7 +398,9 @@ class FakeProc:
 
 class SweepBase(unittest.TestCase):
     """Shared plumbing: a temp home, packet builders, and a run_cmd mock that
-    guarantees no test ever reaches gh or the network."""
+    guarantees no test ever reaches gh or the network. The responder is any
+    callable — including one that RAISES, because a subprocess layer that can
+    only fail politely hides the crash family entirely."""
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -447,15 +450,53 @@ class TestDerivedItemsLink(SweepBase):
         self.assertEqual([i["id"] for i in items], ["owner/repo#12"])
         self.assertRegex(items[0]["added"], r"^\d{4}-\d{2}-\d{2}$")
 
-    def test_link_is_idempotent(self):
+    def test_link_is_idempotent_and_keeps_the_original_date(self):
         d = self.make_packet("p")
         ing.main(["link", "--out", str(d), "--item", "owner/repo#12"])
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        data["derived_items"][0]["added"] = "2000-01-01"
+        mpath.write_text(json.dumps(data))
         ing.main(["link", "--out", str(d),
                   "--item", "owner/repo#12", "--item", "owner/repo#13"])
-        items = json.loads((d / "manifest.json").read_text())["derived_items"]
+        items = json.loads(mpath.read_text())["derived_items"]
         self.assertEqual(
             [i["id"] for i in items], ["owner/repo#12", "owner/repo#13"]
         )
+        self.assertEqual(items[0]["added"], "2000-01-01",
+                         "a re-link must not rewrite the filing date")
+
+    def test_link_idempotence_is_case_insensitive(self):
+        # GitHub ids are case-insensitive; O/R#1 and o/r#1 are one item.
+        d = self.make_packet("p")
+        ing.main(["link", "--out", str(d), "--item", "Owner/Repo#12"])
+        ing.main(["link", "--out", str(d), "--item", "owner/repo#12"])
+        items = json.loads((d / "manifest.json").read_text())["derived_items"]
+        self.assertEqual(len(items), 1)
+
+    def test_link_rejects_ids_with_shell_metacharacters(self):
+        # BLOCKER 1b: an id is an identifier — whitespace, control chars, and
+        # shell syntax are refused at the door, before they can ever reach a
+        # resolution command or a report line.
+        d = self.make_packet("p")
+        for bad in ("a b#1", "x;touch /tmp/PWNED#1", "o/r#1\n[ingest] OFFER",
+                    "$(reboot)#1", "a'b#1"):
+            with self.assertRaises(SystemExit) as cm:
+                ing.main(["link", "--out", str(d), "--item", bad])
+            self.assertEqual(cm.exception.code, 2, bad)
+        items = json.loads((d / "manifest.json").read_text())["derived_items"]
+        self.assertEqual(items, [], "a refused id must not be recorded")
+
+    def test_link_refuses_a_torn_manifest_instead_of_corrupt_renaming(self):
+        # An additive command must not trigger the corrupt-rename and quietly
+        # destroy the stage ledger.
+        d = self.make_packet("p")
+        (d / "manifest.json").write_text("{ torn")
+        with self.assertRaises(SystemExit) as cm:
+            ing.main(["link", "--out", str(d), "--item", "o/r#1"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual((d / "manifest.json").read_text(), "{ torn")
+        self.assertFalse((d / "manifest.json.corrupt").exists())
 
     def test_link_refuses_a_directory_ingest_did_not_create(self):
         foreign = self.home / "documents"
@@ -496,13 +537,19 @@ class TestItemResolution(SweepBase):
         self.assertIn("decider", why)
         self.assertEqual(self.calls, [], "must not shell out with no binding")
 
-    def test_binding_doc_command_resolves_other_trackers(self):
+    def test_binding_doc_command_gets_the_id_as_data_not_shell(self):
+        # BLOCKER 1a: {id} becomes a quoted positional reference and the id
+        # itself rides in as $1 — never spliced into the -c string.
         self.respond(lambda argv: FakeProc(returncode=0))
+        hostile = "X; touch /tmp/PWNED; exit 0"
         state, _ = ing.check_item_resolution(
-            "JIRA-42", check_cmd="check-resolved {id}"
+            hostile, check_cmd="check-resolved {id}"
         )
         self.assertEqual(state, "resolved")
-        self.assertEqual(self.calls[0][-1], "check-resolved JIRA-42")
+        self.assertEqual(
+            self.calls[0],
+            ["/bin/sh", "-c", 'check-resolved "$1"', "sh", hostile],
+        )
 
     def test_binding_doc_exit_1_is_open_and_other_exits_are_unknown(self):
         self.respond(lambda argv: FakeProc(returncode=1))
@@ -514,6 +561,62 @@ class TestItemResolution(SweepBase):
             ing.check_item_resolution("JIRA-42", check_cmd="c {id}")[0],
             "unknown",
         )
+
+    def test_check_cmd_without_the_placeholder_is_refused(self):
+        # MAJOR 4: `--check-cmd true` would resolve everything — fail closed.
+        with self.assertRaises(SystemExit) as cm:
+            ing.check_item_resolution("JIRA-42", check_cmd="true")
+        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(self.calls, [], "must die before running anything")
+
+    def test_a_raising_run_cmd_is_unknown_not_a_crash(self):
+        # MAJOR 3: gh missing (OSError) or hanging (TimeoutExpired) is a fact
+        # about the machine, not the item — and never aborts the sweep.
+        def boom(argv):
+            raise OSError("No such file or directory: 'gh'")
+        self.respond(boom)
+        state, why = ing.check_item_resolution("o/r#1")
+        self.assertEqual(state, "unknown")
+        self.assertIn("gh", why)
+
+        def hang(argv):
+            raise ing.subprocess.TimeoutExpired(argv, 120)
+        self.respond(hang)
+        state, _ = ing.check_item_resolution("JIRA-42", check_cmd="c {id}")
+        self.assertEqual(state, "unknown")
+
+    def test_dot_segments_are_not_github_shaped(self):
+        # NIT: '../..#1' must not ride into the gh API path as traversal.
+        for tricky in ("../..#1", "./x#1", "a/..#2"):
+            state, _ = ing.check_item_resolution(tricky)
+            self.assertEqual(state, "unknown", tricky)
+        self.assertEqual(self.calls, [], "no gh call for a non-GitHub shape")
+
+
+class TestInjectionRealShell(unittest.TestCase):
+    """BLOCKER 1 pinned against a real /bin/sh (no mock, no network): the
+    reproduced exploit — a hostile id forging 'resolved' AND executing — must
+    stay dead at the subprocess boundary itself."""
+
+    def test_hostile_id_cannot_execute_or_forge_resolution(self):
+        with tempfile.TemporaryDirectory() as t:
+            pwned = Path(t) / "PWNED"
+            hostile = f"X; touch {pwned}; exit 0"
+            state, _ = ing.check_item_resolution(
+                hostile, check_cmd="false {id}"
+            )
+            self.assertEqual(state, "open", "false must stay exit 1")
+            self.assertFalse(pwned.exists(), "the id executed as shell")
+
+    def test_the_id_arrives_as_the_first_positional_argument(self):
+        state, _ = ing.check_item_resolution(
+            "safe-id", check_cmd='test {id} = "safe-id"'
+        )
+        self.assertEqual(state, "resolved")
+        state, _ = ing.check_item_resolution(
+            "other", check_cmd='test {id} = "safe-id"'
+        )
+        self.assertEqual(state, "open")
 
 
 class TestSweepVerdicts(SweepBase):
@@ -573,6 +676,82 @@ class TestSweepVerdicts(SweepBase):
         d = self.make_packet("p")
         self.assertEqual(ing.find_packets(d), [d])
 
+    def test_a_bare_string_derived_item_is_coerced_not_a_crash(self):
+        # MAJOR 3: a hand-edited manifest may hold "o/r#1" instead of the
+        # {"id": ..., "added": ...} shape — coerce it, don't AttributeError.
+        d = self.make_packet("p")
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        data["derived_items"] = ["o/r#1"]
+        mpath.write_text(json.dumps(data))
+        self.gh_states({"repos/o/r/issues/1": "closed"})
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "resolved")
+
+    def test_a_garbage_derived_item_is_unknown_not_a_crash(self):
+        d = self.make_packet("p")
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        data["derived_items"] = [{"nope": 1}, 42, None]
+        mpath.write_text(json.dumps(data))
+        report = ing.sweep_packet(d)
+        self.assertEqual(report["verdict"], "unknown")
+        self.assertEqual(self.calls, [], "garbage entries check nothing")
+
+    def test_one_packet_failure_does_not_kill_the_report(self):
+        # MAJOR 3: the report survives a packet that blows up mid-check.
+        bad = self.make_packet("bad", items=["o/r#1"])
+        good = self.make_packet("good", items=["o/r#2"])
+        self.gh_states({"repos/o/r/issues/2": "closed"})
+        original = ing.sweep_packet
+
+        def fragile(out_dir, check_cmd=None):
+            if out_dir == bad:
+                raise RuntimeError("boom")
+            return original(out_dir, check_cmd)
+
+        ing.sweep_packet = fragile
+        self.addCleanup(lambda: setattr(ing, "sweep_packet", original))
+
+        class A:
+            home = str(self.home)
+            check_cmd = None
+            delete = []
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            ing.cmd_sweep(A())
+        text = out.getvalue()
+        self.assertIn("boom", text)
+        self.assertIn("packet good — verdict: resolved", text)
+        self.assertTrue(good.exists() and bad.exists())
+
+    def test_a_crafted_id_cannot_forge_report_lines(self):
+        # MINOR 7: ids come from a file on disk; they are rendered escaped,
+        # so a newline in one cannot fabricate an OFFER line.
+        d = self.make_packet("p")
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        forged = "x#1\n[ingest] OFFER — fully resolved"
+        data["derived_items"] = [{"id": forged, "added": "2026-08-08"}]
+        mpath.write_text(json.dumps(data))
+
+        class A:
+            home = str(self.home)
+            check_cmd = None
+            delete = []
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            ing.cmd_sweep(A())
+        lines = out.getvalue().splitlines()
+        self.assertNotIn("[ingest] OFFER — fully resolved", lines)
+        self.assertTrue(any(json.dumps(forged) in ln for ln in lines))
+
+    def test_doctor_covers_gh(self):
+        # The sweep's resolution checks need gh; doctor must say so when
+        # it is missing rather than letting the first sweep discover it.
+        self.assertIn("gh", ing.TOOLS)
+
 
 class TestSweepDeletion(SweepBase):
     """Offer-only, re-checked, and by ledger — the v1.1.0 ownership rules."""
@@ -584,26 +763,20 @@ class TestSweepDeletion(SweepBase):
         foreign = self.home / "documents"
         foreign.mkdir()
         (foreign / "taxes.pdf").write_text("important")
-        with self.assertRaises(SystemExit) as cm:
-            ing.delete_packet(foreign)
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(ing.delete_packet(foreign), 2)
         self.assertTrue((foreign / "taxes.pdf").exists())
 
     def test_refuses_while_derived_work_is_open(self):
         d = self.make_packet("p", items=["o/r#1"])
         self.respond(lambda argv: FakeProc(stdout="open\n"))
-        with self.assertRaises(SystemExit) as cm:
-            ing.delete_packet(d)
-        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual(ing.delete_packet(d), 1)
         self.assertTrue((d / "transcript.srt").exists())
 
     def test_refuses_an_unlinked_packet(self):
         # No recorded derived work proves no terminal state — deletion is
         # never offered off silence.
         d = self.make_packet("p")
-        with self.assertRaises(SystemExit) as cm:
-            ing.delete_packet(d)
-        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual(ing.delete_packet(d), 1)
         self.assertTrue(d.exists())
 
     def test_deletes_a_resolved_packet_by_ledger(self):
@@ -615,17 +788,25 @@ class TestSweepDeletion(SweepBase):
         m.data["frames"] = [{"file": "frames/ladder_00001.jpg", "ts": 0}]
         m.finish("frames", [frames / "ladder_00001.jpg"])
         self.all_closed()
-        ing.delete_packet(d)
+        self.assertEqual(ing.delete_packet(d), 0)
         self.assertFalse(d.exists(), "a fully-ledgered packet is removed")
 
-    def test_a_foreign_file_survives_and_keeps_the_directory(self):
+    def test_partial_deletion_keeps_the_packet_sweepable(self):
+        # BLOCKER 2: the kept directory (foreign files — e.g. a call run's
+        # saved recap email) keeps its marker and manifest, stays visible to
+        # find_packets, and is distinguishable from a refusal by exit code.
         d = self.make_packet("p", items=["o/r#1"],
-                             extra_files=["notes/my-own-notes.md"])
+                             extra_files=["notes/recap-email.md"])
         self.all_closed()
-        ing.delete_packet(d)
-        self.assertTrue((d / "notes" / "my-own-notes.md").exists())
-        self.assertTrue(d.exists(), "a dir still holding foreign files stays")
+        self.assertEqual(ing.delete_packet(d), 5)
+        self.assertTrue((d / "notes" / "recap-email.md").exists())
         self.assertFalse((d / "transcript.srt").exists())
+        self.assertTrue((d / ".ingest-run").exists(),
+                        "the marker is sweepability — never removed first")
+        self.assertTrue((d / "manifest.json").exists())
+        self.assertIn(d, ing.find_packets(self.home))
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "resolved",
+                         "the kept packet can still be swept and re-offered")
 
     def test_a_ledger_path_outside_the_packet_is_refused(self):
         d = self.make_packet("p", items=["o/r#1"])
@@ -636,6 +817,50 @@ class TestSweepDeletion(SweepBase):
         self.all_closed()
         ing.delete_packet(d)
         self.assertTrue(outsider.exists())
+
+    def test_a_ledgered_path_that_became_a_symlink_is_left_alone(self):
+        # MAJOR 6: the ledger recorded a file; a link in its place is not
+        # that file, and deletion never reaches through it.
+        d = self.make_packet("p", items=["o/r#1"])
+        precious = self.home / "precious.txt"
+        precious.write_text("irreplaceable")
+        srt = d / "transcript.srt"
+        srt.unlink()
+        srt.symlink_to(precious)
+        self.all_closed()
+        self.assertEqual(ing.delete_packet(d), 5)
+        self.assertTrue(precious.exists())
+        self.assertTrue(srt.is_symlink(), "the link itself is a leftover")
+        self.assertTrue((d / ".ingest-run").exists())
+
+    def test_symlink_to_a_directory_does_not_crash_deletion(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        target = self.home / "real-dir"
+        target.mkdir()
+        (target / "keep.txt").write_text("keep")
+        (d / "linked").symlink_to(target)
+        self.all_closed()
+        self.assertEqual(ing.delete_packet(d), 5)
+        self.assertTrue((target / "keep.txt").exists())
+        self.assertTrue((d / "linked").is_symlink())
+
+    def test_a_dangling_symlink_is_a_leftover_not_a_crash(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        (d / "dangling").symlink_to(self.home / "no-such-target")
+        self.all_closed()
+        self.assertEqual(ing.delete_packet(d), 5)
+        self.assertTrue((d / "dangling").is_symlink())
+        self.assertTrue((d / ".ingest-run").exists())
+
+    def test_a_pre_existing_empty_directory_is_not_pruned(self):
+        # MINOR 10: only directories the deletion itself emptied are pruned —
+        # an empty directory the decider made is not ours.
+        d = self.make_packet("p", items=["o/r#1"])
+        (d / "keep-me").mkdir()
+        self.all_closed()
+        self.assertEqual(ing.delete_packet(d), 5)
+        self.assertTrue((d / "keep-me").is_dir())
+        self.assertTrue((d / ".ingest-run").exists())
 
     def test_sweep_report_never_deletes(self):
         d = self.make_packet("p", items=["o/r#1"])
@@ -649,6 +874,64 @@ class TestSweepDeletion(SweepBase):
         ing.cmd_sweep(A())
         self.assertTrue(d.exists())
         self.assertTrue((d / "transcript.srt").exists())
+
+
+class TestSweepDeleteCli(SweepBase):
+    """--delete is bounded by --home, processes every target, and reports
+    an honest aggregate."""
+
+    def all_closed(self):
+        self.respond(lambda argv: FakeProc(stdout="closed\n"))
+
+    def run_sweep(self, home, deletes, check_cmd=None):
+        class A:
+            pass
+        A.home = str(home)
+        A.check_cmd = check_cmd
+        A.delete = list(deletes)
+        with self.assertRaises(SystemExit) as cm:
+            ing.cmd_sweep(A)
+        return cm.exception.code
+
+    def test_a_nonexistent_home_is_refused_before_any_deletion(self):
+        # MAJOR 5 (reproduced upstream): --home was ignored on the delete
+        # path — a bogus home plus an outside target still deleted.
+        d = self.make_packet("p", items=["o/r#1"])
+        self.all_closed()
+        code = self.run_sweep(self.home / "no-such-home", [str(d)])
+        self.assertEqual(code, 2)
+        self.assertTrue((d / "transcript.srt").exists(), "nothing deleted")
+
+    def test_a_target_outside_home_is_refused(self):
+        inside_home = self.home / "the-home"
+        inside_home.mkdir()
+        d = self.make_packet("p", items=["o/r#1"])   # NOT under the-home
+        self.all_closed()
+        code = self.run_sweep(inside_home, [str(d)])
+        self.assertEqual(code, 2)
+        self.assertTrue((d / "transcript.srt").exists())
+
+    def test_all_targets_processed_and_the_aggregate_is_honest(self):
+        # MINOR 11: a refused first target must not stop the second, and the
+        # exit code carries the worst outcome, not the last one.
+        good = self.make_packet("good", items=["o/r#1"])
+        foreign = self.home / "documents"
+        foreign.mkdir()
+        (foreign / "taxes.pdf").write_text("important")
+        self.all_closed()
+        code = self.run_sweep(self.home, [str(foreign), str(good)])
+        self.assertEqual(code, 2)
+        self.assertFalse(good.exists(), "the deletable target was processed")
+        self.assertTrue((foreign / "taxes.pdf").exists())
+
+    def test_all_targets_deleted_exits_zero(self):
+        a = self.make_packet("a", items=["o/r#1"])
+        b = self.make_packet("b", items=["o/r#2"])
+        self.all_closed()
+        code = self.run_sweep(self.home, [str(a), str(b)])
+        self.assertEqual(code, 0)
+        self.assertFalse(a.exists())
+        self.assertFalse(b.exists())
 
 
 if __name__ == "__main__":

--- a/skills/investigate/ingest/tests/test_ingest.py
+++ b/skills/investigate/ingest/tests/test_ingest.py
@@ -386,5 +386,270 @@ class TestManifestDurability(unittest.TestCase):
             )
 
 
+class FakeProc:
+    """A subprocess.CompletedProcess stand-in for mocked run_cmd calls."""
+
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class SweepBase(unittest.TestCase):
+    """Shared plumbing: a temp home, packet builders, and a run_cmd mock that
+    guarantees no test ever reaches gh or the network."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.calls = []
+        self._responder = lambda argv: FakeProc(
+            returncode=127, stderr="unexpected subprocess call in test"
+        )
+        original = ing.run_cmd
+
+        def fake_run(argv, timeout=None, **kw):
+            self.calls.append(argv)
+            return self._responder(argv)
+
+        ing.run_cmd = fake_run
+        self.addCleanup(lambda: setattr(ing, "run_cmd", original))
+
+    def respond(self, fn):
+        self._responder = fn
+
+    def make_packet(self, name, items=(), extra_files=()):
+        d = self.home / name
+        d.mkdir()
+        (d / ".ingest-run").write_text("created by ingest.py in test\n")
+        m = ing.Manifest(d, identity_hash="abc")
+        srt = d / "transcript.srt"
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nhi\n")
+        m.finish("transcribe", [srt])
+        for item in items:
+            m.data["derived_items"].append({"id": item, "added": "2026-08-08"})
+        m.save()
+        for rel in extra_files:
+            p = d / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x")
+        return d
+
+
+class TestDerivedItemsLink(SweepBase):
+    """Filing time is when the link is written — and only into our own dirs."""
+
+    def test_link_appends_id_and_date(self):
+        d = self.make_packet("p")
+        ing.main(["link", "--out", str(d), "--item", "owner/repo#12"])
+        items = json.loads((d / "manifest.json").read_text())["derived_items"]
+        self.assertEqual([i["id"] for i in items], ["owner/repo#12"])
+        self.assertRegex(items[0]["added"], r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_link_is_idempotent(self):
+        d = self.make_packet("p")
+        ing.main(["link", "--out", str(d), "--item", "owner/repo#12"])
+        ing.main(["link", "--out", str(d),
+                  "--item", "owner/repo#12", "--item", "owner/repo#13"])
+        items = json.loads((d / "manifest.json").read_text())["derived_items"]
+        self.assertEqual(
+            [i["id"] for i in items], ["owner/repo#12", "owner/repo#13"]
+        )
+
+    def test_link_refuses_a_directory_ingest_did_not_create(self):
+        foreign = self.home / "documents"
+        foreign.mkdir()
+        with self.assertRaises(SystemExit) as cm:
+            ing.main(["link", "--out", str(foreign), "--item", "o/r#1"])
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_manifest_defaults_derived_items(self):
+        m = ing.Manifest(self.home, identity_hash="abc")
+        self.assertEqual(m.data["derived_items"], [])
+
+
+class TestItemResolution(SweepBase):
+    """GitHub-first via gh; binding-doc command otherwise; never a guess."""
+
+    def test_closed_github_issue_is_resolved(self):
+        self.respond(lambda argv: FakeProc(stdout="closed\n"))
+        state, _ = ing.check_item_resolution("owner/repo#7")
+        self.assertEqual(state, "resolved")
+        self.assertEqual(
+            self.calls[0][:3], ["gh", "api", "repos/owner/repo/issues/7"]
+        )
+
+    def test_open_github_issue_is_open(self):
+        self.respond(lambda argv: FakeProc(stdout="open\n"))
+        self.assertEqual(ing.check_item_resolution("owner/repo#7")[0], "open")
+
+    def test_gh_failure_is_unknown_not_resolved(self):
+        self.respond(lambda argv: FakeProc(returncode=1, stderr="HTTP 404"))
+        state, why = ing.check_item_resolution("owner/repo#7")
+        self.assertEqual(state, "unknown")
+        self.assertIn("404", why)
+
+    def test_non_github_id_without_binding_asks_the_decider(self):
+        state, why = ing.check_item_resolution("JIRA-42")
+        self.assertEqual(state, "unknown")
+        self.assertIn("decider", why)
+        self.assertEqual(self.calls, [], "must not shell out with no binding")
+
+    def test_binding_doc_command_resolves_other_trackers(self):
+        self.respond(lambda argv: FakeProc(returncode=0))
+        state, _ = ing.check_item_resolution(
+            "JIRA-42", check_cmd="check-resolved {id}"
+        )
+        self.assertEqual(state, "resolved")
+        self.assertEqual(self.calls[0][-1], "check-resolved JIRA-42")
+
+    def test_binding_doc_exit_1_is_open_and_other_exits_are_unknown(self):
+        self.respond(lambda argv: FakeProc(returncode=1))
+        self.assertEqual(
+            ing.check_item_resolution("JIRA-42", check_cmd="c {id}")[0], "open"
+        )
+        self.respond(lambda argv: FakeProc(returncode=3))
+        self.assertEqual(
+            ing.check_item_resolution("JIRA-42", check_cmd="c {id}")[0],
+            "unknown",
+        )
+
+
+class TestSweepVerdicts(SweepBase):
+    """The verdict is what the offer hangs on: resolved may be offered,
+    open stays, unknown/unlinked go to the decider."""
+
+    def gh_states(self, mapping):
+        def responder(argv):
+            key = argv[2] if argv[0] == "gh" else None
+            state = mapping.get(key, "open")
+            return FakeProc(stdout=state + "\n")
+        self.respond(responder)
+
+    def test_all_items_closed_is_resolved(self):
+        d = self.make_packet("p", items=["o/r#1", "o/r#2"])
+        self.gh_states({"repos/o/r/issues/1": "closed",
+                        "repos/o/r/issues/2": "closed"})
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "resolved")
+
+    def test_one_open_item_keeps_the_packet(self):
+        d = self.make_packet("p", items=["o/r#1", "o/r#2"])
+        self.gh_states({"repos/o/r/issues/1": "closed",
+                        "repos/o/r/issues/2": "open"})
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "open")
+
+    def test_open_beats_unknown(self):
+        # A live item settles the question — no need to bother the decider
+        # about an unresolvable one in the same packet.
+        d = self.make_packet("p", items=["o/r#1", "JIRA-9"])
+        self.gh_states({"repos/o/r/issues/1": "open"})
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "open")
+
+    def test_unresolvable_item_is_unknown(self):
+        d = self.make_packet("p", items=["o/r#1", "JIRA-9"])
+        self.gh_states({"repos/o/r/issues/1": "closed"})
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "unknown")
+
+    def test_no_derived_items_is_unlinked_not_resolved(self):
+        d = self.make_packet("p")
+        report = ing.sweep_packet(d)
+        self.assertEqual(report["verdict"], "unlinked")
+        self.assertEqual(self.calls, [], "nothing to check, nothing called")
+
+    def test_unreadable_manifest_is_unknown(self):
+        d = self.make_packet("p")
+        (d / "manifest.json").write_text("{ torn")
+        self.assertEqual(ing.sweep_packet(d)["verdict"], "unknown")
+
+    def test_find_packets_goes_by_marker_not_name(self):
+        ours = self.make_packet("demo-run")
+        lookalike = self.home / "demo-run-2"
+        lookalike.mkdir()
+        (lookalike / "manifest.json").write_text("{}")
+        self.assertEqual(ing.find_packets(self.home), [ours])
+
+    def test_a_home_that_is_itself_a_packet_sweeps_as_one(self):
+        d = self.make_packet("p")
+        self.assertEqual(ing.find_packets(d), [d])
+
+
+class TestSweepDeletion(SweepBase):
+    """Offer-only, re-checked, and by ledger — the v1.1.0 ownership rules."""
+
+    def all_closed(self):
+        self.respond(lambda argv: FakeProc(stdout="closed\n"))
+
+    def test_refuses_a_directory_ingest_did_not_create(self):
+        foreign = self.home / "documents"
+        foreign.mkdir()
+        (foreign / "taxes.pdf").write_text("important")
+        with self.assertRaises(SystemExit) as cm:
+            ing.delete_packet(foreign)
+        self.assertEqual(cm.exception.code, 2)
+        self.assertTrue((foreign / "taxes.pdf").exists())
+
+    def test_refuses_while_derived_work_is_open(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        self.respond(lambda argv: FakeProc(stdout="open\n"))
+        with self.assertRaises(SystemExit) as cm:
+            ing.delete_packet(d)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertTrue((d / "transcript.srt").exists())
+
+    def test_refuses_an_unlinked_packet(self):
+        # No recorded derived work proves no terminal state — deletion is
+        # never offered off silence.
+        d = self.make_packet("p")
+        with self.assertRaises(SystemExit) as cm:
+            ing.delete_packet(d)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertTrue(d.exists())
+
+    def test_deletes_a_resolved_packet_by_ledger(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        m = ing.Manifest(d, identity_hash="abc")
+        frames = d / "frames"
+        frames.mkdir()
+        (frames / "ladder_00001.jpg").write_text("jpg")
+        m.data["frames"] = [{"file": "frames/ladder_00001.jpg", "ts": 0}]
+        m.finish("frames", [frames / "ladder_00001.jpg"])
+        self.all_closed()
+        ing.delete_packet(d)
+        self.assertFalse(d.exists(), "a fully-ledgered packet is removed")
+
+    def test_a_foreign_file_survives_and_keeps_the_directory(self):
+        d = self.make_packet("p", items=["o/r#1"],
+                             extra_files=["notes/my-own-notes.md"])
+        self.all_closed()
+        ing.delete_packet(d)
+        self.assertTrue((d / "notes" / "my-own-notes.md").exists())
+        self.assertTrue(d.exists(), "a dir still holding foreign files stays")
+        self.assertFalse((d / "transcript.srt").exists())
+
+    def test_a_ledger_path_outside_the_packet_is_refused(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        outsider = self.home / "not-the-packet.mp4"
+        outsider.write_text("someone else's file")
+        m = ing.Manifest(d, identity_hash="abc")
+        m.finish("fetch", [outsider])
+        self.all_closed()
+        ing.delete_packet(d)
+        self.assertTrue(outsider.exists())
+
+    def test_sweep_report_never_deletes(self):
+        d = self.make_packet("p", items=["o/r#1"])
+        self.all_closed()
+
+        class A:
+            home = str(self.home)
+            check_cmd = None
+            delete = []
+
+        ing.cmd_sweep(A())
+        self.assertTrue(d.exists())
+        self.assertTrue((d / "transcript.srt").exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/investigate/ingest/tests/test_ingest.py
+++ b/skills/investigate/ingest/tests/test_ingest.py
@@ -687,6 +687,19 @@ class TestSweepVerdicts(SweepBase):
         self.gh_states({"repos/o/r/issues/1": "closed"})
         self.assertEqual(ing.sweep_packet(d)["verdict"], "resolved")
 
+    def test_a_non_list_derived_items_is_unknown_not_a_crash(self):
+        # CodeRabbit (PR #135): derived_items: 42 raised TypeError in
+        # sweep_packet — malformed at the container level is unknown too.
+        d = self.make_packet("p")
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        data["derived_items"] = 42
+        mpath.write_text(json.dumps(data))
+        report = ing.sweep_packet(d)
+        self.assertEqual(report["verdict"], "unknown")
+        self.assertIn("not a list", report["note"])
+        self.assertEqual(self.calls, [], "nothing checkable, nothing called")
+
     def test_a_garbage_derived_item_is_unknown_not_a_crash(self):
         d = self.make_packet("p")
         mpath = d / "manifest.json"
@@ -851,6 +864,31 @@ class TestSweepDeletion(SweepBase):
         self.assertEqual(ing.delete_packet(d), 5)
         self.assertTrue((d / "dangling").is_symlink())
         self.assertTrue((d / ".ingest-run").exists())
+
+    def test_delete_on_a_non_list_derived_items_refuses_not_crashes(self):
+        # CodeRabbit (PR #135): --delete reached sweep_packet unguarded, so a
+        # hand-edited derived_items: 42 ended in a traceback, not a refusal.
+        d = self.make_packet("p")
+        mpath = d / "manifest.json"
+        data = json.loads(mpath.read_text())
+        data["derived_items"] = 42
+        mpath.write_text(json.dumps(data))
+        self.assertEqual(ing.delete_packet(d), 1)
+        self.assertTrue((d / "transcript.srt").exists())
+        self.assertTrue((d / ".ingest-run").exists())
+
+    def test_delete_refuses_when_assessment_itself_raises(self):
+        # Deletion without a verdict would be deletion without the offer.
+        d = self.make_packet("p", items=["o/r#1"])
+        original = ing.sweep_packet
+
+        def boom(out_dir, check_cmd=None):
+            raise RuntimeError("assessment exploded")
+
+        ing.sweep_packet = boom
+        self.addCleanup(lambda: setattr(ing, "sweep_packet", original))
+        self.assertEqual(ing.delete_packet(d), 1)
+        self.assertTrue((d / "transcript.srt").exists())
 
     def test_a_pre_existing_empty_directory_is_not_pruned(self):
         # MINOR 10: only directories the deletion itself emptied are pruned —

--- a/skills/run/to-tickets/SKILL.md
+++ b/skills/run/to-tickets/SKILL.md
@@ -62,6 +62,7 @@ Confirm the labels exist on the tracker before filing. A frontier query against 
 - Pass 2 ran: every ticket-blocker is a native edge, every non-ticket blocker is the `blocked` label, and no item carries both.
 - Every item is labeled, and every ready-labeled item could be handed to a stranger as-is.
 - The frontier query returns the items you expect to be takeable now — run it and read the result rather than assuming.
+- Every item filed from an [ingest](../../investigate/ingest/SKILL.md) evidence packet is recorded in that packet's `derived_items` — the `link` command from the recommendation ran at filing time.
 - Nothing filed is claimed, and every question that surfaced while slicing is recorded for the decider rather than resolved by you.
 
 ## Attribution

--- a/skills/run/to-tickets/SKILL.md
+++ b/skills/run/to-tickets/SKILL.md
@@ -31,7 +31,7 @@ Before Pass 1 files anything, put the slice list in front of the decider: each i
 
 Items need ids before they can reference each other, so filing is always two passes. Doing it in one produces edges pointing at numbers that do not exist yet.
 
-**Pass 1 — file the bodies** (the approved list, nothing else). Each item's body IS the spec, per the [work-item spec template](../../orient/setup/references/templates/issue-slice-spec.md) that setup seeds: destination, plan source, acceptance criteria, verification, out of scope. The **plan source** line is not optional — it links the primary source (the decision-map entry, the grilling verdict, the research findings) so review never relitigates a settled question.
+**Pass 1 — file the bodies** (the approved list, nothing else). Each item's body IS the spec, per the [work-item spec template](../../orient/setup/references/templates/issue-slice-spec.md) that setup seeds: destination, plan source, acceptance criteria, verification, out of scope. The **plan source** line is not optional — it links the primary source (the decision-map entry, the grilling verdict, the research findings) so review never relitigates a settled question. When items derive from an [ingest](../../investigate/ingest/SKILL.md) evidence packet, also run the `ingest.py link` command the recommendation handed you for each item as you file it — the packet's retention lifetime is measured by those links.
 
 **Pass 2 — wire the edges.** Add native dependency edges for every blocker that is itself a tracker item, using the recipe's database-id form:
 


### PR DESCRIPTION
Implements items 2–3 of #116 (with item 1's policy paragraph flipped to describe the real mechanism) and cuts **ingest v1.2.0** — the version bump is decider-approved and auto-release will tag from the changelog's v1.2.0 section on merge.

The mechanism: `manifest.json` gains `derived_items` (appended at filing time via `ingest.py link`), and `ingest.py sweep` checks each packet's derived work for resolution (GitHub-first via gh; binding-doc check command for other trackers; ask-don't-guess where unbound) and offers deletion of fully-resolved packets — offer-only, ledger-ruled, bounded to the swept home.

Process: built by delegated lane from the grilled, decider-confirmed design on #116; full adversarial CODE review with scratch-dir exploitation — verdict was MERGE-BLOCKING with two reproduced blockers (shell injection via item ids that could also forge a "resolved" verdict; deletion orphaning packets on the documented directory-kept path) plus 4 majors and 7 minors. All fixed in 42125de with a regression test per finding class (81 tests, up from 35, including a real-/bin/sh injection probe and raise-capable subprocess mocks). Both blocker fixes were then re-probed empirically by the original reviewer using its own exploits: cleared. Issue #116 closes with this.

Closes #116.
