### PR TITLE
terminology: agent-invoked / user-invoked, and a CI-enforced invocation classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Check bucket, marketplace, and router freshness
         run: python3 scripts/check_router_freshness.py
 
+      # The site's per-skill invocation classification (agent-invoked vs
+      # user-invoked, and the slash command for the user path) is derived from
+      # each SKILL.md's frontmatter; this fails the build when catalog.ts's
+      # INVOCATION map disagrees. See the script's docstring.
+      - name: Check invocation classification freshness
+        run: python3 scripts/check_invocation_freshness.py
+
       # The site is written from a private context repository. This fails the
       # build if a confidential name or any email address reaches site/src.
       # The forbidden terms are stored as salted digests, so the check itself

--- a/scripts/check_invocation_freshness.py
+++ b/scripts/check_invocation_freshness.py
@@ -52,6 +52,8 @@ def frontmatter(skill_md: Path) -> dict:
     lines = skill_md.read_text().splitlines()
     if not lines or lines[0].strip() != "---":
         return {}
+    if not any(line.strip() == "---" for line in lines[1:]):
+        return {}  # unclosed frontmatter: treat as none rather than swallow the body
     data = {}
     for line in lines[1:]:
         if line.strip() == "---":
@@ -103,7 +105,7 @@ def derive_expected(skills: dict, owners: dict) -> dict:
     aliased = {}  # reference slug -> alias command
     for slug, command in user_invoked.items():
         body = (skills[slug] / "SKILL.md").read_text()
-        for link in re.findall(r"\]\((\.\.?/[^)#]+SKILL\.md)\)", body):
+        for link in re.findall(r"\]\((\.\.?/[^)#\s]+SKILL\.md)(?:#[^)\s]*)?(?:\s+\"[^\"]*\")?\)", body):
             target = ((skills[slug] / link).resolve())
             for ref_slug, ref_dir in skills.items():
                 if ref_slug != slug and target == (ref_dir / "SKILL.md").resolve():

--- a/scripts/check_invocation_freshness.py
+++ b/scripts/check_invocation_freshness.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Invocation classification check (CI).
+
+`site/src/lib/catalog.ts` carries a hand-maintained INVOCATION map — for every
+promoted skill, who triggers it (`invokedBy`) and the slash command for the
+user path (`command`). The skills' frontmatter is the source of truth, so this
+check derives the expected values from each SKILL.md and fails when the map
+disagrees — the same posture as `check_router_freshness.py`: site and skills
+can never drift apart.
+
+Derivation, per promoted skill:
+
+  1. `disable-model-invocation: true` in its frontmatter → `invokedBy: "user"`,
+     `command: "/<plugin>:<slug>"` (the plugin that claims it in
+     `.claude-plugin/marketplace.json`).
+  2. No flag, but some user-invoked promoted skill's SKILL.md links to this
+     skill's SKILL.md (the thin-alias pattern: a user-invoked invoker pointing
+     at an agent-invoked reference skill) → `invokedBy: "either"`, `command`
+     is the alias's slash command.
+  3. Otherwise → `invokedBy: "agent"`, `command: null`.
+
+The map must list exactly the promoted skills — a missing or phantom entry is
+an error, as is any value disagreement. The checker parses the INVOCATION
+block line by line, so each entry stays on one line (catalog.ts says so too).
+
+Standard library only. Exit 0 = in agreement; exit 1 = drift, one line per
+problem.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / "skills"
+BUCKETS = SKILLS_DIR / "buckets.json"
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+CATALOG = ROOT / "site" / "src" / "lib" / "catalog.ts"
+
+ENTRY_RE = re.compile(
+    r'^\s*(?:"(?P<qslug>[\w-]+)"|(?P<slug>[\w-]+)):\s*'
+    r'\{\s*invokedBy:\s*"(?P<invoked>user|agent|either)",\s*'
+    r'command:\s*(?:null|"(?P<command>[^"]*)")\s*\},?\s*$'
+)
+
+errors = []
+
+
+def frontmatter(skill_md: Path) -> dict:
+    """The flat `key: value` pairs of the leading `---` block."""
+    lines = skill_md.read_text().splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    data = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        match = re.match(r"^([A-Za-z][\w-]*):\s*(.*)$", line)
+        if match:
+            data[match.group(1)] = match.group(2).strip().strip("\"'")
+    return data
+
+
+def promoted_skills() -> dict:
+    """slug -> skill directory, for every skill in a promoted bucket."""
+    buckets = json.loads(BUCKETS.read_text())["buckets"]
+    out = {}
+    for bucket in buckets:
+        if not bucket["promoted"]:
+            continue
+        bucket_dir = SKILLS_DIR / bucket["id"]
+        if not bucket_dir.is_dir():
+            continue
+        for entry in sorted(bucket_dir.iterdir()):
+            if entry.is_dir() and (entry / "SKILL.md").is_file():
+                out[entry.name] = entry
+    return out
+
+
+def plugin_owners() -> dict:
+    """slug -> claiming plugin name, from the Claude marketplace."""
+    marketplace = json.loads(MARKETPLACE.read_text())
+    owners = {}
+    for plugin in marketplace.get("plugins", []):
+        for raw in plugin.get("skills", []):
+            rel = (raw[2:] if raw.startswith("./") else raw).rstrip("/")
+            owners[rel.rsplit("/", 1)[-1]] = plugin.get("name", "<unnamed>")
+    return owners
+
+
+def derive_expected(skills: dict, owners: dict) -> dict:
+    """slug -> (invokedBy, command), from frontmatter plus the alias pattern."""
+    user_invoked = {}
+    for slug, skill_dir in skills.items():
+        data = frontmatter(skill_dir / "SKILL.md")
+        if data.get("disable-model-invocation", "").lower() == "true":
+            user_invoked[slug] = f"/{owners.get(slug, '?')}:{slug}"
+
+    # The alias pattern: a user-invoked skill whose SKILL.md links to another
+    # promoted skill's SKILL.md marks that reference skill "either" — invocable
+    # by the agent directly and by the user through the alias's command.
+    aliased = {}  # reference slug -> alias command
+    for slug, command in user_invoked.items():
+        body = (skills[slug] / "SKILL.md").read_text()
+        for link in re.findall(r"\]\((\.\.?/[^)#]+SKILL\.md)\)", body):
+            target = ((skills[slug] / link).resolve())
+            for ref_slug, ref_dir in skills.items():
+                if ref_slug != slug and target == (ref_dir / "SKILL.md").resolve():
+                    aliased[ref_slug] = command
+
+    expected = {}
+    for slug in skills:
+        if slug in user_invoked:
+            expected[slug] = ("user", user_invoked[slug])
+        elif slug in aliased:
+            expected[slug] = ("either", aliased[slug])
+        else:
+            expected[slug] = ("agent", None)
+    return expected
+
+
+def parse_catalog() -> dict:
+    """slug -> (invokedBy, command) as written in catalog.ts's INVOCATION map."""
+    text = CATALOG.read_text()
+    match = re.search(r"export const INVOCATION[^{]*\{(.*?)\n\};", text, re.DOTALL)
+    if match is None:
+        errors.append("site/src/lib/catalog.ts has no INVOCATION map")
+        return {}
+    found = {}
+    for line in match.group(1).splitlines():
+        if not line.strip() or line.strip().startswith(("//", "/*", "*")):
+            continue
+        entry = ENTRY_RE.match(line)
+        if entry is None:
+            errors.append(f"catalog.ts INVOCATION line not parseable: {line.strip()}")
+            continue
+        slug = entry.group("qslug") or entry.group("slug")
+        found[slug] = (entry.group("invoked"), entry.group("command"))
+    return found
+
+
+def main():
+    skills = promoted_skills()
+    expected = derive_expected(skills, plugin_owners())
+    actual = parse_catalog()
+
+    for slug in sorted(set(expected) - set(actual)):
+        errors.append(
+            f"'{slug}' is promoted but has no INVOCATION entry in catalog.ts — "
+            f"expected invokedBy '{expected[slug][0]}'"
+        )
+    for slug in sorted(set(actual) - set(expected)):
+        errors.append(
+            f"'{slug}' is in catalog.ts INVOCATION but is not a promoted skill — remove it"
+        )
+    for slug in sorted(set(expected) & set(actual)):
+        if expected[slug] != actual[slug]:
+            exp_by, exp_cmd = expected[slug]
+            act_by, act_cmd = actual[slug]
+            errors.append(
+                f"'{slug}': catalog.ts says invokedBy '{act_by}' command {act_cmd!r}, "
+                f"but frontmatter derives invokedBy '{exp_by}' command {exp_cmd!r}"
+            )
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}")
+        print(f"invocation freshness: {len(errors)} problem(s)")
+        return 1
+
+    counts = {}
+    for invoked_by, _ in expected.values():
+        counts[invoked_by] = counts.get(invoked_by, 0) + 1
+    summary = ", ".join(f"{k}:{n}" for k, n in sorted(counts.items()))
+    print(f"invocation freshness: OK ({len(expected)} skills — {summary})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_invocation_freshness.py
+++ b/scripts/check_invocation_freshness.py
@@ -77,6 +77,9 @@ def promoted_skills() -> dict:
         for entry in sorted(bucket_dir.iterdir()):
             if entry.is_dir() and (entry / "SKILL.md").is_file():
                 out[entry.name] = entry
+    if not out:
+        print("ERROR: no promoted skills found — an empty check is not a green check")
+        sys.exit(1)
     return out
 
 
@@ -105,7 +108,7 @@ def derive_expected(skills: dict, owners: dict) -> dict:
     aliased = {}  # reference slug -> alias command
     for slug, command in user_invoked.items():
         body = (skills[slug] / "SKILL.md").read_text()
-        for link in re.findall(r"\]\((\.\.?/[^)#\s]+SKILL\.md)(?:#[^)\s]*)?(?:\s+\"[^\"]*\")?\)", body):
+        for link in re.findall(r"\]\((\.\.?/[^)#\s]+SKILL\.md)(?:#[^)\s]*)?(?:\s+(?:\"[^\"]*\"|'[^']*'|\([^)]*\)))?\)", body):
             target = ((skills[slug] / link).resolve())
             for ref_slug, ref_dir in skills.items():
                 if ref_slug != slug and target == (ref_dir / "SKILL.md").resolve():

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -5,14 +5,58 @@ import { getBuckets, getSkills, type Bucket, type Skill } from "./skills";
  * and blurb all come from `skills/buckets.json`, so a skill's category is the
  * directory it sits in and there is no second list to keep in step.
  *
- * What stays hand-maintained here is the one thing a directory cannot express:
- * where each skill plots on the hero chart, and which handoffs to draw between
- * them. `assertComplete` fails the build when a skill has no plot position —
- * the same enforcement `scripts/check_router_freshness.py` applies to the
- * marketplace and the router.
+ * What stays hand-maintained here is what a directory cannot express: where
+ * each skill plots on the hero chart, which handoffs to draw between them, and
+ * who invokes each skill. `assertComplete` fails the build when a skill has no
+ * plot position or no invocation entry — the same enforcement
+ * `scripts/check_router_freshness.py` applies to the marketplace and the
+ * router, and `scripts/check_invocation_freshness.py` applies to INVOCATION.
  */
 
-export type Region = Bucket & { entries: Skill[] };
+/**
+ * Who triggers a skill. `agent` — the agent recognizes the situation and
+ * invokes it (the default; no frontmatter flag). `user` — it fires only when
+ * the user names it (`disable-model-invocation: true` in its frontmatter).
+ * `either` — an agent-invoked reference skill that also ships a thin
+ * user-invoked alias. `command` carries the slash command for the user path
+ * (e.g. "/team-workflow:grilling"); it is null for purely agent-invoked skills.
+ */
+export type InvokedBy = "user" | "agent" | "either";
+export type Invocation = { invokedBy: InvokedBy; command: string | null };
+
+/** A catalog entry: the generated Skill plus its hand-asserted invocation. */
+export type CatalogSkill = Skill & Invocation;
+
+export type Region = Bucket & { entries: CatalogSkill[] };
+
+/**
+ * Per-skill invocation, keyed by slug. Hand-maintained here like PLOT, but not
+ * hand-trusted: `scripts/check_invocation_freshness.py` derives the expected
+ * values from each SKILL.md's frontmatter and fails CI when this map disagrees,
+ * so the site and the skills can never drift apart. Keep each entry on one
+ * line — the checker parses this block.
+ */
+export const INVOCATION: Record<string, Invocation> = {
+  router: { invokedBy: "agent", command: null },
+  setup: { invokedBy: "agent", command: null },
+  "domain-memory": { invokedBy: "agent", command: null },
+  grilling: { invokedBy: "agent", command: null },
+  "advisory-board": { invokedBy: "agent", command: null },
+  "decision-map": { invokedBy: "agent", command: null },
+  ingest: { invokedBy: "agent", command: null },
+  research: { invokedBy: "agent", command: null },
+  "codebase-review": { invokedBy: "agent", command: null },
+  prototype: { invokedBy: "agent", command: null },
+  diagnose: { invokedBy: "agent", command: null },
+  implement: { invokedBy: "agent", command: null },
+  "to-tickets": { invokedBy: "agent", command: null },
+  wizard: { invokedBy: "agent", command: null },
+  orchestrate: { invokedBy: "agent", command: null },
+  "adversarial-review": { invokedBy: "agent", command: null },
+  handoff: { invokedBy: "agent", command: null },
+  "writing-for-agents": { invokedBy: "agent", command: null },
+  "writing-for-humans": { invokedBy: "agent", command: null },
+};
 
 /**
  * Plotted positions on the hero chart, in a 1000×520 viewBox. Left to right is
@@ -82,7 +126,7 @@ export const BEARINGS: Array<{ from: string; to: string; note: string }> = [
   { from: "writing-for-agents", to: "writing-for-humans", note: "human readers" },
 ];
 
-export type PlacedSkill = Skill & { region: Region };
+export type PlacedSkill = CatalogSkill & { region: Region };
 
 /**
  * A skill's region is settled by its directory, so the only thing left to check
@@ -108,6 +152,22 @@ function assertComplete(skills: Skill[]) {
     );
   }
 
+  const uninvoked = skills.filter((s) => !INVOCATION[s.slug]).map((s) => s.slug);
+  if (uninvoked.length) {
+    throw new Error(
+      `catalog.ts: ${uninvoked.join(", ")} ${uninvoked.length === 1 ? "has" : "have"} no ` +
+        "INVOCATION entry. Add one in src/lib/catalog.ts.",
+    );
+  }
+
+  const phantom = Object.keys(INVOCATION).filter((slug) => !known.has(slug));
+  if (phantom.length) {
+    throw new Error(
+      `catalog.ts: ${phantom.join(", ")} in INVOCATION but not in any promoted bucket — ` +
+        "remove the entry, or promote the skill.",
+    );
+  }
+
   const plotted = new Set(known);
   const dangling = BEARINGS.filter((b) => !plotted.has(b.from) || !plotted.has(b.to));
   if (dangling.length) {
@@ -119,8 +179,9 @@ function assertComplete(skills: Skill[]) {
 }
 
 export function getCatalog(): { regions: Region[]; skills: PlacedSkill[] } {
-  const skills = getSkills();
-  assertComplete(skills);
+  const bare = getSkills();
+  assertComplete(bare);
+  const skills: CatalogSkill[] = bare.map((s) => ({ ...s, ...INVOCATION[s.slug] }));
 
   const regions = getBuckets()
     .filter((b) => b.promoted)

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -10,6 +10,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Terminology: agent-invoked / user-invoked** (#144). The skill-mechanics
+  reference now says who actually triggers a skill: the invocation-mode section
+  and its table say "agent-invoked" and "user-invoked" instead of the old
+  model-/human-centred phrasings. The literal frontmatter key
+  `disable-model-invocation` is the harness's name and stays quoted as-is.
+
 - Cross-link to the new sibling skill **writing-for-humans** (#141): the intro
   now names when the other register applies — a document a human reads goes to
   the counterpart, not through these levers.

--- a/skills/author/writing-for-agents/references/skill-mechanics.md
+++ b/skills/author/writing-for-agents/references/skill-mechanics.md
@@ -21,18 +21,18 @@ The `Use when` clause is where the branches live. One trigger per branch; a run 
 
 Optional fields, used sparingly:
 
-- `disable-model-invocation: true` — the skill fires only when a human names it. Correct for skills whose whole value is a deliberate human act (a live interview, a wrap-up). Wrong for skills the agent should notice it needs.
-- `argument-hint` — the placeholder shown after the skill name for human-invoked skills.
+- `disable-model-invocation: true` — the skill fires only when the user names it. Correct for skills whose whole value is a deliberate human act (a live interview, a wrap-up). Wrong for skills the agent should notice it needs.
+- `argument-hint` — the placeholder shown after the skill name for user-invoked skills.
 
 ## Choosing the invocation mode
 
 | The skill should fire… | Mode |
 | --- | --- |
-| whenever the agent recognizes the situation | model-invocable (default) — spend the description on branch triggers |
-| only when a human decides it is time | `disable-model-invocation: true` — the description is a menu entry, and can be short |
-| both, through a thin human-facing alias | two skills: the reference skill model-invocable, plus a one-line invoker |
+| whenever the agent recognizes the situation | agent-invoked (default) — spend the description on branch triggers |
+| only when the user decides it is time | user-invoked (`disable-model-invocation: true`) — the description is a menu entry, and can be short |
+| both, through a thin user-facing alias | two skills: the reference skill agent-invoked, plus a one-line invoker |
 
-The third row is a real pattern, not a workaround: a reference skill holds the process and a short human-invoked skill exists purely so a person can name it. Keep the process in exactly one of them — the alias points, it does not restate.
+The third row is a real pattern, not a workaround: an agent-invoked reference skill holds the process and a short user-invoked skill exists purely so a person can name it. Keep the process in exactly one of them — the alias points, it does not restate.
 
 ## Buckets
 

--- a/skills/author/writing-for-agents/references/skill-mechanics.md
+++ b/skills/author/writing-for-agents/references/skill-mechanics.md
@@ -32,7 +32,7 @@ Optional fields, used sparingly:
 | only when the user decides it is time | user-invoked (`disable-model-invocation: true`) — the description is a menu entry, and can be short |
 | both, through a thin user-facing alias | two skills: the reference skill agent-invoked, plus a one-line invoker |
 
-The third row is a real pattern, not a workaround: an agent-invoked reference skill holds the process and a short user-invoked skill exists purely so a person can name it. Keep the process in exactly one of them — the alias points, it does not restate.
+The third row is a real pattern, not a workaround: an agent-invoked reference skill holds the process and a short user-invoked skill exists purely so a person can name it. Keep the process in exactly one of them — the alias points, it does not restate. That pointing link is also how the catalog reads the pattern: a SKILL.md link from a user-invoked skill to another promoted skill's SKILL.md is an alias claim (the target classifies as invocable either way), so a user-invoked skill that merely wants to mention a sibling links to its directory or names it in plain text, not its SKILL.md.
 
 ## Buckets
 


### PR DESCRIPTION
Closes #144. Part 1: prose sweep to the decider-set terminology — agent-invoked / user-invoked — with the harness's literal `disable-model-invocation` key kept verbatim where mechanics are taught. Part 2: every catalog entry gains `invokedBy: 'user' | 'agent' | 'either'` and `command: string | null` per the data contract agreed with the marketing lane, derived from frontmatter and enforced by a new CI check (scripts/check_invocation_freshness.py) so site and skills can never disagree. Today's derivation: all 19 skills agent-invoked.

Independent verification: full CI set green including the new check (1679+84 tests), negative test fails red with a precise diagnosis, site build green, sweep grep zero residuals. Adversarial review with exploitation mandate: no blockers; 2 repro-confirmed latent defects in the checker fixed in the final commit (alias-link regex now tolerates anchors/titles; unclosed frontmatter parses as none) and the alias-claim convention is now written into skill-mechanics so the heuristic is the recorded rule. writing-for-agents changelog under Unreleased, no version bumps.