### PR TITLE
team-workflow v1.4.0: the engineering hemisphere release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "name": "team-workflow",
       "source": "./",
       "strict": false,
-      "version": "1.3.0",
+      "version": "1.4.0",
       "description": "Fifteen skills that ship as one pack — a portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, per-repo institutional memory written as side effects of work, relentless grilling, decision maps, throwaway prototypes, autonomous research lanes, ticket filing, human-step wizards, session handoffs, an orchestration protocol for parallel lanes, a build discipline of seam-scoped test-first tracer slices, a disciplined bug-diagnosis loop where no fix ships without a named cause, an adversarial review that breaks changes before they ship, and a skeptic-verified state review of the codebase itself. Versioned together (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
       "license": "MIT",
       "skills": [

--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,6 +14,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.4.0] - 2026-08-08
+
 ### Added
 
 - **codebase-review** — the twelfth pack skill (#120): a state review of the codebase, the


### PR DESCRIPTION
The batch release the decider ordered after the chain: renames the pack changelog's Unreleased section to v1.4.0 (dated) and bumps the marketplace version 1.3.0 → 1.4.0. Merging auto-cuts `team-workflow/v1.4.0` from the changelog section (validated: `changelog_section.py team-workflow v1.4.0` resolves non-empty).

Ships everything staged since v1.3.0: codebase-review (#120), the fidelity-audit batch (#122), orchestrate archiving/titling (#123), domain-memory (#128), diagnose (#130), implement (#131), runner policy + parity reference (#134), setup audit mode (#133), and the terminology/classification work (#144). Decider-confirmed sequencing on the issues; release timing confirmed in-session.