### PR TITLE
Project-scoped skills marketplace settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "extraKnownMarketplaces": {
+    "timharris-skills": {
+      "source": {
+        "source": "github",
+        "repo": "timharris707/skills"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "team-workflow@timharris-skills": true,
+    "advisory-board@timharris-skills": true,
+    "ingest@timharris-skills": true,
+    "writing-for-agents@timharris-skills": true,
+    "writing-for-humans@timharris-skills": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 tmp/
 dist/
 .cache/
-.claude/
+.claude/*
+!.claude/settings.json
 
 # Python
 __pycache__/


### PR DESCRIPTION
Commits a project-scoped `.claude/settings.json` entry so any Claude profile opening this project gets the timharris707/skills marketplace registered (one trust prompt per profile) and the five plugins — team-workflow, advisory-board, ingest, writing-for-agents, writing-for-humans — enabled with auto-update.

Decider-requested (Tim, 2026-08-08).
