### PR TITLE
Trim four skill descriptions to identity + triggers

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -16,6 +16,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **setup, codebase-review, research** — description trims: the frontmatter description
+  is the only part of a skill loaded into every session, so it carries identity plus
+  `Use when` triggers and nothing else. Mechanism inventories (setup's binding list and
+  seed list, codebase-review's finder/skeptic/disposition pipeline, research's output
+  file location) moved out of the descriptions; the skill bodies already state them.
+  Triggers are unchanged. codebase-review keeps its "counterpart to adversarial-review"
+  clause — that one does routing work.
 - **orchestrate** — announce model and effort at lane launch and at review hand-off, read
   from a recorded source, never guessed (#156). Every launch announcement now carries the
   reasoning-effort level beside the runner and model §4 already required, and

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -9,6 +9,13 @@ versioned separately and do not replace the skill release version.
 
 ## [Unreleased]
 
+### Changed
+- **Description trimmed to identity + triggers.** The frontmatter description is loaded
+  into every session, so the per-mode explanations and the intake-process summary moved
+  out of it (the skill body already carries both). Trigger phrases are consolidated —
+  synonym runs collapsed, the provider cross-check folded into "cross-provider review" —
+  with no trigger situation dropped.
+
 ### Fixed
 - **Preflight no longer passes a signed-out CLI as GO.** The claude CLI answers any prompt with `Not logged in · Please run /login` on **stdout** and exits **0**, so every mechanical signal the classifier reads — exit code, non-empty output, clean stderr — looked healthy. A real run took consent, spent three other seats' tokens, and lost the claude seat at round 1 with `InvalidOutput`. Preflight now screens the smoke reply's text for signed-out tells and returns a labelled NO-GO carrying the adapter's auth hint. Scanning stdout is confined to the smoke path (a fixed `SMOKE_PROMPT`, so it cannot be poisoned by material under review) — the round classifiers still read stderr only, and only when no usable review came back.
 

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisory-board
-description: Convene a multi-model advisory board where subscription-backed Claude, Codex, Gemini, and Grok CLIs review the same material in one of three modes — Formal Board Review (independent first round, rebuttal, structured verdict), Roundtable (collaborative judgment and synthesis), or Competitive (rival proposals, critique, and voting) — opening with a mandatory guided intake that settles mode, seats, lenses, and effort with the user before anything runs. Use when the user asks for an advisory board, round table, panel, or idea tournament; a multi-model or multi-provider review; a skilled debate among models; an adversarial review or red-team of a plan, design, architecture, skill, document, decision, or strategy; an Anthropic/OpenAI/Google/xAI cross-check; or a consensus handoff from several frontier models.
+description: Convene a multi-model advisory board — subscription-backed Claude, Codex, Gemini, and Grok CLIs reviewing the same material in formal, roundtable, or competitive mode. Use when the user asks for an advisory board, roundtable, panel, or idea tournament; a multi-model or cross-provider review or debate; a red-team of a plan, design, decision, or document by several models; or a consensus handoff from several frontier models.
 ---
 
 # Advisory Board

--- a/skills/investigate/codebase-review/SKILL.md
+++ b/skills/investigate/codebase-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-review
-description: Run a state review of the codebase — the counterpart to adversarial-review's change review — lens-named finders, a built-in skeptic, a decider disposition loop. Use before building against an upcoming spec (make the change easy first), when lanes merged since the last review cross the repo's threshold, or when lanes or the orchestrator report the code fighting them.
+description: Run a state review of the codebase — the counterpart to adversarial-review's change review. Use before building against an upcoming spec (make the change easy first), when lanes merged since the last review cross the repo's threshold, or when lanes or the orchestrator report the code fighting them.
 ---
 
 # Codebase review

--- a/skills/investigate/research/SKILL.md
+++ b/skills/investigate/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Run an autonomous research lane against primary sources, ending in a cited findings file linked from the driving ticket — and, when the missing facts are human-held, a questionnaire. Use for investigations of vendor materials, regulations, upstream repos, recorded calls, or any fact-finding that should run fire-and-report.
+description: Run an autonomous research lane against primary sources, ending in cited findings — and, when the missing facts are human-held, a questionnaire. Use for investigations of vendor materials, regulations, upstream repos, recorded calls, or any fact-finding that should run fire-and-report.
 ---
 
 # Research

--- a/skills/orient/setup/SKILL.md
+++ b/skills/orient/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Once-per-repo binding interview for the team-workflow pack — scan the repo, confirm the mandatory bindings (tracker, verify commands, decider, binding-doc home), seed the anchor binding doc, templates, and the session-start handoff hook, and refresh idempotently on re-run. Use when installing the pack into a repo, updating an existing installation, or auditing a consuming repo's bindings for drift after a pack release (audit mode).
+description: Once-per-repo binding interview for the team-workflow pack — records how the pack composes with this repo and seeds the binding doc the other skills read. Use when installing the pack into a repo, refreshing an existing installation's bindings, or auditing a consuming repo for drift after a pack release (audit mode).
 ---
 
 # Setup


### PR DESCRIPTION
Every skill description loads into every session whether or not the skill runs — so a description that explains mechanism is context spent on nothing. Four descriptions had drifted that way: **advisory-board** explained all three modes with parentheticals plus the intake process, **setup** listed all four bindings and everything it seeds, **codebase-review** named its finder/skeptic/disposition pipeline, **research** located its output file. An agent deciding whether to pull a skill in needs none of that; the bodies already state it.

Each description now carries one identity sentence plus its `Use when` triggers. No trigger situation was dropped: advisory-board's synonym runs were consolidated (the Anthropic/OpenAI/Google/xAI cross-check folds into "cross-provider review"), and codebase-review keeps its "counterpart to adversarial-review" clause because that one does real routing work. Changelog entries staged under Unreleased in both changelogs; no version bump, so no release fires.

Prompted by Theo's skill-description lesson (descriptions are trigger surfaces, not explanations), which matches the house standard in writing-for-agents' skill-mechanics reference — this PR is the compliance pass.

Filed by Claude Fable 5 via Claude Code (orchestrator session).