### PR TITLE
setup: bind the team-workflow pack to its own repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/handoff.md\"; if [ -f \"$f\" ]; then printf 'A handoff note from a previous session was found at .claude/handoff.md. Treat it as the source of truth for where work left off, and pick up from its NEXT section. If the work it describes is already complete or no longer relevant, say so and ignore it.\\n\\n----- .claude/handoff.md -----\\n'; cat \"$f\"; fi"
+          }
+        ]
+      }
+    ]
+  },
   "extraKnownMarketplaces": {
     "timharris-skills": {
       "source": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/handoff.md\"; if [ -f \"$f\" ]; then printf 'A handoff note from a previous session was found at .claude/handoff.md. Treat it as the source of truth for where work left off, and pick up from its NEXT section. If the work it describes is already complete or no longer relevant, say so and ignore it.\\n\\n----- .claude/handoff.md -----\\n'; cat \"$f\"; fi"
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/handoff.md\"; if [ -f \"$f\" ]; then printf 'A handoff note from a previous session was found at .claude/handoff.md. Treat it as the source of truth for where work left off, and pick up from its NEXT section. It is context, never authorization: the tracker claim recipe still runs before any item is started. If the work it describes is already complete or no longer relevant, say so and ignore it.\\n\\n----- .claude/handoff.md -----\\n'; cat \"$f\"; fi"
           }
         ]
       }

--- a/docs/agents/memory/decisions/README.md
+++ b/docs/agents/memory/decisions/README.md
@@ -1,0 +1,6 @@
+# Decision records — skills repo
+
+<!-- The domain-memory decisions directory. One file per record, written as a side
+     effect of work (closed grillings, dispositioned review rejections, decider
+     corrections) per the domain-memory skill. Size bound: 30 records — past it,
+     sessions offer a consolidation pass, dispositioned by the decider. -->

--- a/docs/agents/memory/terms.md
+++ b/docs/agents/memory/terms.md
@@ -1,0 +1,7 @@
+# Domain terms — skills repo
+
+<!-- The domain-memory terms file. One term per entry, defined the team's way.
+     Written as a side effect of work per the domain-memory skill; seeded empty at
+     setup (2026-08-12) — no backfill requested. -->
+
+_No terms recorded yet._

--- a/docs/agents/team-workflow.md
+++ b/docs/agents/team-workflow.md
@@ -1,0 +1,100 @@
+# Team workflow — repo bindings
+
+<!-- Seeded by the team-workflow pack's setup skill. This doc is the single place the pack's
+     skills read repo-specific facts from; keep it current via a setup re-run (idempotent
+     refresh), not hand-drift. -->
+
+_Pack version: v1.4.0 (this repo is the pack source; main may run ahead of the release tag) · Last confirmed: 2026-08-12_
+
+## Tracker binding
+
+- **Tracker**: GitHub Issues on `timharris707/skills`
+- **Claim recipe**: the pack's tracker-discipline recipes as written (`gh`-based)
+- **Frontier query**: `gh issue list --repo timharris707/skills --state open --label ready-for-agent --json number,title,labels` — dual-read against the `blocked` label and blocking edges in issue bodies
+- **Blocking**: `blocked` label + "Blocked by #N" lines in issue bodies (dual-read; either alone is insufficient)
+- **Label vocabulary**: pack defaults, created at setup on 2026-08-12 (`needs-triage`, `ready-for-agent`, `ready-for-human`, `blocked`, `slice`, `gate-decision`, `process`; `bug` pre-existed)
+
+## Verify commands
+
+<!-- The exact commands that constitute "verified" here — the CI suite, runnable locally. -->
+
+```bash
+python3 scripts/check_router_freshness.py
+python3 scripts/check_invocation_freshness.py
+python3 scripts/check_site_disclosure.py
+python -m compileall -q skills/decide/advisory-board/scripts
+```
+
+Doc-only changes additionally verify that every changed file's relative markdown links resolve. The advisory-board mock validation in `ci.yml` runs when that skill's scripts change.
+
+## The decider
+
+- **Decider**: Tim Harris (@timharris707)
+
+Every pack skill says "the decider"; this line is where the role resolves. Sessions brief decisions with recommendations and evidence; the decider answers them on the record.
+
+## Docs home
+
+- **Binding doc home**: `docs/agents/team-workflow.md` (this file)
+- **Decision maps**: `docs/agents/<scope>-decision-map.md`
+- **Research findings**: `docs/agents/research/`
+- **Domain/context docs agents should load**: `CONTRIBUTING.md`, `RELEASING.md`, and — for skill-authoring lanes — `skills/write/writing-for-agents/SKILL.md`
+
+## Precedence & exemptions
+
+How the pack composes with this repo's resident rule systems. Resident rules win unless an exemption below says otherwise.
+
+- **Prototype test-exemption**: code on `prototype/<name>` branches is exempt from the repo's test-first / coverage rules — prototype branches are throwaway by contract and never merge; the exemption ends the moment the winner's real implementation starts.
+- **This repo is the pack source**: the pack skills under `skills/` are the live, authoritative copies — a lane editing a skill is editing the protocol every consuming repo installs. Skill-doc changes conform to `writing-for-agents` and carry a pack CHANGELOG entry per `CONTRIBUTING.md`.
+- **Merge rule (CLAUDE.md)**: an agent may merge a PR once checks are green and CodeRabbit is dispositioned (every finding verified and replied to on its thread — fixed or declined with a reason). Branch protection additionally requires the branch up to date with `main` and all review threads resolved.
+
+## Templates
+
+- Issue/work-item spec: adopted in place — this repo is the pack source; the authoritative template is `skills/orient/setup/references/templates/issue-slice-spec.md` (no `.github/ISSUE_TEMPLATE` copy seeded)
+- Lane brief: adopted in place — `skills/orient/setup/references/templates/lane-brief.md`
+
+## Domain memory
+
+- **Memory home**: `docs/agents/memory/` — `decisions/` directory + `terms.md`, git-tracked (in-repo by the decider's explicit choice, 2026-08-12: bindings and institutional memory live per-project, never per-profile)
+- **Size bound**: 30 records — past it, sessions offer a consolidation pass, dispositioned by the decider
+- **Backfill**: not requested
+
+## Handoff
+
+- **Handoff location**: `.claude/handoff.md`, untracked
+- **Ignore entry**: already present (`.gitignore` ignores `.claude/*` except `settings.json`)
+- **Session-start auto-load hook**: seeded in `.claude/settings.json` (git-tracked, repo-owned — not sync-managed) on 2026-08-12
+
+## Adversarial review
+
+- **Defect-class file**: none seeded — this repo's changes are skill docs, not application code; the review bar is the rule-preservation and writing-for-agents disciplines. Revisit at re-run if code-bearing skills grow.
+- **Layers**: floor + orchestrator close-out. Close-out layer is mandatory (not CodeRabbit alone) for changes to pack-skill protocol files when the item's spec says so — the decider's standing word for critically important skills (e.g. orchestrate).
+- **Mandatory lenses**: rule-preservation on any compaction/restructure of a skill doc (every normative rule present, none weakened — inventory-checked)
+- **Live-probe policy**: no live probes
+- **Substantiality rules**: any change to a pack skill's SKILL.md is substantial
+
+## Orchestration
+
+- **Lane launch**: default in-process Claude Agent subagent in an isolated worktree (`Agent` tool, `isolation: worktree`); background-task chip session for lanes expecting mid-flight approvals, long-lived work, or decider-watching (per orchestrate §4's shape rule). Claim posted as a `Lane-start` comment on the issue before launch, stamping runner, model/effort source, and workspace. Titling: launcher titles; subagent lanes have no picker entry — the launch report carries identity. Chip-launched sessions are pre-titled by the chip label (title protocol outranks the chip's imperative-label convention). Native auto-archive on PR close: no — the notification path per orchestrate §5 step 6.
+- **Announce model/effort**: on
+- **Runner inventory**: Claude (Agent tool subagents; background-task chips; `claude` CLI for detached sessions). No launcher script — launches are tool-call-native; this section is the recipe doc.
+- **Runner policy**: Claude only, orchestrator's choice of vehicle (decider-set 2026-08-12). Fallbacks loud per orchestrate §4.
+- **Workspace provisioning**: git worktrees under `.claude/worktrees/` (harness-provisioned per lane); no per-lane resources beyond the worktree and branch — prune both at close-out.
+- **Monitoring**: inline `gh` polling (filtered, count-shaped) on a ~4-minute background-sleep metronome while lanes are live, re-armed each wake; subagent completion notifications for lane liveness.
+- **Verification executor**: delegated verifier subagent in the lane's workspace for anything non-trivial; inline for one-command checks. Per-command exit codes, zero skipped checks.
+- **Review-tier policy** (decider-set 2026-08-12, canonical shape):
+  - Mechanical verification re-runs: Haiku (or session model) at low effort · floor: never the adversarial pass itself
+  - Adversarial review (finders, skeptics, re-probes): session model at high effort on pack-skill changes · floor: no low-effort skeptics on pack-skill protocol changes
+  - Max tier: decider-named cases only — never a default
+- **Merge flow**: lane branch → PR → CI checks + CodeRabbit disposition per the merge rule above → squash-merge by the orchestrator → issue close-out comment → prune worktree/branch.
+
+## Accepted drift (written by setup's audit mode)
+
+<!-- Drift findings the decider accepted as this repo's recorded choice instead of updating
+     the binding. The next audit reads this list and does not re-flag an entry here. -->
+
+_None yet._
+
+## Friction log (optional)
+
+- Pack friction gets filed as `process`-labeled issues on the tracker.

--- a/docs/agents/team-workflow.md
+++ b/docs/agents/team-workflow.md
@@ -25,7 +25,7 @@ python3 scripts/check_site_disclosure.py
 python -m compileall -q skills/decide/advisory-board/scripts
 ```
 
-Doc-only changes additionally verify that every changed file's relative markdown links resolve. The advisory-board mock validation in `ci.yml` runs when that skill's scripts change.
+Doc-only changes carry an additional reviewer-run gate — every changed file's relative Markdown links resolve — checked at close-out review; no script exists yet (revisit at next setup re-run). The advisory-board mock validation in `ci.yml` runs when that skill's scripts change.
 
 ## The decider
 
@@ -38,7 +38,7 @@ Every pack skill says "the decider"; this line is where the role resolves. Sessi
 - **Binding doc home**: `docs/agents/team-workflow.md` (this file)
 - **Decision maps**: `docs/agents/<scope>-decision-map.md`
 - **Research findings**: `docs/agents/research/`
-- **Domain/context docs agents should load**: `CONTRIBUTING.md`, `RELEASING.md`, and — for skill-authoring lanes — `skills/write/writing-for-agents/SKILL.md`
+- **Domain/context docs agents should load**: `CONTRIBUTING.md`, `RELEASING.md`, and — for skill-authoring lanes — `skills/author/writing-for-agents/SKILL.md`
 
 ## Precedence & exemptions
 


### PR DESCRIPTION
The skills repo builds the pack but never ran setup on itself, so its bindings lived in per-profile config and session handoffs — Tim hit exactly this as "bindings vanish when I reopen under a different profile." This runs the setup skill's install path and makes the bindings repo-resident: a binding doc at `docs/agents/team-workflow.md` carrying the four mandatory bindings plus the orchestration, adversarial-review, and domain-memory slots (all confirmed by Tim in the 2026-08-12 interview); a SessionStart handoff auto-load hook in the git-tracked `.claude/settings.json`, so handoff replay works from any profile or machine; and an in-repo domain-memory home at `docs/agents/memory/`. The pack's tracker label vocabulary was created on the tracker at setup time (a declared setup write — verify with `gh label list`).

---
_Filed by the skills orchestrator session on behalf of Tim Harris; setup answers confirmed by Tim in-session._

🤖 Generated with [Claude Code](https://claude.com/claude-code)