### PR TITLE
site: derive the pack/standalone badge from the marketplace manifest

### DIFF
--- a/site/src/components/Regions.tsx
+++ b/site/src/components/Regions.tsx
@@ -2,14 +2,6 @@ import Link from "next/link";
 import { summarize } from "@/lib/skills";
 import type { Region } from "@/lib/catalog";
 
-const SHIPS_AS: Record<string, string> = {
-  "team-workflow": "pack",
-  "advisory-board": "standalone",
-  "writing-for-agents": "standalone",
-  "writing-for-humans": "standalone",
-  "ingest": "standalone",
-};
-
 export default function Regions({ regions }: { regions: Region[] }) {
   return (
     <div className="shell regions" id="catalog">
@@ -28,7 +20,7 @@ export default function Regions({ regions }: { regions: Region[] }) {
               <li className="entry" key={skill.slug}>
                 <Link className="entry__link" href={`/skills/${skill.slug}`}>
                   <span className="entry__name">{skill.name}</span>
-                  <span className="entry__ships">{SHIPS_AS[skill.plugin] ?? skill.plugin}</span>
+                  <span className="entry__ships">{skill.shipsAs}</span>
                   <p className="entry__what">{summarize(skill.description)}</p>
                 </Link>
               </li>

--- a/site/src/lib/skills.ts
+++ b/site/src/lib/skills.ts
@@ -30,6 +30,12 @@ export type Skill = {
   /** The plugin that ships it, from marketplace.json. */
   plugin: string;
   pluginVersion: string;
+  /**
+   * "pack" when its plugin ships more than one skill, "standalone" when it
+   * ships alone — derived from the plugin's own skill count, so a plugin
+   * cannot claim a skill without its badge coming out correct.
+   */
+  shipsAs: "pack" | "standalone";
   /** Files beside SKILL.md — references/, scripts/, agents/. */
   extras: string[];
   githubUrl: string;
@@ -166,6 +172,7 @@ export function getSkills(): Skill[] {
         bucket: bucket.id,
         plugin: owner?.name ?? "unpublished",
         pluginVersion: owner?.version ?? "",
+        shipsAs: (owner?.skills.length ?? 0) > 1 ? "pack" : "standalone",
         extras: listExtras(dir),
         githubUrl: `https://github.com/timharris707/skills/blob/main/${rel}/SKILL.md`,
       });


### PR DESCRIPTION
Claude Fable 5 responding on behalf of Tim Harris:

Closes #147.

The catalog badge saying whether a skill ships standalone or in the team-workflow pack came from a hand-kept SHIPS_AS map in Regions.tsx — every new skill needed a manual entry, and a missed one rendered a wrong badge (writing-for-humans and ingest both just did). That is the exact hand-kept-list drift the site's own rules warn against.

The badge now derives at build time from `.claude-plugin/marketplace.json`, which already records each skill's owning plugin: a plugin shipping more than one skill renders "pack", one skill renders "standalone". SHIPS_AS is deleted, so adding a skill to the manifest is sufficient for its badge to be correct and a manifest/badge mismatch is impossible by construction — the same no-drift principle as the flip toggle (#139).

Verified: site build green (146 pages, full type-check), disclosure + router freshness checks green, and a three-skill spot-check of built HTML against the manifest (router → pack; advisory-board, ingest → standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)