### PR TITLE
ingest: preview claims its own run directory so run can adopt it

### DIFF
--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the **ingest** skill. Versioned as a standalone plugin
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`preview` can now be followed by `run` in the same `--out` directory**
+  (issue #160). `preview` created its run directory with a plain `mkdir`
+  and never wrote the `.ingest-run` adoption marker, so a same-directory
+  `run` afterwards was refused as a foreign non-empty directory (exit 2) —
+  breaking the preview-then-run flow SKILL.md describes. `preview` now
+  claims its directory through `claim_out_dir`, the same ownership path
+  `run` uses, so it writes the marker itself; a genuinely foreign non-empty
+  directory is still refused.
+
 ## [v1.2.0] - 2026-08-07 — Packets that know their work and offer their own cleanup
 
 ### Added

--- a/skills/investigate/ingest/scripts/ingest.py
+++ b/skills/investigate/ingest/scripts/ingest.py
@@ -1383,7 +1383,7 @@ def main(argv=None) -> None:
         sys.exit(0 if doctor() else 3)
     elif args.cmd == "preview":
         out_dir = Path(args.out).expanduser()
-        out_dir.mkdir(parents=True, exist_ok=True)
+        claim_out_dir(out_dir)
         got = captions_preview(args.url, out_dir, Manifest(out_dir))
         sys.exit(0 if got else 1)
     elif args.cmd == "run":

--- a/skills/investigate/ingest/tests/test_ingest.py
+++ b/skills/investigate/ingest/tests/test_ingest.py
@@ -122,6 +122,49 @@ class TestOutDirOwnership(unittest.TestCase):
             ing.claim_out_dir(d)      # a second run reuses its own dir
 
 
+class TestPreviewMarksItsOwnDirectory(unittest.TestCase):
+    """Issue #160: `preview --out DIR` created DIR without the adoption
+    marker, so a same-dir `run --out DIR` afterwards was refused by
+    claim_out_dir as a foreign non-empty directory. preview must claim the
+    directory itself so the preview-then-run flow SKILL.md describes works,
+    while a genuinely foreign non-empty directory stays refused."""
+
+    def setUp(self):
+        original = ing.run_cmd
+        # No network: yt-dlp is mocked to "no captions available" so the
+        # test exercises directory ownership, not the caption pipeline.
+        ing.run_cmd = lambda argv, timeout=None, **kw: __import__(
+            "subprocess"
+        ).CompletedProcess(argv, 1, stdout="", stderr="")
+        self.addCleanup(lambda: setattr(ing, "run_cmd", original))
+
+    def test_preview_writes_the_marker_so_run_can_adopt_the_directory(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t) / "packet"
+            with self.assertRaises(SystemExit):
+                ing.main(["preview", "--url", "https://example.com/v",
+                          "--out", str(d)])
+            self.assertTrue(
+                (d / ".ingest-run").exists(),
+                "preview must mark the directory it creates",
+            )
+            # A subsequent `run --out` on the same dir must adopt it, not
+            # refuse it (the bug: exit 2, "not empty and was not created by
+            # ingest").
+            ing.claim_out_dir(d)
+
+    def test_preview_still_refuses_a_foreign_non_empty_directory(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t) / "my-documents"
+            d.mkdir()
+            (d / "taxes.pdf").write_text("important")
+            with self.assertRaises(SystemExit) as cm:
+                ing.main(["preview", "--url", "https://example.com/v",
+                          "--out", str(d)])
+            self.assertEqual(cm.exception.code, 2)
+            self.assertTrue((d / "taxes.pdf").exists())
+
+
 class TestRetention(unittest.TestCase):
     """Deletion is by ledger, never by directory name."""
 


### PR DESCRIPTION
Claude Fable 5 responding on behalf of Tim Harris:

Closes #160.

`ingest.py preview --out DIR` created DIR with a bare `mkdir()` and never wrote the `.ingest-run` adoption marker, so the documented preview-then-run flow on the same directory died at `run` with "not empty and was not created by ingest" (exit 2). Hit live on the first real ingest run in a consuming repo.

The fix routes preview's directory creation through the same `claim_out_dir()` helper that `run`, `link`, and `sweep` already trust — one changed line, no new whitelist logic, and the refusal-to-adopt safety rule is untouched (a genuinely foreign non-empty directory is still refused, covered by a test). A pinned regression test was confirmed red against the unfixed code and green after; the full ingest suite passes (86 tests). Changelog entry added under ingest's [Unreleased] per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)