### PR TITLE
docs: drop stale pack roster, align CONTRIBUTING's version-bump step with staged releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,9 @@ Buckets are declared in [`skills/buckets.json`](./skills/buckets.json), and each
 **Start a new skill in `in-progress/`.** It is a real directory with a real `SKILL.md`, it just isn't claimed by any plugin and isn't listed anywhere. When it earns its place:
 
 1. `git mv skills/in-progress/<name> skills/<bucket>/<name>`
-2. Claim it in `.claude-plugin/marketplace.json` and bump that plugin's version
+2. Claim it in `.claude-plugin/marketplace.json`; the version bump itself happens later, in the
+   release commit per [`RELEASING.md`](./RELEASING.md)'s per-PR habit (bump + changelog section
+   rename together) — bumping here without that changelog section would fail auto-release
 3. Add it to `.codex-plugin/plugin.json` so Codex ships it too
 4. Write `agents/openai.yaml` with a `display_name` and `short_description`
 5. Add it to the router roster if it joins the `team-workflow` pack

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,9 +27,8 @@ Pushing a version tag by hand still works and triggers
   explicit flags; and **patch** for backward-compatible fixes. Model and artifact schema versions
   such as `advisory-board/verdict@N` are separate axes and do not replace the skill version.
 - **Packs:** skills that ship and version **together** release under one **pack-scoped tag**
-  instead of per-skill tags. The `team-workflow` pack (router, setup, grilling, decision-map,
-  prototype, research, to-tickets, wizard, handoff, orchestrate) releases as `team-workflow/vX.Y.Z`
-  with one changelog at [`packs/team-workflow/CHANGELOG.md`](packs/team-workflow/CHANGELOG.md).
+  instead of per-skill tags. The `team-workflow` pack releases as `team-workflow/vX.Y.Z` with one
+  changelog at [`packs/team-workflow/CHANGELOG.md`](packs/team-workflow/CHANGELOG.md).
   A pack is not a skill, so its changelog lives outside `skills/`. Individual pack skills never get
   their own tags. The pack's plugin `version` in
   [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) mirrors the latest pack tag;


### PR DESCRIPTION
Claude Fable 5 responding on behalf of Tim Harris:

Closes #136.

Two doc-truth fixes from the batch that issue records. RELEASING.md's illustrative pack-roster parenthetical was missing four newer skills and is a fourth roster copy nobody should maintain — dropped entirely, per the review recommendation that surfaced it. CONTRIBUTING.md's promotion step said to bump the plugin version in the promotion PR, which contradicts RELEASING.md and auto-release.yml where the bump IS the release decision — the step now defers the bump to the release commit.

The issue's README item needed no edit: commit 9723791 already replaced the stale plugin enumeration with a non-enumerating comment. The graph-engineering.md stale-counts item is deliberately not touched — it is a decider call, reported on the issue with a recommendation (routine survey re-check in place, not a Correction note).

Verified: router/invocation freshness, site disclosure, and advisory-board compileall all green; every relative link in both changed files resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)