### PR TITLE
adversarial-review: sequential finder passes when the review runs as a delegated subagent

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -130,6 +130,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **adversarial-review** — finder execution shape follows where the review runs (#154).
+  Observed twice in one overnight session: a close-out review delegated to a subagent
+  spawned its isolated finder subagents and stalled waiting for them — nested subagents'
+  completions do not re-invoke a parent subagent in that harness shape. §2 now records the
+  rule: a reviewer in the harness's main loop launches finders as parallel subagents; a
+  review that itself runs as a delegated subagent runs the finder passes sequentially in
+  one context, keeping isolation between passes (fresh perspective per pass, no shared
+  candidate list until the skeptic) rather than between processes.
+
 - **orchestrate** — compaction pass (#180). Tim's verdict after the size check: SKILL.md had
   grown to 4,151 words — second-largest skill in the repo, 2.5× the pack median — with titling
   rules spread across §3/§4/§6/§7 and roughly a third of the word count being measured-incident

--- a/skills/run/adversarial-review/SKILL.md
+++ b/skills/run/adversarial-review/SKILL.md
@@ -18,7 +18,7 @@ Read the team-workflow binding doc first. The review runs **before external revi
 
 ## 2. Composition: three finders, isolated
 
-Three reviewers, run as parallel subagents that **never see each other's reasoning** — isolation is what makes agreement between finders meaningful. Each loads the diff, the repo's defect-class checklist (§5), the repo's decision records where [domain-memory](../../orient/domain-memory/SKILL.md) is bound, and nothing of the others' output.
+Three reviewers that **never see each other's reasoning** — isolation is what makes agreement between finders meaningful. Each loads the diff, the repo's defect-class checklist (§5), the repo's decision records where [domain-memory](../../orient/domain-memory/SKILL.md) is bound, and nothing of the others' output. The execution shape follows where the review runs: a reviewer in the harness's main loop launches the finders as parallel subagents, whose completions re-invoke it; a review that itself runs as a delegated subagent runs the finder passes **sequentially in one context** — nested subagents' completions do not re-invoke a parent subagent, so a spawn-and-wait reviewer there stalls. Sequential passes keep the isolation between passes rather than between processes: a fresh perspective per pass, no shared candidate list until the skeptic.
 
 1. **The correctness finder** — logic, edge cases, error paths, invariants; the defect-class checklist is its opening moves, not its limit.
 2. **The fitting lens** — one perspective chosen to match the change, from the menu:


### PR DESCRIPTION
Claude Fable 5 responding on behalf of Tim Harris:

Closes #154.

A review delegated to a background subagent that spawns its finders as nested subagents stalls: nested completions don't re-invoke a parent subagent, so the reviewer stops to "wait for reports" that can never wake it. Observed twice in one overnight session; both times the sequential fallback produced a full, sound review.

The composition section now ties execution shape to where the review runs: a main-loop reviewer launches parallel finder subagents; a delegated reviewer runs the finder passes sequentially in one context — isolation between passes (fresh perspective per pass, no shared candidate list until the skeptic) rather than between processes. No other rules touched; pack CHANGELOG entry added.

The lane ran the adversarial-review floor on its own diff (sequentially, per this very finding): two finder passes plus a skeptic, one MINOR fixed pre-commit, zero blockers. Repo verify commands all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)