### PR TITLE
codebase-review: five refinements from the insight-chat pilot

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -16,6 +16,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **codebase-review** — five refinements from the insight-chat pilot (#129), the skill's
+  first real run: the lane shapes candidates before the skeptic — convergent findings merge
+  into one candidate with the convergence recorded as evidence, bundled claims split, one
+  claim per candidate stated explicitly, one skeptic per candidate; partial kills fold the
+  skeptic's corrections into the survivor's write-up so the decider reads skeptic-hardened
+  claims; the skeptic reproduces the claimed behavior read-only where possible; and a
+  first-run-without-bindings degrade — the executor creates the tracker item itself and the
+  report names the unbound slots.
+
 - **orchestrate** — on-behalf comment formatting (#179). Tim's formatting request, promoted
   from one repo's local preference to the pack: any tracker-visible comment an agent writes
   on a human's behalf (PR comments, review-thread replies, issue close-outs — not just PR

--- a/skills/investigate/codebase-review/SKILL.md
+++ b/skills/investigate/codebase-review/SKILL.md
@@ -33,11 +33,13 @@ Finder agents run as parallel subagents that never see each other's output — i
 - **boundaries-vs-reality** — the declared module layout versus how change actually flows: imports that cross seams, layers honored in the diagram and bypassed in the code.
 - **test-pain** — code that can only be tested past its interface, and the setup-heavy tests that prove it.
 
+**The lane shapes candidates before any skeptic sees them, one claim per candidate, stated explicitly.** Convergent findings — lenses landing on the same code — merge into one candidate, with the convergence recorded as evidence; bundled claims split into one candidate each. One skeptic per candidate.
+
 Finders and the skeptic speak the shared design vocabulary — depth, seams, locality, the deletion test — defined in [references/design-vocabulary.md](references/design-vocabulary.md); every claim in the report is phrased in those terms, in the codebase's own domain names.
 
 ## 3. The skeptic
 
-A finder's candidate is a hypothesis. **Every candidate goes to a built-in skeptic whose brief is to kill it before the report exists** — a separate agent in its own context, handed the candidate and its evidence and nothing of the finder's reasoning, so the kill attempt starts from the code rather than from the argument: re-read the code, find the second caller that makes the "duplicate" a real seam, the constraint that explains the "shallow" wrapper, the test that already covers the pain. Only candidates the skeptic fails to kill reach the report.
+A finder's candidate is a hypothesis. **Every candidate goes to a built-in skeptic whose brief is to kill it before the report exists** — a separate agent in its own context, handed the candidate and its evidence and nothing of the finder's reasoning, so the kill attempt starts from the code rather than from the argument: re-read the code, reproduce the claimed behavior read-only where possible, find the second caller that makes the "duplicate" a real seam, the constraint that explains the "shallow" wrapper, the test that already covers the pain. Only candidates the skeptic fails to kill reach the report. A kill can be partial — where the skeptic kills legs but the core stands, the corrections fold into the survivor's write-up, so the decider reads skeptic-hardened claims, not finder enthusiasm.
 
 Survival is the only grade. A finder ranking its own findings — strong, worth exploring, speculative — is grading its own homework; the skeptic's failed kill is evidence, a badge is a mood.
 
@@ -66,6 +68,8 @@ The run's tracker item closes only when nothing is undispositioned.
 - **Lane-count threshold (N)** — merged lanes since the last review that open gate 2.
 - **Rejection memory** — where rejected candidates and their load-bearing reasons live. In repos also bound to [domain-memory](../../orient/domain-memory/SKILL.md), this slot points at its memory home and rejections land as decision records there — one store, never two.
 - **Executor mechanics** — how the review lane is launched, claimed, and tracked (in repos running the [orchestrate](../../run/orchestrate/SKILL.md) skill, its lane-launch machinery is the natural answer).
+
+On a first run before the setup interview has filled these, the executor creates the tracker item itself and the report names the unbound slots.
 
 ## Done when (checkable)
 

--- a/skills/investigate/codebase-review/SKILL.md
+++ b/skills/investigate/codebase-review/SKILL.md
@@ -33,7 +33,7 @@ Finder agents run as parallel subagents that never see each other's output — i
 - **boundaries-vs-reality** — the declared module layout versus how change actually flows: imports that cross seams, layers honored in the diagram and bypassed in the code.
 - **test-pain** — code that can only be tested past its interface, and the setup-heavy tests that prove it.
 
-**The lane shapes candidates before any skeptic sees them, one claim per candidate, stated explicitly.** Convergent findings — lenses landing on the same code — merge into one candidate, with the convergence recorded as evidence; bundled claims split into one candidate each. One skeptic per candidate.
+**The lane shapes candidates before any skeptic sees them, one claim per candidate, stated explicitly.** Convergent findings — lenses making the same claim about the same code — merge into one candidate, with the convergence recorded as evidence; findings that share code but make different claims stay separate, the shared location recorded as evidence on each; bundled claims split into one candidate each. One skeptic per candidate.
 
 Finders and the skeptic speak the shared design vocabulary — depth, seams, locality, the deletion test — defined in [references/design-vocabulary.md](references/design-vocabulary.md); every claim in the report is phrased in those terms, in the codebase's own domain names.
 


### PR DESCRIPTION
Claude Fable 5 responding on behalf of Tim Harris:

Closes #129.

Five gaps the skill's first real run surfaced, codified minimally at their natural points: the lane shapes candidates before any skeptic sees them (convergent findings merge with the convergence recorded as evidence, bundled claims split, one claim per candidate, one skeptic per candidate); a kill can be partial, with corrections folding into the survivor's write-up; the skeptic's kill attempts now include reproducing the claimed behavior read-only where possible; and §6 gains the first-run-without-bindings degrade (executor creates the tracker item, report names the unbound slots). Pack CHANGELOG entry added.

The issue's insight-chat binding-doc note is not a skill change and is already tracked via the #153 audit. The lane ran the adversarial-review floor on its own diff (sequential, per #154): two finder passes plus a skeptic, both candidates killed, zero blockers. Repo verify commands all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)