### PR TITLE
team-workflow v1.5.0 — ship the seven merged changes to installed consumers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "name": "team-workflow",
       "source": "./",
       "strict": false,
-      "version": "1.4.0",
+      "version": "1.5.0",
       "description": "Fifteen skills that ship as one pack — a portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, per-repo institutional memory written as side effects of work, relentless grilling, decision maps, throwaway prototypes, autonomous research lanes, ticket filing, human-step wizards, session handoffs, an orchestration protocol for parallel lanes, a build discipline of seam-scoped test-first tracer slices, a disciplined bug-diagnosis loop where no fix ships without a named cause, an adversarial review that breaks changes before they ship, and a skeptic-verified state review of the codebase itself. Versioned together (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
       "license": "MIT",
       "skills": [

--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,6 +14,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.5.0] - 2026-08-12 — orchestrate cost & announce protocol, review-cycle refinements
+
 ### Added
 
 - **setup** — session-scope conduct pointer (#168). PR conduct pinned in a binding doc was


### PR DESCRIPTION
Installed consumers of the team-workflow pack are pinned to v1.4.0 (Aug 8) — everything merged since, including today's seven PRs, sits in the changelog's Unreleased section and never reaches them, because the marketplace version field is what update detection compares.

This is the release commit per RELEASING.md: bump the pack's plugin `version` to 1.5.0 in `.claude-plugin/marketplace.json`, and roll `## [Unreleased]` into `## [v1.5.0] - 2026-08-12` with a fresh empty Unreleased above it. On merge, auto-release cuts the `team-workflow/v1.5.0` tag and publishes the GitHub release from that section (validated locally with `scripts/changelog_section.py team-workflow v1.5.0` — resolves non-empty, 240 lines).

Minor bump: the section is all backward-compatible Added/Changed entries, no workflow-contract breaks. (Going forward, per the decider's call today, the default bump is the patch digit — 1.5.1 next — unless a release carries significant changes.)

Provenance: written by Claude Fable 5 (claude-fable-5) in Claude Code, filed at Tim's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)