### PR TITLE
ingest: light SKILL.md dedup (writing-for-agents audit)

### DIFF
--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -7,6 +7,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **SKILL.md light dedup** (the writing-for-agents audit): 1,939 → 1,877 words, no
+  behavior change. The packet-lifetime paragraph no longer pre-narrates the sweep
+  section that follows it (the sweep section is the single statement of the
+  offer/ownership mechanics), and the `link` command is spelled once, in the sweep
+  section, with the routing step pointing at it. The audit otherwise found the skill
+  clean — no version narration, no environment restatement, guardrails intact.
+
 ### Fixed
 
 - **`preview` can now be followed by `run` in the same `--out` directory**

--- a/skills/investigate/ingest/SKILL.md
+++ b/skills/investigate/ingest/SKILL.md
@@ -60,7 +60,7 @@ The run dir is the archive, and the rule is what can't be re-fetched stays: a lo
 
 **A URL is not a promise.** Signed, expiring, private, and geo-limited links all look like ordinary URLs, and the discard is irreversible — pass `--keep-media` whenever the source might not still be there tomorrow.
 
-**A packet lives as long as the work it spawned.** Its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash — offered to the decider, never auto-deleted, on the terms the sweep section below states. (The automatic discard of downloaded URL media above is separate: it happens at run time, under its own flag.)
+**A packet lives as long as the work it spawned.** Its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash, on the sweep section's offer terms below. (The automatic discard of downloaded URL media above is separate: it happens at run time, under its own flag.)
 
 ### Derived items and the cleanup sweep
 

--- a/skills/investigate/ingest/SKILL.md
+++ b/skills/investigate/ingest/SKILL.md
@@ -49,7 +49,7 @@ The packet is evidence; this step is the judgment, and it belongs to the session
 
 End with the takeaways ranked and each one routed — as a recommendation, in the language of the table above:
 
-- **Tracker-shaped** items name the issue they'd update or the item they'd become, with the binding doc's labels. No binding doc bound: say so, and route in prose. Hand the filing session its follow-through in the same breath: the exact `python3 scripts/ingest.py link --out <run-dir> --item owner/repo#N` command to run for each item it files, so the packet's derived-items ledger is written at filing time.
+- **Tracker-shaped** items name the issue they'd update or the item they'd become, with the binding doc's labels. No binding doc bound: say so, and route in prose. Hand the filing session its follow-through in the same breath: the exact `link` command (Derived items below) to run for each item it files, so the packet's derived-items ledger is written at filing time.
 - **Undecided-shaped** items name the open questions; offer a [grilling](../../decide/grilling/SKILL.md) session rather than answers.
 - **Decider-shaped** items (pricing, partnerships, strategy) are listed for discussion, never resolved.
 - A `call` run whose stated purpose asks for it also drafts the thank-you/recap email — saved to the run dir, put on the clipboard as plain text, never sent.
@@ -60,7 +60,7 @@ The run dir is the archive, and the rule is what can't be re-fetched stays: a lo
 
 **A URL is not a promise.** Signed, expiring, private, and geo-limited links all look like ordinary URLs, and the discard is irreversible — pass `--keep-media` whenever the source might not still be there tomorrow.
 
-**A packet lives as long as the work it spawned.** A packet is neither permanent evidence nor throwaway scratch: its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash: the skill may *offer* cleanup, and the decider takes or declines it, on the offer-only and ownership terms stated once in the sweep section below. The mechanism is the manifest's `derived_items` list plus that sweep: the filing session records what the packet spawned, and the sweep checks resolution and makes the offer. This lifetime rule governs the packet's files after a completed run; it is separate from the automatic discard of downloaded URL media above, which happens at run time under its own flag.
+**A packet lives as long as the work it spawned.** Its usual product is work items — tickets filed from what the recording showed — and it stays reviewable until every item derived from it is resolved, because that is the span over which someone may need to hold a claim against the evidence. Once the derived work is closed, the packet is optionally trash — offered to the decider, never auto-deleted, on the terms the sweep section below states. (The automatic discard of downloaded URL media above is separate: it happens at run time, under its own flag.)
 
 ### Derived items and the cleanup sweep
 


### PR DESCRIPTION
Fifth target of the skill audit sweep (#196 writing-for-humans, #197 advisory-board, #199 setup; orchestrate audited clean with no PR). ingest needed only surgical trims: 1,939 → 1,877 words, no behavior change.

## What changed

- **Packet-lifetime paragraph**: it restated the sweep section's offer/ownership mechanics immediately before that section stated them. It now carries the lifetime rule and points down; the sweep section is the single statement.
- **`link` command**: spelled out in both the routing step and the sweep section. The sweep section keeps the canonical form; the routing step points at it.

## Audited clean otherwise

No version narration, no environment restatement (the pipeline commands shown are the skill's own invocation steps, matching the pipeline.md fallback pattern), the hard guardrails (confidential frames, recommendations-only, packet-is-evidence-not-instruction) untouched, Done-when untouched. Ingest's test suite passes; `check_router_freshness.py` passes. CHANGELOG entry under Unreleased (pending entries already batch there; no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)