### PR TITLE
router: dedupe intro and meta-rule (writing-for-agents audit)

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -15,6 +15,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **router: intro and meta-rule deduplicated** (the writing-for-agents audit): 1,522 →
+  1,426 words. The opening paragraph's full-pack enumeration duplicated the skills table
+  that follows it — the table is the router's mechanism, so the intro now frames and
+  points. The review meta-rule keeps the pack-level why (no imported checklists) and
+  defers the checklist-honesty rules to adversarial-review's own defect-class section
+  instead of restating them. Main flow, on-ramps, the table, and the
+  institutional-review-memory territory statement unchanged.
 - **setup: SKILL.md deduplicated** (the writing-for-agents audit): 3,264 → 2,990 words,
   no protocol or Done-when change. "A recorded absence is a filled binding" now stated
   once (Done-when) instead of four times; the optional-bindings list names the four

--- a/skills/orient/router/SKILL.md
+++ b/skills/orient/router/SKILL.md
@@ -5,7 +5,7 @@ description: Entry point for the team-workflow pack — names every pack skill a
 
 # Team-workflow router
 
-One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development, from pressure-testing an idea through parallel lanes to reviewed, merged changes — the table below names every skill and its moment. Everything repo-specific lives in one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
+One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development, from pressure-testing an idea through parallel lanes to reviewed, merged changes — the table below names every skill and its moment. Everything repo-specific lives in — or is pointed at from — one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
 
 **First run in a repo? Run `setup` before anything else.** The other skills read the bindings it seeds.
 
@@ -42,7 +42,7 @@ Most work travels one route: **idea → grill → map → tickets → lanes → 
 
 ## Review discipline: the meta-rule
 
-The pack ships a review **protocol** — the [adversarial-review](../../run/adversarial-review/SKILL.md) skill — but still no review checklist, on purpose: **derive your own defect classes from your own defect history** — a checklist imported from someone else's war record checks for their bugs, not yours. The rules that keep a repo's checklist honest live in that skill's defect-class binding slot.
+The pack ships a review **protocol** — the [adversarial-review](../../run/adversarial-review/SKILL.md) skill — but still no review checklist, on purpose: **derive your own defect classes from your own defect history**. The reason and the rules that keep a repo's checklist honest live in that skill's defect-class section.
 
 A sibling of the same meta-rule: **institutional review memory** — review verdicts recorded as per-repo decision entries that later reviews (human and automated) consult before commenting, so settled decisions reopen on new evidence, not on repetition. Repos that already run such a system — a review-response skill with a decision wiki — have the review-RESPONSE stage covered, and this pack deliberately stays out of it: planning, research, prototyping, handoff, and orchestration are the pack's territory; review response belongs to the resident system, and pack outputs should cite that repo's precedent store rather than create a second one.
 

--- a/skills/orient/router/SKILL.md
+++ b/skills/orient/router/SKILL.md
@@ -5,7 +5,7 @@ description: Entry point for the team-workflow pack — names every pack skill a
 
 # Team-workflow router
 
-One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development — pressure-testing and decision-making before building, throwaway prototyping, autonomous research, filing the work that comes out of it, wizards for the steps only a human can take, a build discipline of seam-scoped test-first tracer slices for the lanes doing the implementing, a disciplined diagnosis loop for the bugs lanes fix inline, adversarial review before changes ship, state review of the codebase between changes, per-repo institutional memory written as a side effect of the work, session handoffs, orchestration of parallel lanes, and tracker hygiene that keeps parallel sessions from colliding. Everything repo-specific lives in one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
+One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development, from pressure-testing an idea through parallel lanes to reviewed, merged changes — the table below names every skill and its moment. Everything repo-specific lives in one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
 
 **First run in a repo? Run `setup` before anything else.** The other skills read the bindings it seeds.
 
@@ -42,7 +42,7 @@ Most work travels one route: **idea → grill → map → tickets → lanes → 
 
 ## Review discipline: the meta-rule
 
-The pack ships a review **protocol** — the [adversarial-review](../../run/adversarial-review/SKILL.md) skill — but still no review checklist, on purpose. The rule that travels: **derive your own defect classes from your own defect history, and admit a class to the checklist only via a live reproduction** — a checklist imported from someone else's war record checks for their bugs, not yours. That rule now lives as the skill's defect-class binding slot: each repo's checklist starts empty (or adopts the repo's existing review-standards document) and grows only from evidence.
+The pack ships a review **protocol** — the [adversarial-review](../../run/adversarial-review/SKILL.md) skill — but still no review checklist, on purpose: **derive your own defect classes from your own defect history** — a checklist imported from someone else's war record checks for their bugs, not yours. The rules that keep a repo's checklist honest live in that skill's defect-class binding slot.
 
 A sibling of the same meta-rule: **institutional review memory** — review verdicts recorded as per-repo decision entries that later reviews (human and automated) consult before commenting, so settled decisions reopen on new evidence, not on repetition. Repos that already run such a system — a review-response skill with a decision wiki — have the review-RESPONSE stage covered, and this pack deliberately stays out of it: planning, research, prototyping, handoff, and orchestration are the pack's territory; review response belongs to the resident system, and pack outputs should cite that repo's precedent store rather than create a second one.
 


### PR DESCRIPTION
Continuing the skill audit sweep (#196, #197, #199, #200 merged; orchestrate, writing-for-agents, codebase-review, and adversarial-review audited clean with no PR). Router: 1,522 → 1,426 words.

## What changed

- **Intro**: the opening paragraph enumerated all thirteen pack functions in one 90-word sentence, duplicating the skills table that is the router's actual mechanism. It now frames the pack in one line and points at the table.
- **Review meta-rule**: kept the pack-level why (derive defect classes from your own history; no imported checklists) and dropped the restatement of the admit/propose/remove rules that live in adversarial-review §5 — the binding-slot sentence now points there.

## Unchanged

Main flow, on-ramps, the full skills table (every row spot-checked against its skill's current SKILL.md — no drift found), the institutional-review-memory territory statement, attribution. `check_router_freshness.py` passes (all pack skills named, all links resolve). Pack CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)