### PR TITLE
handoff: add Done-when; writing-for-agents: scope the Done-when invariant honestly

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,6 +14,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **handoff: Done-when section** (the writing-for-agents audit): handoff was the one
+  task-shaped skill in the catalog without a checkable exit gate. Four lines: file at the
+  confirmed location overwritten not appended, all template sections filled with NEXT as
+  the tracker query, the saved file re-read for pointer-only content and no secret
+  values, and the user told a fresh session is safe.
+
 ### Changed
 - **setup: SKILL.md deduplicated** (the writing-for-agents audit): 3,264 → 2,990 words,
   no protocol or Done-when change. "A recorded absence is a filled binding" now stated

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -10,6 +10,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Done-when invariant claim corrected** (the catalog audit): the completion-criteria
+  section claimed the `## Done when (checkable)` section is one "every skill carries";
+  advisory-board, router, and orchestrate legitimately lack one (a gated artifact chain,
+  a menu, a standing role). The sentence now scopes the invariant to task-shaped skills
+  and names the exemption as a deliberate call. (The audit also added the missing
+  Done-when to handoff, the one task-shaped skill without one.)
+
 - **Terminology: agent-invoked / user-invoked** (#144). The skill-mechanics
   reference now says who actually triggers a skill: the invocation-mode section
   and its table say "agent-invoked" and "user-invoked" instead of the old

--- a/skills/author/writing-for-agents/SKILL.md
+++ b/skills/author/writing-for-agents/SKILL.md
@@ -53,7 +53,7 @@ Every step ends on a **completion criterion** — the condition telling the agen
 - **Clarity** — can the agent tell done from not-done? A vague bound ("understanding reached") invites **premature completion**: ending early as attention slips toward *being done*. Visible later steps supply the pull; the criterion's clarity is the resistance. Sharpen the bound first — it is local and cheap. Only when a bound is irreducibly fuzzy *and* you observe the rush should you hide later steps by splitting the sequence, and hiding works only across a real context boundary (a handoff, a subagent dispatch). An inline call leaves the later steps in context and clears nothing.
 - **Demand** — how much the criterion requires. "Every modified model accounted for" forces thorough work where "produce a change list" does not. Demand drives the digging the agent does inside the work, and it is not step-bound: "every rule applied" binds a body of flat reference exactly as "every step done" binds a sequence. That is how an all-reference document still carries an exhaustiveness bar.
 
-The strongest criteria are both checkable and exhaustive. In this catalog they surface as the **`## Done when (checkable)`** section every skill carries.
+The strongest criteria are both checkable and exhaustive. In this catalog they surface as the **`## Done when (checkable)`** section every task-shaped skill carries; a skill with no discrete run to complete (a menu, a standing role) is exempt, and the exemption is a deliberate call, not an omission.
 
 ## When to split
 

--- a/skills/run/handoff/SKILL.md
+++ b/skills/run/handoff/SKILL.md
@@ -37,6 +37,6 @@ In repos with an approval-before-edit guardrail: invoking this skill **is** the 
 ## Done when (checkable — verify each line before reporting complete)
 
 - The handoff file exists at the binding doc's confirmed location, overwriting any previous one — no appended history.
-- All four template sections are filled, and NEXT is the tracker query, not an enumerated item list.
-- The saved file was re-read after writing: every entry is a pointer into a durable record, no pasted code blocks, and nothing shaped like a token, key, or password — secret *locations* only.
+- All four template sections are filled; NEXT contains the tracker query and enumerates no specific work items.
+- The saved file was re-read after writing: every entry is a pointer into a durable record with no pasted code blocks, and rule 5's secret scan ran against the saved text — any candidate value it flagged was replaced with its pointer and the file re-saved before reporting.
 - The user was told the handoff is saved and a fresh session or context reset is now safe.

--- a/skills/run/handoff/SKILL.md
+++ b/skills/run/handoff/SKILL.md
@@ -33,3 +33,10 @@ In repos with an approval-before-edit guardrail: invoking this skill **is** the 
 2. Fill the [reference template](references/template.md) — STATE / DONE / NEXT / GOTCHAS — overwriting any existing handoff.
 3. Keep it tight and high-signal; apply the five rules above.
 4. Tell the user it's saved and that a fresh session (or a context reset) is now safe.
+
+## Done when (checkable — verify each line before reporting complete)
+
+- The handoff file exists at the binding doc's confirmed location, overwriting any previous one — no appended history.
+- All four template sections are filled, and NEXT is the tracker query, not an enumerated item list.
+- The saved file was re-read after writing: every entry is a pointer into a durable record, no pasted code blocks, and nothing shaped like a token, key, or password — secret *locations* only.
+- The user was told the handoff is saved and a fresh session or context reset is now safe.


### PR DESCRIPTION
From the audit sweep's cross-catalog check: writing-for-agents claims the `## Done when (checkable)` section is one "every skill carries". Grepping the catalog: advisory-board, router, orchestrate, and handoff lack it. The first three are legitimately shaped without one (a gated artifact chain with When-To-Stop, a menu, a standing role). handoff is a discrete task skill with declared writes and a secrets rule — it should have one and didn't.

## What changed

- **handoff** gains a four-line Done-when: file at the confirmed location overwritten not appended; template sections filled with NEXT as the tracker query; the saved file re-read for pointer-only content and no secret values (this makes rule 5's pre-write scan a checked step, not a hope); user told a fresh session is safe.
- **writing-for-agents** scopes the invariant sentence to task-shaped skills and names the exemption as a deliberate call — the no-stale-claims rule applied to the ruler itself.

Changelog entries under both plugins' Unreleased sections (both batch; no version bumps). `check_router_freshness.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)