### PR TITLE
release: roll the audit sweep — team-workflow v1.5.1 + three standalone patches

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "advisory-board",
       "source": "./",
       "strict": false,
-      "version": "1.18.0",
+      "version": "1.18.1",
       "description": "Convene a board of frontier AI models — Claude, Codex, Gemini, and Grok — that each review the same decision independently, debate across rounds, and hand back one clear recommendation.",
       "license": "MIT",
       "skills": [
@@ -23,7 +23,7 @@
       "name": "team-workflow",
       "source": "./",
       "strict": false,
-      "version": "1.5.0",
+      "version": "1.5.1",
       "description": "Fifteen skills that ship as one pack — a portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, per-repo institutional memory written as side effects of work, relentless grilling, decision maps, throwaway prototypes, autonomous research lanes, ticket filing, human-step wizards, session handoffs, an orchestration protocol for parallel lanes, a build discipline of seam-scoped test-first tracer slices, a disciplined bug-diagnosis loop where no fix ships without a named cause, an adversarial review that breaks changes before they ship, and a skeptic-verified state review of the codebase itself. Versioned together (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
       "license": "MIT",
       "skills": [
@@ -48,7 +48,7 @@
       "name": "ingest",
       "source": "./",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Turn a video, recording, voice memo, or media URL into an evidence packet — authoritative whisper transcript, timestamped frames, manifest — plus a routing recommendation. Six intents behind a mandatory purpose gate; the pipeline script is resumable and encodes the hard-won gotchas.",
       "license": "MIT",
       "skills": [
@@ -59,7 +59,7 @@
       "name": "writing-for-agents",
       "source": "./",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Write and prune documents an agent consumes — a SKILL.md, an AGENTS.md or CLAUDE.md, a reference reached by a pointer. Context pointers, the two loads, the information hierarchy, leading words, and the no-op test.",
       "license": "MIT",
       "skills": [

--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,6 +14,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.5.1] - 2026-08-13 — catalog audit: dedup pass + handoff exit gate
+
 ### Added
 - **handoff: Done-when section** (the writing-for-agents audit): handoff was the one
   task-shaped skill in the catalog without a checkable exit gate. Four lines: file at the

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -8,6 +8,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.0.1] - 2026-08-13 — fidelity and invariant corrections
+
 ### Changed
 
 - **Done-when invariant claim corrected** (the catalog audit): the completion-criteria

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -9,6 +9,8 @@ versioned separately and do not replace the skill release version.
 
 ## [Unreleased]
 
+## [v1.18.1] - 2026-08-13 — audit prune, lean description, signed-out preflight fix
+
 ### Changed
 - **SKILL.md pruned to the lines that steer the agent** (the writing-for-agents audit, following
   writing-for-humans v1.2.0): 6,558 → 4,547 words with no protocol change. Version-history

--- a/skills/investigate/ingest/CHANGELOG.md
+++ b/skills/investigate/ingest/CHANGELOG.md
@@ -7,6 +7,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.2.1] - 2026-08-13 — preview-then-run fix, audit dedup
+
 ### Changed
 
 - **SKILL.md light dedup** (the writing-for-agents audit): 1,939 → 1,877 words, no


### PR DESCRIPTION
Tim's call: roll everything batched during the audit sweep. Four patch releases in one PR; auto-release cuts the tags and publishes from these changelog sections on merge.

| Plugin | Version | Carries |
|---|---|---|
| team-workflow | 1.5.0 → **1.5.1** | setup dedup (#199), router dedup (#201), handoff Done-when (#202) |
| advisory-board | 1.18.0 → **1.18.1** | audit prune (#197), description trim, signed-out preflight fix |
| ingest | 1.2.0 → **1.2.1** | preview-then-run marker fix (#160 / #186), audit dedup (#200) |
| writing-for-agents | 1.0.0 → **1.0.1** | Done-when invariant scoping (#202), agent-/user-invoked terminology (#144), sibling cross-link (#141), attribution fidelity (#122) |

All four are patch-grade per RELEASING.md's scheme: backward-compatible fixes and documented-behavior clarifications, no new capabilities, no contract changes. Each changelog's Unreleased was renamed to its dated version section with a fresh empty Unreleased above it, per the recorded per-PR habit. `check_router_freshness.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)