### PR TITLE
CI tripwire: unqualified gh tracker commands can't reappear in skill docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Check invocation classification freshness
         run: python3 scripts/check_invocation_freshness.py
 
+      # Tracker recipes must name the bound repo explicitly (#208): an
+      # unqualified gh command resolves the repo implicitly, which in a fork
+      # targets the upstream repo instead of the bound tracker.
+      - name: Check tracker commands carry an explicit repo
+        run: |
+          set -euo pipefail
+          bad=$(grep -rnE '\bgh (issue|label|pr|search)\b' skills --include='*.md' | grep -v 'skills/deprecated/' | grep -v -- '--repo' || true)
+          bad="$bad$(grep -rn 'repos/{owner}/{repo}' skills --include='*.md' | grep -v 'skills/deprecated/' || true)"
+          if [ -n "$bad" ]; then
+            printf '%s\n' "$bad"
+            echo 'Unqualified gh command or repos/{owner}/{repo} placeholder in skill docs — carry --repo <bound repo> / the literal repo in the api path (see tracker-discipline).' >&2
+            exit 1
+          fi
+
       # The site is written from a private context repository. This fails the
       # build if a confidential name or any email address reaches site/src.
       # The forbidden terms are stored as salted digests, so the check itself

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,16 @@ jobs:
       - name: Check tracker commands carry an explicit repo
         run: |
           set -euo pipefail
-          bad=$(grep -rnE '\bgh (issue|label|pr|search)\b' skills --include='*.md' | grep -v 'skills/deprecated/' | grep -v -- '--repo' || true)
-          bad="$bad$(grep -rn 'repos/{owner}/{repo}' skills --include='*.md' | grep -v 'skills/deprecated/' || true)"
-          if [ -n "$bad" ]; then
-            printf '%s\n' "$bad"
+          # grep exit 1 is "no match" (fine); anything else (missing dir,
+          # unreadable file) fails the step — no bare `|| true`.
+          test -d skills
+          grep -rnE --include='*.md' --exclude-dir=deprecated \
+            '\bgh (issue|label|pr|search)\b' skills > /tmp/gh_lines || [ $? -eq 1 ]
+          grep -v -- '--repo' /tmp/gh_lines > /tmp/bad || [ $? -eq 1 ]
+          grep -rnE --include='*.md' --exclude-dir=deprecated \
+            'repos/\{owner\}/\{repo\}' skills >> /tmp/bad || [ $? -eq 1 ]
+          if [ -s /tmp/bad ]; then
+            cat /tmp/bad
             echo 'Unqualified gh command or repos/{owner}/{repo} placeholder in skill docs — carry --repo <bound repo> / the literal repo in the api path (see tracker-discipline).' >&2
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #209 (the fix for #208): the fork mis-targeting bug was fixed by qualifying every tracker recipe with the bound repo, but nothing would catch a future recipe edit reintroducing an unqualified `gh issue/label/pr/search` command or a `repos/{owner}/{repo}` placeholder path — the exact regression class the field report hit.

This adds one grep step to the existing catalog-freshness CI job that fails the build on either form in `skills/**/*.md` (deprecated/ excluded). Prose *mentions* of the `{owner}/{repo}` hazard stay legal — only the `repos/`-prefixed path form is flagged. Verified locally: current tree passes; reverting one recipe line fails.

Filed by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)