### PR TITLE
release: team-workflow v1.5.2 — tracker recipes carry the bound repo explicitly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "name": "team-workflow",
       "source": "./",
       "strict": false,
-      "version": "1.5.1",
+      "version": "1.5.2",
       "description": "Fifteen skills that ship as one pack — a portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, per-repo institutional memory written as side effects of work, relentless grilling, decision maps, throwaway prototypes, autonomous research lanes, ticket filing, human-step wizards, session handoffs, an orchestration protocol for parallel lanes, a build discipline of seam-scoped test-first tracer slices, a disciplined bug-diagnosis loop where no fix ships without a named cause, an adversarial review that breaks changes before they ship, and a skeptic-verified state review of the codebase itself. Versioned together (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
       "license": "MIT",
       "skills": [

--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,6 +14,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.5.2] - 2026-08-14 — tracker recipes carry the bound repo explicitly
+
 ### Fixed
 - **Tracker recipes name the bound repo explicitly** (#208, field report from a fork
   consumer): every `gh issue`/`gh label` command in the recipes now carries


### PR DESCRIPTION
Cuts `team-workflow/v1.5.2` so consumers pick up the fork mis-targeting fix from #208: a consumer installing the pack into a fork had every tracker recipe read and write against the upstream repo instead of the bound tracker, because the recipes relied on gh's implicit repo resolution. The fix (#209) qualifies every recipe command with the bound repo and adds setup's implicit-repo check; #210 added the CI tripwire.

Release mechanics per RELEASING.md: the changelog's `[Unreleased]` section is renamed to `[v1.5.2] - 2026-08-14` with a fresh empty `[Unreleased]` above it, and the plugin version in marketplace.json is bumped to 1.5.2 — auto-release cuts the tag and publishes on merge. Verified locally that `scripts/changelog_section.py team-workflow v1.5.2` extracts the section non-empty (the workflow's own resolution path).

Filed by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)