### PR TITLE
CI tripwire: per-skill link-preview cards can't silently regress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,34 @@ jobs:
       - name: Check the site discloses nothing it should not
         run: python3 scripts/check_site_disclosure.py
 
+  site-link-previews:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Build the site
+        working-directory: site
+        run: |
+          npm ci
+          npm run build
+
+      # Tripwire for the per-skill link-preview cards (#214): og:url names the
+      # page itself, the card images come from /skills/<slug>/, and the image
+      # route serves a 1200x630 PNG. See the script's docstring.
+      - name: Check per-skill link-preview cards
+        working-directory: site
+        run: |
+          set -euo pipefail
+          npm run start &
+          python3 ../scripts/check_skill_og_cards.py
+
   advisory-board:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/check_skill_og_cards.py
+++ b/scripts/check_skill_og_cards.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tripwire for the per-skill link-preview cards (PR #214).
+
+Fetches a skill page from a running site build and asserts the three
+properties that PR shipped, so a metadata regression fails CI instead of
+silently shipping a homepage card to every timeline:
+
+  1. og:url names the page's own path, not the bare origin.
+  2. og:image and twitter:image point at the per-skill image route
+     (/skills/<slug>/...), not the site-wide fallback.
+  3. The og:image route serves a real 1200x630 PNG (dimensions read from
+     the IHDR chunk, content sniffed from the PNG signature).
+
+Standard library only; HTML is matched with attribute-order-tolerant
+regexes rather than shelling out, so the check behaves the same in CI and
+on any developer machine. Expects `next start` to be listening; retries
+until the server is up. Usage:
+
+  python3 scripts/check_skill_og_cards.py [--base http://localhost:3000]
+                                          [--slug adversarial-review]
+"""
+
+import argparse
+import re
+import struct
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SITE_ORIGIN = "https://clickai.dev"
+
+
+def fetch(url: str, timeout: float = 15.0) -> bytes:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return response.read()
+
+
+def fetch_when_up(url: str, deadline: float = 60.0) -> bytes:
+    """Retry until the dev/prod server answers — it starts in parallel."""
+    start = time.monotonic()
+    while True:
+        try:
+            return fetch(url)
+        except (urllib.error.URLError, ConnectionError, OSError) as error:
+            if time.monotonic() - start > deadline:
+                raise SystemExit(f"server never answered at {url}: {error}")
+            time.sleep(1)
+
+
+def meta_content(html: str, attr: str, key: str) -> str:
+    """The content= of a <meta> tag, tolerating either attribute order."""
+    for pattern in (
+        rf'<meta\s+{attr}="{re.escape(key)}"\s+content="([^"]*)"',
+        rf'<meta\s+content="([^"]*)"\s+{attr}="{re.escape(key)}"',
+    ):
+        match = re.search(pattern, html)
+        if match:
+            return match.group(1)
+    raise SystemExit(f'no <meta {attr}="{key}"> tag found')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="http://localhost:3000")
+    parser.add_argument("--slug", default="adversarial-review")
+    args = parser.parse_args()
+
+    page_path = f"/skills/{args.slug}"
+    html = fetch_when_up(args.base + page_path).decode("utf-8")
+    failures = []
+
+    # 1. og:url claims this page, not the homepage (the pre-#214 bug).
+    og_url = meta_content(html, "property", "og:url")
+    if og_url != SITE_ORIGIN + page_path:
+        failures.append(f"og:url is {og_url!r}, want {SITE_ORIGIN + page_path!r}")
+
+    # 2. Both card images come from the per-skill route.
+    og_image = meta_content(html, "property", "og:image")
+    twitter_image = meta_content(html, "name", "twitter:image")
+    for label, url in (("og:image", og_image), ("twitter:image", twitter_image)):
+        if not url.startswith(f"{SITE_ORIGIN}{page_path}/"):
+            failures.append(f"{label} is {url!r}, want it under {SITE_ORIGIN}{page_path}/")
+
+    # 3. The image route serves a 1200x630 PNG. og:image is absolute against
+    # the production origin; refetch its path from the server under test.
+    if og_image.startswith(SITE_ORIGIN):
+        png = fetch_when_up(args.base + og_image[len(SITE_ORIGIN):])
+        if png[:8] != b"\x89PNG\r\n\x1a\n":
+            failures.append("og:image route did not return a PNG")
+        else:
+            width, height = struct.unpack(">II", png[16:24])
+            if (width, height) != (1200, 630):
+                failures.append(f"og:image is {width}x{height}, want 1200x630")
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        raise SystemExit(1)
+    print(f"link-preview card checks passed for {page_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_skill_og_cards.py
+++ b/scripts/check_skill_og_cards.py
@@ -6,9 +6,10 @@ properties that PR shipped, so a metadata regression fails CI instead of
 silently shipping a homepage card to every timeline:
 
   1. og:url names the page's own path, not the bare origin.
-  2. og:image and twitter:image point at the per-skill image route
-     (/skills/<slug>/...), not the site-wide fallback.
-  3. The og:image route serves a real 1200x630 PNG (dimensions read from
+  2. og:image and twitter:image each name their per-skill image route
+     (/skills/<slug>/opengraph-image, .../twitter-image) exactly, not the
+     site-wide fallback.
+  3. Each image route serves a real 1200x630 PNG (dimensions read from
      the IHDR chunk, content sniffed from the PNG signature).
 
 Standard library only; HTML is matched with attribute-order-tolerant
@@ -26,6 +27,7 @@ import struct
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 SITE_ORIGIN = "https://clickai.dev"
@@ -75,23 +77,32 @@ def main() -> None:
     if og_url != SITE_ORIGIN + page_path:
         failures.append(f"og:url is {og_url!r}, want {SITE_ORIGIN + page_path!r}")
 
-    # 2. Both card images come from the per-skill route.
-    og_image = meta_content(html, "property", "og:image")
-    twitter_image = meta_content(html, "name", "twitter:image")
-    for label, url in (("og:image", og_image), ("twitter:image", twitter_image)):
-        if not url.startswith(f"{SITE_ORIGIN}{page_path}/"):
-            failures.append(f"{label} is {url!r}, want it under {SITE_ORIGIN}{page_path}/")
-
-    # 3. The image route serves a 1200x630 PNG. og:image is absolute against
-    # the production origin; refetch its path from the server under test.
-    if og_image.startswith(SITE_ORIGIN):
-        png = fetch_when_up(args.base + og_image[len(SITE_ORIGIN):])
+    # 2 and 3. Each card image is the per-skill image route — exactly, not
+    # merely somewhere under the skill path — and that route serves a
+    # 1200x630 PNG. The emitted URL is absolute against the production origin
+    # (with a cache-busting query); refetch its path from the server under
+    # test.
+    for tag_attr, key, route in (
+        ("property", "og:image", "opengraph-image"),
+        ("name", "twitter:image", "twitter-image"),
+    ):
+        url = meta_content(html, tag_attr, key)
+        parsed = urllib.parse.urlsplit(url)
+        expected = urllib.parse.urlsplit(f"{SITE_ORIGIN}{page_path}/{route}")
+        if (parsed.scheme, parsed.netloc, parsed.path) != (
+            expected.scheme,
+            expected.netloc,
+            expected.path,
+        ):
+            failures.append(f"{key} is {url!r}, want {expected.geturl()!r}")
+            continue
+        png = fetch_when_up(args.base + parsed.path)
         if png[:8] != b"\x89PNG\r\n\x1a\n":
-            failures.append("og:image route did not return a PNG")
+            failures.append(f"{key} route did not return a PNG")
         else:
             width, height = struct.unpack(">II", png[16:24])
             if (width, height) != (1200, 630):
-                failures.append(f"og:image is {width}x{height}, want 1200x630")
+                failures.append(f"{key} is {width}x{height}, want 1200x630")
 
     if failures:
         print("\n".join(failures), file=sys.stderr)


### PR DESCRIPTION
[#214](https://github.com/timharris707/skills/pull/214) shipped per-skill OG/Twitter cards and per-page og:url, but nothing would catch a regression — a metadata merge slip would quietly put the homepage card back on every skill link.

New `site-link-previews` job in ci.yml: `npm ci` + `next build`, start the server, then run `scripts/check_skill_og_cards.py` against `/skills/adversarial-review`. It asserts:

1. `og:url` is `https://clickai.dev/skills/adversarial-review` — the page's own path, not the bare origin (the pre-#214 bug).
2. `og:image` and `twitter:image` both point under `/skills/adversarial-review/` — the per-skill image route, not the site-wide fallback.
3. The `og:image` route returns a real PNG (signature-sniffed) whose IHDR dimensions are 1200x630.

The assertions are standard-library python3 (matching the repo's other CI checks) rather than grep pipelines, so they don't depend on any grep implementation's exit-code behavior and run identically in CI and locally.

Verified locally: built the site, started it, ran the script — all three assertions pass; the failure paths print the offending value to stderr and exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)