### PR TITLE
site: human copy layer — skill pages, cards, and link previews stop speaking agent

### DIFF
--- a/site/src/app/legend/[term]/page.tsx
+++ b/site/src/app/legend/[term]/page.tsx
@@ -3,7 +3,8 @@ import { openGraph } from "@/lib/meta";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BANDS, ENTRIES, getEntry } from "@/lib/legend";
-import { getSkill, summarize } from "@/lib/skills";
+import { getSkill } from "@/lib/skills";
+import { human } from "@/lib/human";
 import {
   DEFINED_TERM_SET,
   definedTermNode,
@@ -77,7 +78,7 @@ export default async function LegendTerm({ params }: Params) {
             <h3>Implemented by</h3>
             <p className="term__skill">
               <Link href={`/skills/${skill.slug}`}>{skill.name}</Link>
-              <span>{summarize(skill.description)}</span>
+              <span>{human(skill.slug).card}</span>
             </p>
           </>
         ) : null}

--- a/site/src/app/skills/[slug]/opengraph-image.tsx
+++ b/site/src/app/skills/[slug]/opengraph-image.tsx
@@ -2,7 +2,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { ImageResponse } from "next/og";
 import { notFound } from "next/navigation";
-import { getSkill, getSkills, summarize } from "@/lib/skills";
+import { getSkill, getSkills } from "@/lib/skills";
+import { human } from "@/lib/human";
 
 /**
  * Per-skill link-preview card, in the survey-chart style of the site-wide
@@ -30,15 +31,13 @@ const GRIDLINE = "rgba(219, 231, 233, 0.05)";
 const MUTED = "rgba(219, 231, 233, 0.66)";
 
 /**
- * First sentence only — summarize() keeps trigger clauses that don't open
- * with "Use when/for", and a card is not the place for triggers. The longest
- * first sentence today is 183 chars (four rendered lines); the char clamp is
- * a backstop for a future skill that outgrows that, cutting on a word.
+ * The tagline is the skill's human card line, whole. The longest card today
+ * is 211 chars (five rendered lines, which the layout absorbs); the clamp is
+ * a backstop for a future line that outgrows that, cutting on a word.
  */
-function clip(text: string, max = 200): string {
-  const sentence = text.split(/(?<=[.!?])\s+/)[0];
-  if (sentence.length <= max) return sentence;
-  return `${sentence.slice(0, sentence.lastIndexOf(" ", max))} …`;
+function clip(text: string, max = 240): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, text.lastIndexOf(" ", max))} …`;
 }
 
 export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
@@ -95,7 +94,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
             }}
           />
           <div style={{ fontSize: 30, lineHeight: 1.55, color: MUTED, maxWidth: 980 }}>
-            {clip(summarize(skill.description))}
+            {clip(human(skill.slug).card)}
           </div>
         </div>
 

--- a/site/src/app/skills/[slug]/page.tsx
+++ b/site/src/app/skills/[slug]/page.tsx
@@ -5,8 +5,9 @@ import { notFound } from "next/navigation";
 import { marked } from "marked";
 import Terminal from "@/components/Terminal";
 import Runtimes from "@/components/Runtimes";
-import { getCodexPlugin, getSkill, getSkills, summarize } from "@/lib/skills";
+import { getCodexPlugin, getSkill, getSkills } from "@/lib/skills";
 import { getBuckets } from "@/lib/skills";
+import { human } from "@/lib/human";
 
 type Params = { params: Promise<{ slug: string }> };
 
@@ -20,68 +21,11 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   if (!skill) return {};
   return {
     title: skill.name,
-    description: summarize(skill.description),
+    description: human(skill.slug).card,
     alternates: { canonical: `/skills/${skill.slug}` },
     openGraph: openGraph(`/skills/${skill.slug}`),
   };
 }
-
-/** The "Use when …" clause — the triggers that decide when a skill fires. */
-function trigger(description: string): string | null {
-  const match = description.match(/\b(Use when|Use for)\b.*/s);
-  return match ? match[0].trim() : null;
-}
-
-/**
- * One subject-claim sentence per skill — "x is a skill that …" — so the page
- * answers what the thing IS before the "Use when" triggers fire. Site-side on
- * purpose: SKILL.md descriptions open with an imperative for the agent reading
- * them, and this page is read by humans. Each sentence paraphrases the skill's
- * own description and must stay checkable against it. A skill missing here
- * falls back to its description's first sentence — add a claim when a skill
- * lands in a promoted bucket.
- */
-const SUBJECT_CLAIMS: Record<string, string> = {
-  router:
-    "router is a skill that gives a session one entry point to the team-workflow pack: it names every skill and when to reach for each.",
-  setup:
-    "setup is a skill that binds the team-workflow pack to a repo through a one-time interview: how you test, where work is tracked, who has the final say.",
-  "domain-memory":
-    "domain-memory is a skill that keeps a repo's institutional memory as a side effect of ordinary work: what its words mean, and why its settled decisions went the way they did.",
-  grilling:
-    "grilling is a skill that has the agent interview you, round after round, until nothing load-bearing in a plan is still assumed.",
-  "advisory-board":
-    "advisory-board is a skill that convenes frontier models from four vendors on one question and returns a single verdict with the dissent preserved.",
-  "decision-map":
-    "decision-map is a skill that charts genuinely foggy work as a map of gated decisions and works it until nothing gating is undecided.",
-  ingest:
-    "ingest is a skill that turns a video, recording, or voice memo into an evidence packet (transcript, timestamped frames, manifest) plus a recommendation for where it enters the work.",
-  research:
-    "research is a skill that runs an autonomous investigation against primary sources and ends in a cited findings file linked from the ticket that asked.",
-  prototype:
-    "prototype is a skill that builds throwaway code to answer a design question that discussion and static artifacts cannot settle.",
-  "codebase-review":
-    "codebase-review is a skill that reviews the state of the codebase between changes, the counterpart to adversarial-review's review of a single change.",
-  diagnose:
-    "diagnose is a skill that holds bug-fixing to a disciplined loop: no fix ships without a cause the fixer can state in one plain sentence, with evidence.",
-  implement:
-    "implement is a skill that disciplines how a working session builds an item, test-first and in thin slices that go end to end, with a green checkpoint after each.",
-  "to-tickets":
-    "to-tickets is a skill that turns a decided plan into tracker items a stranger could pick up cold, with their blocking edges wired.",
-  wizard:
-    "wizard is a skill that generates an interactive walkthrough for the steps only a human can perform, from third-party dashboards to credentials to DNS records.",
-  orchestrate:
-    "orchestrate is a skill that turns one session into the coordinator of many, routing tracked work to parallel sessions, auditing what comes back, and owning integration.",
-  "adversarial-review":
-    "adversarial-review is a skill that tries to break a change before it ships: isolated finders attack it, a skeptic pass kills unproven findings, and confirmed blockers gate the merge.",
-  handoff:
-    "handoff is a skill that writes where the work stands into one small file, so a fresh session resumes without re-explanation.",
-  "writing-for-agents":
-    "writing-for-agents is a skill that writes and prunes the documents agents consume: SKILL.md files, standing instructions, reference files.",
-  "writing-for-humans":
-    "writing-for-humans is a skill that makes public-facing prose worth a stranger's next minute through guide shape, observable warmth, and a last-mile scrub for AI tells.",
-  huh: "huh is a skill that decodes an agent message that didn't land: a plain-sentence restatement, invented shorthand expanded, the ask separated from the report, and unevidenced claims flagged.",
-};
 
 /**
  * SKILL.md links are relative to the skill's own directory, so they only
@@ -115,7 +59,6 @@ export default async function SkillPage({ params }: Params) {
   // The SKILL.md H1 is the page title, so drop it rather than printing it twice.
   const body = skill.body.trimStart().replace(/^#\s+.*(\r?\n|$)/, "");
   const html = absolutise(await marked.parse(body), skill.bucket, skill.slug);
-  const useWhen = trigger(skill.description);
   const codex = getCodexPlugin();
 
   return (
@@ -125,10 +68,13 @@ export default async function SkillPage({ params }: Params) {
           ← Catalog {region ? `/ ${region.name}` : ""}
         </Link>
         <h1 className="detail__title">{skill.name}</h1>
+        {/* The human intro, from src/lib/human.ts. The agent's own wording —
+            description, triggers, the full document — is one flip away and
+            rendered below; this paragraph is the page's only copy written for
+            a reader who doesn't code. */}
         <p className="detail__claim" style={{ fontSize: "1.05rem", maxWidth: "var(--measure)", margin: "0.5rem 0 1rem" }}>
-          {SUBJECT_CLAIMS[skill.slug] ?? summarize(skill.description)}
+          {human(skill.slug).intro}
         </p>
-        <p className="detail__trigger">{useWhen ?? summarize(skill.description)}</p>
         <div className="prose" dangerouslySetInnerHTML={{ __html: html }} />
       </article>
 

--- a/site/src/components/Regions.tsx
+++ b/site/src/components/Regions.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { summarize } from "@/lib/skills";
+import { human } from "@/lib/human";
 import type { Region } from "@/lib/catalog";
 
 export default function Regions({ regions }: { regions: Region[] }) {
@@ -21,7 +21,7 @@ export default function Regions({ regions }: { regions: Region[] }) {
                 <Link className="entry__link" href={`/skills/${skill.slug}`}>
                   <span className="entry__name">{skill.name}</span>
                   <span className="entry__ships">{skill.shipsAs}</span>
-                  <p className="entry__what">{summarize(skill.description)}</p>
+                  <p className="entry__what">{human(skill.slug).card}</p>
                 </Link>
               </li>
             ))}

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -1,4 +1,5 @@
 import { getBuckets, getSkills, type Bucket, type Skill } from "./skills";
+import { HUMAN } from "./human";
 
 /**
  * The catalog's regions ARE the repository's promoted buckets — name, order,
@@ -167,6 +168,25 @@ function assertComplete(skills: Skill[]) {
     throw new Error(
       `catalog.ts: ${phantom.join(", ")} in INVOCATION but not in any promoted bucket — ` +
         "remove the entry, or promote the skill.",
+    );
+  }
+
+  // Same discipline for the human copy as for PLOT and INVOCATION: the whole
+  // slug set compared both ways, so a promoted skill cannot ship without its
+  // human card and intro, and a demoted skill cannot leave stray copy behind.
+  const uncopied = skills.filter((s) => !HUMAN[s.slug]).map((s) => s.slug);
+  if (uncopied.length) {
+    throw new Error(
+      `catalog.ts: ${uncopied.join(", ")} ${uncopied.length === 1 ? "has" : "have"} no human ` +
+        "copy. Add a card and an intro in src/lib/human.ts.",
+    );
+  }
+
+  const stray = Object.keys(HUMAN).filter((slug) => !known.has(slug));
+  if (stray.length) {
+    throw new Error(
+      `catalog.ts: ${stray.join(", ")} in HUMAN but not in any promoted bucket — ` +
+        "remove the entry in src/lib/human.ts, or promote the skill.",
     );
   }
 

--- a/site/src/lib/human.ts
+++ b/site/src/lib/human.ts
@@ -1,0 +1,175 @@
+/**
+ * The human copy layer — one entry per promoted skill, written for a reader
+ * who does not code.
+ *
+ * SKILL.md descriptions are written for the agent that has to decide when to
+ * fire them, and for years of this site's life they leaked straight onto the
+ * human surfaces: catalog cards, page intros, link previews. This file is the
+ * fix. Each entry is written from the reader's chair — the pain first, the
+ * fix in plain words, and an honest limit where it earns trust — and never
+ * borrows the agent's trigger vocabulary.
+ *
+ * `card` is the short form: the link-preview tagline and the catalog entry
+ * line. `intro` is the longer form that opens the skill's own page. The agent
+ * view is untouched by design: the Markdown twins behind the flip serve the
+ * raw SKILL.md bytes, never anything from here.
+ *
+ * `human()` throws on a missing slug, so promoting a skill without writing
+ * its human copy fails `next build` instead of quietly shipping agent text
+ * back onto a human page.
+ */
+
+export type HumanCopy = {
+  /** Link-preview tagline and catalog entry line. A few short sentences. */
+  card: string;
+  /** Opens the skill page: the pain, the fix in plain words, an honest limit. */
+  intro: string;
+};
+
+export const HUMAN: Record<string, HumanCopy> = {
+  // ── Orient ─────────────────────────────────────────────────────────────────
+  router: {
+    card:
+      "You won't remember every skill in a pack this size, and you shouldn't have to. Ask your agent what fits the moment and it names the skill and says why. It points; it never runs anything on its own.",
+    intro:
+      "A pack this size has a findability problem: you won't remember every skill in it, and you shouldn't have to. router is the front door. Ask your agent what fits the situation and it names the right skill and says why. It's a map, not a manager — it points, and you decide whether to go.",
+  },
+  setup: {
+    card:
+      "One short interview teaches the pack how your project works: how you test, where the work is tracked, who has the final say. Answer once, and the other skills stop asking.",
+    intro:
+      "Every new tool asks you the same questions about your project, forever. setup asks them once. It's a short interview, run one time per project: how you test, where work is tracked, who has the final say. The answers are written down where every other skill can read them, so none of them has to ask again. It records how you already work; it never restructures anything.",
+  },
+  "domain-memory": {
+    card:
+      "What your project's words mean, and why old arguments were settled the way they were, written down as the work happens. A new session stops reopening decisions you already made.",
+    intro:
+      "Every project builds up a private language and a pile of settled arguments, and a fresh agent session knows none of it. So it asks again, or worse, quietly decides differently this time. domain-memory writes the language and the decisions down as a side effect of ordinary work: when a plan survives its interview, when a review finding is declined, when you correct a wrong assumption. It can only record decisions somebody actually stated out loud — it won't reconstruct why something was done last year.",
+  },
+
+  // ── Decide ─────────────────────────────────────────────────────────────────
+  grilling: {
+    card:
+      "Your agent asks you every hard question before the work starts. Vague plans die in the interview instead of in the code.",
+    intro:
+      "You describe a feature, the agent agrees instantly, and hours later you're reviewing a polished version of something you never meant. The gaps you didn't fill, it filled with guesses. grilling flips the ritual: the agent interviews you, round after round of hard questions, until nothing important is still assumed and the answers are written down. Vague plans die in the interview instead of in the code. It works only as hard as your answers, so bring real attention.",
+  },
+  "advisory-board": {
+    card:
+      "One model's answer is one opinion. This puts the same question to Claude, Codex, Gemini, and Grok, lets them read each other, and hands you one verdict with the disagreement kept visible. The call is still yours.",
+    intro:
+      "A hard call — an architecture, a migration, a contract — usually gets decided by whichever model you happened to ask, in one pass, with nobody pushing back. advisory-board convenes Claude, Codex, Gemini, and Grok on the same question, has them answer independently, then read and challenge each other. You get one verdict with the disagreement kept visible and a list of what the board could not verify. It's slower than asking once, on purpose, and it's still models arguing with models: the final call stays yours.",
+  },
+  "decision-map": {
+    card:
+      "For work too foggy to plan in one sitting. The open questions go on a map, with what blocks what, and building waits until nothing the build rests on is still a guess.",
+    intro:
+      "Some work is too foggy to plan in one sitting: a new kind of feature, an integration nobody fully understands yet. Writing it up as a simple to-do list just hides the unknowns. decision-map charts the open questions instead, with what blocks what, and the map is worked question by question until nothing the build rests on is still a guess. It's for genuinely foggy work. If you could spec the thing in an afternoon, this is overhead.",
+  },
+
+  // ── Investigate ────────────────────────────────────────────────────────────
+  ingest: {
+    card:
+      "Give it a call recording, a demo video, or a voice memo. You get back what was actually said, with timestamps and stills to prove it. It won't guess at words it can't hear.",
+    intro:
+      "An hour-long call recording is where decisions go to disappear. ingest turns a video, a recording, or a voice memo into evidence you can actually use: a transcript you can trust, stills with timestamps, and a recommendation for what to do with what was said. When the audio is bad, it marks what it couldn't hear rather than guessing.",
+  },
+  research: {
+    card:
+      "An agent goes and reads the actual sources: the vendor docs, the regulation, the upstream code. It comes back with findings you can check, each one pointing at where it was found.",
+    intro:
+      "Somebody has to actually read the vendor docs, the regulation, the upstream code, and it's tedious enough that mostly nobody does. research sends an agent to do the reading against the original sources and come back with findings you can check, each one pointing at where it was found. When the missing facts live in someone's head instead of a document, you get a list of questions for that person instead of a made-up answer.",
+  },
+  "codebase-review": {
+    card:
+      "Every so often, agents walk the whole codebase and report where it has gotten hard to work in. You decide what's worth fixing; nothing gets changed behind your back.",
+    intro:
+      "Agents merge work fast, and the codebase quietly accumulates the cost: duplication, drift, corners nobody owns. codebase-review is the periodic walk-through. Agents survey the whole codebase rather than one change and report where it has gotten hard to work in. It reports and files tickets; it fixes nothing behind your back, and it's no substitute for reviewing each change on its way in.",
+  },
+  prototype: {
+    card:
+      "Some design questions can't be settled by talking. This builds a quick throwaway version so you can click around and decide. The code is meant to be deleted, not shipped.",
+    intro:
+      "Some questions survive any amount of discussion: how should this screen feel, is this interaction annoying, which of these two layouts is right. prototype ends the debate by building the cheapest version you can actually click. The code is throwaway on purpose — it exists to answer the question, and it's deleted once the question is answered. Shipping it would be the mistake the skill exists to prevent.",
+  },
+
+  // ── Run ────────────────────────────────────────────────────────────────────
+  diagnose: {
+    card:
+      "No bug fix ships until the agent can say what was actually broken, in one plain sentence, with evidence. A patch that just makes the symptom go away gets sent back.",
+    intro:
+      "The fastest way to keep a bug is to fix its symptom. An agent will happily patch until the error stops appearing and call it done. diagnose refuses that: no fix ships until the cause fits in one plain sentence, with evidence behind it. It's slower on the easy bugs, and worth it on every bug you'd otherwise meet twice.",
+  },
+  implement: {
+    card:
+      "The agent builds in thin slices that each work end to end, and proves each slice before starting the next. You get checkpoints you can see, not one long silence and a giant pile of code.",
+    intro:
+      "Left alone, an agent will build for an hour and hand you one giant batch of changes to untangle. implement is the building discipline: thin slices that each work end to end, a test written before the code it proves, a working checkpoint after every slice. Things discovered along the way get filed as new work instead of chased on the spot. You see progress you can check, not a long silence.",
+  },
+  "to-tickets": {
+    card:
+      "Turns a plan you've already settled into tracker tickets a stranger could pick up cold, in the right order. It won't paper over a plan that's still full of holes.",
+    intro:
+      "A plan that lives in a conversation dies with the conversation. to-tickets turns a settled plan into tracker tickets a stranger could pick up cold, with the order of work wired in so nothing starts before the thing it depends on. It needs the plan actually settled first. It won't paper over the holes, and it shouldn't.",
+  },
+  wizard: {
+    card:
+      "For the steps only you can do: passwords, vendor dashboards, DNS records. Your agent builds a walkthrough that takes you through click by click and checks that each step actually worked.",
+    intro:
+      "Some steps an agent simply cannot do for you: the password only you know, the vendor dashboard only you can log into, the DNS record on your registrar. wizard builds an interactive walkthrough for exactly those steps, taking you through click by click and checking that each step actually worked before moving on. If an agent could do the step itself, this is the wrong tool.",
+  },
+  orchestrate: {
+    card:
+      "One session becomes the manager. It hands work to parallel agents, checks what comes back, and owns fitting the pieces together. It needs a plan that's already decided; it won't decide for you.",
+    intro:
+      "Running several agents in parallel sounds like leverage, until you become the bottleneck between them. orchestrate turns one session into the coordinator: it routes work to parallel sessions, audits what comes back, and owns fitting the pieces together instead of building anything itself. It needs decided work sitting on a tracker to route. It won't untangle an undecided mess.",
+  },
+  "adversarial-review": {
+    card:
+      "Before anything ships, a team of agents tries to break it, and a skeptic tries to prove them wrong. Only problems that survive both reach you. I can't read the code, so the review has to be this honest.",
+    intro:
+      "You can't review what you can't read, and I can't read code. adversarial-review is how a change earns its way out anyway: a team of agents each tries to break it from a different angle, then a skeptic tries to prove every finding wrong. Only the problems that survive both passes reach you, so what you see is short and real. It blocks shipping on confirmed problems; it can't promise there are none left.",
+  },
+  handoff: {
+    card:
+      "When a session ends, where the work stands goes into one small file. The next session reads it and picks up mid-stride. You stop re-explaining the project every morning.",
+    intro:
+      "Yesterday's session knew the plan, the constraints, and the half-finished thread, and this morning's session knows nothing. handoff ends a session by writing where the work stands into one small file, so the next session picks up mid-stride instead of interviewing you about the last one. It's a pointer, not a transcript: the deep history stays in the records the file points to.",
+  },
+
+  // ── Author ─────────────────────────────────────────────────────────────────
+  "writing-for-agents": {
+    card:
+      "Instructions for agents fail quietly: read once, skimmed later, then ignored. This is my standard for writing instructions an agent will actually follow, and for cutting the ones it won't.",
+    intro:
+      "You write careful instructions for your agent, and three sessions later it's ignoring half of them. Usually the document is the problem: too long to load, too vague to fire at the right moment, too buried to find. writing-for-agents is the standard for the documents agents consume, and just as much for pruning them. It makes instructions predictable rather than beautiful; pages for people belong with its sibling, writing-for-humans.",
+  },
+  "writing-for-humans": {
+    card:
+      "Agents write pages that read like documentation for other agents. This is my standard for copy a person would keep reading, down to a last scrub for the phrases that give AI writing away.",
+    intro:
+      "Ask an agent for a landing page and you get something that reads like documentation wearing a costume: technically clear, and nothing a person wants to keep reading. writing-for-humans is the standard the pages on this site are held to. Open from the reader's chair, say plainly what a thing won't do, and scrub the phrases that give AI writing away. It can't supply the opinions — those still have to be yours.",
+  },
+  huh: {
+    card:
+      "When your agent's answer doesn't quite make sense, this reads it back in plain sentences and flags which parts are proven and which are just confident.",
+    intro:
+      "Agents produce messages that are confident, dense, and not quite parseable: invented shorthand, claims with nothing behind them, a request buried inside a report. huh reads the message back in plain sentences, expands the shorthand, separates what's being reported from what's being asked, and flags which claims come with evidence and which are just confident. It decodes; it can't verify the claims for you, only mark which ones arrived unproven.",
+  },
+};
+
+/**
+ * The strict accessor every human surface goes through. Throwing here fails
+ * `next build` for a promoted skill with no human copy — the regression this
+ * file exists to prevent is agent text quietly returning to a human page.
+ */
+export function human(slug: string): HumanCopy {
+  const copy = HUMAN[slug];
+  if (!copy) {
+    throw new Error(
+      `human.ts: no human copy for "${slug}". Every promoted skill needs a card ` +
+        "and an intro in src/lib/human.ts before it can ship to the site.",
+    );
+  }
+  return copy;
+}

--- a/site/src/lib/skills.ts
+++ b/site/src/lib/skills.ts
@@ -203,12 +203,3 @@ export function getCodexPlugin(): { name: string; marketplace: string; skills: n
   );
   return { name: plugin.name, marketplace: marketplace.name, skills: plugin.skills.length };
 }
-
-/**
- * The first sentence of a description is what it does; the "Use when" clause is
- * where the triggers live. Cards show the former, detail pages show both.
- */
-export function summarize(description: string): string {
-  const cut = description.search(/\s(?:Use when|Use for)\b/);
-  return (cut === -1 ? description : description.slice(0, cut)).trim();
-}


### PR DESCRIPTION
Full human-readability pass on the skill surfaces, per Tim's directive: the site is for humans, many of whom don't code, so no page a person reads should speak the agent's trigger vocabulary.

## What changed

- **New `site/src/lib/human.ts`** — one entry per promoted skill, written pain-first, fix in plain words, honest limit where it earns trust. Two forms: `card` (link-preview tagline, catalog entry line, meta description, the legend term page's implemented-by pointer) and `intro` (opens the skill page, replacing both the old `SUBJECT_CLAIMS` sentence and the verbatim "Use when …" trigger line).
- Tim's three seed lines (adversarial-review, grilling, huh) are carried **verbatim**; the other 17 follow their register.
- `summarize()` in `skills.ts` lost its last caller and is removed, so nobody reaches for agent text by habit.
- **Tripwire:** `human()` throws on an unknown slug, so promoting a skill without human copy fails `next build` instead of quietly shipping agent text back onto a human page. (Check: `npm run build` with a new promoted skill and no `human.ts` entry fails with a named error.)

## What did not change

- **The agent view.** No `skills/*/SKILL.md` was touched; the flip's Markdown twins still serve the raw bytes (verified in the browser and by diffing `/skills/adversarial-review.md` against the source — only the pre-existing #213 install trailer differs, as before).
- **Legend definitions** — untouched, per the build-enforced rules.
- Homepage, /work, /instruments — audited, already in the human voice (PR #149 holds); verified rather than rewritten.

## Flagged, not fixed (chrome that reads agent-flavored — your call)

1. `skills/buckets.json` orient blurb: "Bind the discipline to a repo…" — "bind" / "repo" are our words, not a reader's. Shared file (feeds the marketplace tooling too), so left alone.
2. `/legend` group standfirst "How work is arranged": opens with "Decomposition, ownership…" — term of art before it's taught.
3. Site-wide meta description in `layout.tsx`: "…research lanes, orchestration…" — "lanes" is internal vocabulary.

## Verification

- `npm run build` green (the build runs the legend + catalog + human-copy asserts).
- `check_site_disclosure.py`, `check_router_freshness.py`, `check_invocation_freshness.py` all OK.
- `check_skill_og_cards.py` (the #215 tripwire) passes against `next start`, including the longest new tagline (advisory-board, 211 chars — renders as four lines, screenshot in comments below).

## Card line — link previews, catalog entries, meta descriptions, legend's implemented-by pointer

| skill | before (agent description, first sentence) | after (human card) |
|---|---|---|
| **router** | Entry point for the team-workflow pack — names every pack skill and when to reach for it. | You won't remember every skill in a pack this size, and you shouldn't have to. Ask your agent what fits the moment and it names the skill and says why. It points; it never runs anything on its own. |
| **setup** | Once-per-repo binding interview for the team-workflow pack — records how the pack composes with this repo and seeds the binding doc the other skills read. | One short interview teaches the pack how your project works: how you test, where the work is tracked, who has the final say. Answer once, and the other skills stop asking. |
| **domain-memory** | Keep per-repo institutional memory — a domain glossary plus lightweight decision records, written as side effects of work. | What your project's words mean, and why old arguments were settled the way they were, written down as the work happens. A new session stops reopening decisions you already made. |
| **grilling** | Interview the decider relentlessly to turn a half-formed plan, design, or idea into shared understanding — a design tree worked in rounds until nothing is silently assumed. | Your agent asks you every hard question before the work starts. Vague plans die in the interview instead of in the code. |
| **advisory-board** | Convene a multi-model advisory board — subscription-backed Claude, Codex, Gemini, and Grok CLIs reviewing the same material in formal, roundtable, or competitive mode. | One model's answer is one opinion. This puts the same question to Claude, Codex, Gemini, and Grok, lets them read each other, and hands you one verdict with the disagreement kept visible. The call is still yours. |
| **decision-map** | Chart or work a decision map for genuinely foggy work — a new primitive, a milestone charter, an integration nobody can spec in one sitting — before any build slice is written. | For work too foggy to plan in one sitting. The open questions go on a map, with what blocks what, and building waits until nothing the build rests on is still a guess. |
| **ingest** | Turn a video, recording, voice memo, or media URL into an evidence packet — authoritative transcript, timestamped frames, manifest — plus a routing recommendation. | Give it a call recording, a demo video, or a voice memo. You get back what was actually said, with timestamps and stills to prove it. It won't guess at words it can't hear. |
| **research** | Run an autonomous research lane against primary sources, ending in cited findings — and, when the missing facts are human-held, a questionnaire. | An agent goes and reads the actual sources: the vendor docs, the regulation, the upstream code. It comes back with findings you can check, each one pointing at where it was found. |
| **codebase-review** | Run a state review of the codebase — the counterpart to adversarial-review's change review. Use before building against an upcoming spec (make the change easy first), when lanes merged since the last review cross the repo's threshold, or when lanes or the orchestrator report the code fighting them. | Every so often, agents walk the whole codebase and report where it has gotten hard to work in. You decide what's worth fixing; nothing gets changed behind your back. |
| **prototype** | Build throwaway prototype code that answers a design question — UI variants on a live route, or a terminal UI or single shareable HTML file over a pure logic module. | Some design questions can't be settled by talking. This builds a quick throwaway version so you can click around and decide. The code is meant to be deleted, not shipped. |
| **diagnose** | The disciplined bug-fixing loop — no fix ships without a cause the fixer can state in one plain sentence, with evidence. | No bug fix ships until the agent can say what was actually broken, in one plain sentence, with evidence. A patch that just makes the symptom go away gets sent back. |
| **implement** | How a working lane builds an item — seam-scoped test-first, tracer-first sequencing, a green checkpoint per slice, and file-don't-fix scope discipline. | The agent builds in thin slices that each work end to end, and proves each slice before starting the next. You get checkpoints you can see, not one long silence and a giant pile of code. |
| **to-tickets** | Turn a plan, a spec, a closed decision map, or a pressure-tested conversation into tracer-bullet work items on the repo's tracker, each an issue-as-spec with its blocking edges wired. | Turns a plan you've already settled into tracker tickets a stranger could pick up cold, in the right order. It won't paper over a plan that's still full of holes. |
| **wizard** | Generate an interactive bash wizard that walks a human through a procedure only they can perform — third-party dashboards, credentials, DNS records, CI secrets, one-off cutovers. | For the steps only you can do: passwords, vendor dashboards, DNS records. Your agent builds a walkthrough that takes you through click by click and checks that each step actually worked. |
| **orchestrate** | Run a session as the orchestrator of parallel agent-assisted work — routing items to working sessions, auditing results, and owning integration, instead of implementing. | One session becomes the manager. It hands work to parallel agents, checks what comes back, and owns fitting the pieces together. It needs a plan that's already decided; it won't decide for you. |
| **adversarial-review** | Run an adversarial review of a change before it ships — isolated finders trying to break it, a skeptic pass that kills unproven findings, and a gate on confirmed blockers. Use before committing substantial work, at lane close-out, when the user asks for an adversarial or red-team review of a diff/branch/PR, or before external reviewers see the change. | Before anything ships, a team of agents tries to break it, and a skeptic tries to prove them wrong. Only problems that survive both reach you. I can't read the code, so the review has to be this honest. |
| **handoff** | Write a structured session handoff so a fresh session resumes losslessly. | When a session ends, where the work stands goes into one small file. The next session reads it and picks up mid-stride. You stop re-explaining the project every morning. |
| **writing-for-agents** | Write and prune documents an agent consumes — a SKILL.md, an AGENTS.md or CLAUDE.md, a reference file reached by a pointer. | Instructions for agents fail quietly: read once, skimmed later, then ignored. This is my standard for writing instructions an agent will actually follow, and for cutting the ones it won't. |
| **writing-for-humans** | Write copy a human reads — a landing page, a README's front half, a launch post, a profile page. | Agents write pages that read like documentation for other agents. This is my standard for copy a person would keep reading, down to a last scrub for the phrases that give AI writing away. |
| **huh** | Decode a message that didn't land — restate it in plain sentences, expand invented shorthand, split report from request, and flag claims stated without evidence. | When your agent's answer doesn't quite make sense, this reads it back in plain sentences and flags which parts are proven and which are just confident. |

## Page intro — replaces the subject claim + the verbatim "Use when …" trigger on /skills/<name>

| skill | before (the agent trigger the page showed) | after (human intro) |
|---|---|---|
| **router** | Use when unsure which team-workflow skill applies, or to orient a new session/repo on what the pack offers. | A pack this size has a findability problem: you won't remember every skill in it, and you shouldn't have to. router is the front door. Ask your agent what fits the situation and it names the right skill and says why. It's a map, not a manager — it points, and you decide whether to go. |
| **setup** | Use when installing the pack into a repo, refreshing an existing installation's bindings, or auditing a consuming repo for drift after a pack release (audit mode). | Every new tool asks you the same questions about your project, forever. setup asks them once. It's a short interview, run one time per project: how you test, where work is tracked, who has the final say. The answers are written down where every other skill can read them, so none of them has to ask again. It records how you already work; it never restructures anything. |
| **domain-memory** | Use when a grilling closes, a review rejection or declined finding is dispositioned, the decider corrects a session's wrong assumption, a session starts in a repo whose binding names a memory home, or the store passes its size bound. | Every project builds up a private language and a pile of settled arguments, and a fresh agent session knows none of it. So it asks again, or worse, quietly decides differently this time. domain-memory writes the language and the decisions down as a side effect of ordinary work: when a plan survives its interview, when a review finding is declined, when you correct a wrong assumption. It can only record decisions somebody actually stated out loud — it won't reconstruct why something was done last year. |
| **grilling** | Use when asked to grill, stress-test, or pressure-test thinking, and before charting a decision map or writing a spec off a conversation nobody has pressure-tested. | You describe a feature, the agent agrees instantly, and hours later you're reviewing a polished version of something you never meant. The gaps you didn't fill, it filled with guesses. grilling flips the ritual: the agent interviews you, round after round of hard questions, until nothing important is still assumed and the answers are written down. Vague plans die in the interview instead of in the code. It works only as hard as your answers, so bring real attention. |
| **advisory-board** | Use when the user asks for an advisory board, roundtable, panel, or idea tournament; a multi-model or cross-provider review or debate; a red-team of a plan, design, decision, or document by several models; or a consensus handoff from several frontier models. | A hard call — an architecture, a migration, a contract — usually gets decided by whichever model you happened to ask, in one pass, with nobody pushing back. advisory-board convenes Claude, Codex, Gemini, and Grok on the same question, has them answer independently, then read and challenge each other. You get one verdict with the disagreement kept visible and a list of what the board could not verify. It's slower than asking once, on purpose, and it's still models arguing with models: the final call stays yours. |
| **decision-map** | Use when asked to chart a decision map, work a map ticket, or plan a decision-heavy effort whose open questions gate each other. | Some work is too foggy to plan in one sitting: a new kind of feature, an integration nobody fully understands yet. Writing it up as a simple to-do list just hides the unknowns. decision-map charts the open questions instead, with what blocks what, and the map is worked question by question until nothing the build rests on is still a guess. It's for genuinely foggy work. If you could spec the thing in an afternoon, this is overhead. |
| **ingest** | Use when the user shares a media file or URL with a goal, asks to process or transcribe a recording, or wants takeaways from a call, demo, playtest, or video. | An hour-long call recording is where decisions go to disappear. ingest turns a video, a recording, or a voice memo into evidence you can actually use: a transcript you can trust, stills with timestamps, and a recommendation for what to do with what was said. When the audio is bad, it marks what it couldn't hear rather than guessing. |
| **research** | Use for investigations of vendor materials, regulations, upstream repos, recorded calls, or any fact-finding that should run fire-and-report. | Somebody has to actually read the vendor docs, the regulation, the upstream code, and it's tedious enough that mostly nobody does. research sends an agent to do the reading against the original sources and come back with findings you can check, each one pointing at where it was found. When the missing facts live in someone's head instead of a document, you get a list of questions for that person instead of a made-up answer. |
| **codebase-review** |  | Agents merge work fast, and the codebase quietly accumulates the cost: duplication, drift, corners nobody owns. codebase-review is the periodic walk-through. Agents survey the whole codebase rather than one change and report where it has gotten hard to work in. It reports and files tickets; it fixes nothing behind your back, and it's no substitute for reviewing each change on its way in. |
| **prototype** | Use when a question is "how should this look / behave / feel in action" and discussion or static artifacts cannot settle it. | Some questions survive any amount of discussion: how should this screen feel, is this interaction annoying, which of these two layouts is right. prototype ends the debate by building the cheapest version you can actually click. The code is throwaway on purpose — it exists to answer the question, and it's deleted once the question is answered. Shipping it would be the mistake the skill exists to prevent. |
| **diagnose** | Use when any fix is about to ship without a nameable cause, when a bug resists its first fix attempt, or when a bug-shaped lane brief points here. | The fastest way to keep a bug is to fix its symptom. An agent will happily patch until the error stops appearing and call it done. diagnose refuses that: no fix ships until the cause fits in one plain sentence, with evidence behind it. It's slower on the easy bugs, and worth it on every bug you'd otherwise meet twice. |
| **implement** | Use when a build-shaped lane brief points here, when implementing a spec or tracked item, or when mid-build discoveries tempt a lane beyond its brief. | Left alone, an agent will build for an hour and hand you one giant batch of changes to untangle. implement is the building discipline: thin slices that each work end to end, a test written before the code it proves, a working checkpoint after every slice. Things discovered along the way get filed as new work instead of chased on the spot. You see progress you can check, not a long silence. |
| **to-tickets** | Use when asked to file tickets, break work down, or move from "we've decided" to "it's on the board". | A plan that lives in a conversation dies with the conversation. to-tickets turns a settled plan into tracker tickets a stranger could pick up cold, with the order of work wired in so nothing starts before the thing it depends on. It needs the plan actually settled first. It won't paper over the holes, and it shouldn't. |
| **wizard** | Use when a task stalls on steps an agent cannot take, or when a manual setup is tedious to re-explain every time. Not for steps the agent can perform itself. | Some steps an agent simply cannot do for you: the password only you know, the vendor dashboard only you can log into, the DNS record on your registrar. wizard builds an interactive walkthrough for exactly those steps, taking you through click by click and checking that each step actually worked before moving on. If an agent could do the step itself, this is the wrong tool. |
| **orchestrate** | Use when the user says "orchestration mode", asks one session to coordinate several lanes/sessions, or hands over an orchestrator role. | Running several agents in parallel sounds like leverage, until you become the bottleneck between them. orchestrate turns one session into the coordinator: it routes work to parallel sessions, audits what comes back, and owns fitting the pieces together instead of building anything itself. It needs decided work sitting on a tracker to route. It won't untangle an undecided mess. |
| **adversarial-review** |  | You can't review what you can't read, and I can't read code. adversarial-review is how a change earns its way out anyway: a team of agents each tries to break it from a different angle, then a skeptic tries to prove every finding wrong. Only the problems that survive both passes reach you, so what you see is short and real. It blocks shipping on confirmed problems; it can't promise there are none left. |
| **handoff** | Use when context is filling up (around half the window), when wrapping a work session, or when the user says "handoff", "checkpoint", "wrap up", or "save state". | Yesterday's session knew the plan, the constraints, and the half-finished thread, and this morning's session knows nothing. handoff ends a session by writing where the work stands into one small file, so the next session picks up mid-stride instead of interviewing you about the last one. It's a pointer, not a transcript: the deep history stays in the records the file points to. |
| **writing-for-agents** | Use when authoring or revising a skill, editing standing agent instructions, or diagnosing why a document fires unreliably or gets skimmed. | You write careful instructions for your agent, and three sessions later it's ignoring half of them. Usually the document is the problem: too long to load, too vague to fire at the right moment, too buried to find. writing-for-agents is the standard for the documents agents consume, and just as much for pruning them. It makes instructions predictable rather than beautiful; pages for people belong with its sibling, writing-for-humans. |
| **writing-for-humans** | Use when drafting or revising public-facing prose, when a page reads like agent documentation, or when a finished draft needs its last-mile scrub for AI tells. | Ask an agent for a landing page and you get something that reads like documentation wearing a costume: technically clear, and nothing a person wants to keep reading. writing-for-humans is the standard the pages on this site are held to. Open from the reader's chair, say plainly what a thing won't do, and scrub the phrases that give AI writing away. It can't supply the opinions — those still have to be yours. |
| **huh** | Use when the user signals your last message didn't land ("huh?", "what do you mean"), or pastes agent output from another session to translate. | Agents produce messages that are confident, dense, and not quite parseable: invented shorthand, claims with nothing behind them, a request buried inside a report. huh reads the message back in plain sentences, expands the shorthand, separates what's being reported from what's being asked, and flags which claims come with evidence and which are just confident. It decodes; it can't verify the claims for you, only mark which ones arrived unproven. |