### PR TITLE
ci: markdown twins can't silently drift from their SKILL.md sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
           npm run start &
           python3 ../scripts/check_skill_og_cards.py
 
+      # Tripwire for the Markdown twins (#216 close-out): /skills/<name>.md
+      # serves each source SKILL.md body byte-identical; only the regenerated
+      # frontmatter and the #213 install trailer may differ. Reuses the server
+      # the previous step started. See the script's docstring.
+      - name: Check markdown twins match their source SKILL.md
+        working-directory: site
+        run: python3 ../scripts/check_skill_md_twins.py
+
   advisory-board:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/check_skill_md_twins.py
+++ b/scripts/check_skill_md_twins.py
@@ -62,6 +62,8 @@ def promoted_skill_files() -> list[tuple[str, Path]]:
             continue
         for skill_file in sorted(bucket_dir.glob("*/SKILL.md")):
             out.append((skill_file.parent.name, skill_file))
+    if not out:
+        raise SystemExit("no promoted skills discovered — a green run would check nothing")
     return out
 
 

--- a/scripts/check_skill_md_twins.py
+++ b/scripts/check_skill_md_twins.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Tripwire for the Markdown twins (PR #216 close-out).
+
+Every promoted skill's `/skills/<name>.md` route must serve the SKILL.md an
+agent would install. This fetches each twin from a running site build and
+asserts, so a serving regression fails CI instead of shipping silently:
+
+  1. The body — everything between the frontmatter and the #213 install
+     trailer — is byte-identical to the source SKILL.md body (the route
+     strips leading whitespace, so the comparison allows only that).
+  2. The regenerated frontmatter carries the source's name and description
+     verbatim, modulo the quote-stripping the site's parser applies. That
+     regeneration and the appended install trailer are the only sanctioned
+     differences.
+
+Standard library only. Expects `next start` to be listening; retries until
+the server is up. Usage:
+
+  python3 scripts/check_skill_md_twins.py [--base http://localhost:3000]
+                                          [--slug adversarial-review]
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRAILER = "\n\n---\n\nShips in: "
+
+
+def fetch(url: str, timeout: float = 15.0) -> bytes:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return response.read()
+
+
+def fetch_when_up(url: str, deadline: float = 60.0) -> bytes:
+    """Retry until the dev/prod server answers — it starts in parallel."""
+    start = time.monotonic()
+    while True:
+        try:
+            return fetch(url)
+        except (urllib.error.URLError, ConnectionError, OSError) as error:
+            if time.monotonic() - start > deadline:
+                raise SystemExit(f"server never answered at {url}: {error}")
+            time.sleep(1)
+
+
+def promoted_skill_files() -> list[tuple[str, Path]]:
+    """(slug, SKILL.md path) for every skill the site publishes."""
+    buckets = json.loads((REPO_ROOT / "skills" / "buckets.json").read_text())["buckets"]
+    out = []
+    for bucket in buckets:
+        if not bucket["promoted"]:
+            continue
+        bucket_dir = REPO_ROOT / "skills" / bucket["id"]
+        if not bucket_dir.is_dir():
+            continue
+        for skill_file in sorted(bucket_dir.glob("*/SKILL.md")):
+            out.append((skill_file.parent.name, skill_file))
+    return out
+
+
+def split_source(raw: str) -> tuple[dict[str, str], str]:
+    """Frontmatter fields and body of a source SKILL.md.
+
+    The value transform (strip, then unquote) mirrors the site's parser —
+    that transform is the sanctioned frontmatter difference being allowed,
+    so it is replicated rather than trusted.
+    """
+    lines = raw.split("\n")
+    if lines[0] != "---":
+        raise SystemExit(f"source has no frontmatter: {raw[:40]!r}")
+    close = lines.index("---", 1)
+    fields = {}
+    for line in lines[1:close]:
+        match = re.match(r"^([A-Za-z][\w-]*):\s*(.*)$", line)
+        if not match:
+            continue
+        value = match.group(2).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        fields[match.group(1)] = value
+    body = "\n".join(lines[close + 1 :])
+    return fields, body
+
+
+def check_twin(slug: str, skill_file: Path, base: str) -> list[str]:
+    fields, source_body = split_source(skill_file.read_text(encoding="utf-8"))
+    served = fetch_when_up(f"{base}/skills/{slug}.md").decode("utf-8")
+
+    head, sep, rest = served.partition("\n---\n\n")
+    if not sep:
+        return [f"{slug}: served twin has no frontmatter block"]
+
+    failures = []
+    expected_head = ["---", f"name: {fields.get('name', '')}", f"description: {fields.get('description', '')}"]
+    if head.split("\n") != expected_head:
+        failures.append(f"{slug}: regenerated frontmatter does not match the source's name/description")
+
+    cut = rest.rfind(TRAILER)
+    if cut == -1:
+        return failures + [f"{slug}: served twin has no install trailer (#213)"]
+    served_body = rest[:cut]
+
+    # The route serves body.trimStart(); beyond that, byte-identical.
+    if served_body != source_body.lstrip():
+        want, got = source_body.lstrip(), served_body
+        at = next((i for i, (a, b) in enumerate(zip(want, got)) if a != b), min(len(want), len(got)))
+        line = want.count("\n", 0, at) + 1
+        failures.append(
+            f"{slug}: served body diverges from {skill_file.relative_to(REPO_ROOT)} "
+            f"around body line {line} (want {want[at:at + 40]!r}, got {got[at:at + 40]!r})"
+        )
+    return failures
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="http://localhost:3000")
+    parser.add_argument("--slug", help="check a single skill instead of all promoted ones")
+    args = parser.parse_args()
+
+    skills = promoted_skill_files()
+    if args.slug:
+        skills = [s for s in skills if s[0] == args.slug]
+        if not skills:
+            raise SystemExit(f"no promoted skill named {args.slug!r}")
+
+    failures = []
+    for slug, skill_file in skills:
+        failures.extend(check_twin(slug, skill_file, args.base))
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        raise SystemExit(1)
+    print(f"markdown twins byte-identical for all {len(skills)} promoted skills")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
PR #216's close-out review found that the site's agent-facing flip — the `.md` twin route (`site/src/app/api/skill-md`, rewritten from `/skills/<name>.md`) serving each skill's SKILL.md — had no CI tripwire. It was verified by hand-curling the built site and byte-comparing against the sources.

**What this adds**

- `scripts/check_skill_md_twins.py`, patterned on `check_skill_og_cards.py`: stdlib-only, fetches **every promoted skill's** twin from a running `next start` and asserts the body (between the frontmatter and the #213 install trailer) is **byte-identical** to the source SKILL.md body. The only sanctioned differences are the route's regenerated frontmatter (name/description, quote-stripped — the known #213-era transformation) and the appended install trailer; the frontmatter regeneration is itself checked against the source values.
- A step in the existing `site-link-previews` job, reusing the server the og-cards step starts in the background.

**Verified locally**

- Passes for all 20 promoted skills against a fresh `npm run build` + `next start`.
- Negative test: appending a line to `skills/run/diagnose/SKILL.md` without rebuilding fails the check with a line-numbered divergence message (`served body diverges … around body line 54`).