### PR TITLE
memory: pstack adaptation wave decision records (0003, 0004)

### DIFF
--- a/docs/agents/memory/decisions/0003-pstack-adaptation-wave-scope.md
+++ b/docs/agents/memory/decisions/0003-pstack-adaptation-wave-scope.md
@@ -1,0 +1,24 @@
+# 0003 — pstack adaptation wave: scope and shape
+
+- Date: 2026-08-19
+- Links: grilling session off the Theo video ingest packet (`~/.ingest/theo-skills-video-2026-08-19`, fit matrix therein); wave tickets filed same day
+
+The catalog adopts from Lauren Tan's pstack (github.com/cursor/plugins, `pstack/`, MIT) exactly
+three new standalone skills — a chat-voice skill named **plainspoken** (adapted from unslop,
+auto-firing), **blast-radius**, and **show-me-your-work** (names kept: plain English, not
+coinages; renaming applies only where our version meaningfully diverges) — and everything else
+lands as grafts: the 5-rung evidence ladder plus interrogate's lead-judgment guidance into
+adversarial-review, an optional graft-and-verify phase into advisory-board's Competitive mode,
+and one-liner steals where they fit. The ceiling is deliberate: each promoted skill costs a
+marketplace claim, Codex mirror, human.ts entry, OG card, and CI wiring, and the decider chose
+grafts-over-clones wherever existing skills already carry the capability.
+
+Cross-model needs (interrogate-style reviewer diversity, show-me-your-work's closing gate,
+arena's cross-judge) route through advisory-board's existing CLI-seat plumbing rather than any
+new multi-model mechanism — reuses tested machinery and stays inside the recorded
+Anthropic-ask-first lanes.
+
+Deferred to a later wave (decider-dispositioned, not forgotten): a technical-documentation
+register skill (the fourth register beside writing-for-agents / writing-for-humans / pr-writing),
+a standalone prove-it-works, an arena-as-skill clone, and an advisory-board "quick change-review"
+preset.

--- a/docs/agents/memory/decisions/0004-tell-catalog-single-owner.md
+++ b/docs/agents/memory/decisions/0004-tell-catalog-single-owner.md
@@ -1,0 +1,13 @@
+# 0004 — AI-tell catalog has a single owner: plainspoken
+
+- Date: 2026-08-19
+- Links: same grilling as 0003; plainspoken wave ticket
+
+The merged AI-tell catalog (pstack unslop's 31 patterns folded together with
+writing-for-humans' 12-cluster last-mile scrub) lives in **plainspoken**, the auto-firing
+chat-voice skill; writing-for-humans' scrub section becomes a pointer to it plus only its
+artifact-specific additions (voice samples outrank rules, no-fabrication, marketing register) —
+because two catalogs drift, and the single-source-of-truth rule in writing-for-agents governs
+our own skills too. Boundary sentence on the record: plainspoken is how you write anywhere;
+writing-for-humans is what a shipped page needs beyond clean prose; huh repairs a message that
+already failed, plainspoken prevents the failure.


### PR DESCRIPTION
Grilling close-out write per the domain-memory binding: two decision records for the pstack adaptation wave settled by the decider today — wave scope/shape (three new standalone skills: plainspoken, blast-radius, show-me-your-work; everything else grafts; cross-model needs route through advisory-board CLI seats) and single ownership of the AI-tell catalog (plainspoken owns; writing-for-humans points).

Doc-only change; reviewer-run link gate: the records contain no relative Markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)