### PR TITLE
Readability pass: the front half of every SKILL.md survives being read aloud (#227)

### DIFF
--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -15,6 +15,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Readability pass on SKILL.md front halves** (#227, Theo-video takeaways): the opening
+  paragraphs of eight pack skills (router, decision-map, domain-memory, prototype,
+  codebase-review, implement, diagnose, orchestrate) now read as plain sentences with the
+  pitch before the mechanics: clause-stacked openings split, the coined "expensive-fidelity
+  tool" and "lens-named finders" phrasings spelled out, and decision-map's pitch moved above
+  its session-mechanics paragraph. Register-only edits: no rule weakened, dropped, or
+  reordered; frontmatter descriptions untouched.
 - **Em-dash sweep across every pack skill** (#226): all pack SKILL.mds and their
   references (router, setup and its templates and tracker-discipline, domain-memory,
   grilling, decision-map, prototype, research, codebase-review, to-tickets, wizard,

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -8,6 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Context-pointers definition gets a readable lead** (#227, Theo-video takeaways): the
+  paragraph defining a context pointer now opens with a plain-English sentence carrying the
+  examples, with the precise definition kept verbatim after it. No rule changed.
+
 ### Added
 - **Punctuation rule** (#226): a compact section stating that skill prose carries
   no em dashes (periods, commas, colons instead), because the em dash is a top AI

--- a/skills/author/writing-for-agents/SKILL.md
+++ b/skills/author/writing-for-agents/SKILL.md
@@ -11,7 +11,7 @@ This skill is reference, not a sequence: consult the rung that matches what you'
 
 ## Context pointers
 
-A **context pointer** is a reference the agent already holds that names material it does not, plus the condition for going and getting it. A skill's `description` is one. A line in `AGENTS.md` naming a doc is the same object.
+An agent often holds a short line that points at material it has not loaded: a skill's `description`, or a line in `AGENTS.md` naming a doc. That line is a **context pointer**: a reference the agent already holds that names material it does not, plus the condition for going and getting it.
 
 The pointer's **wording**, not its target, decides whether the agent reaches the material. A must-have target behind a weakly worded pointer is a variance bug: the material is right and the firing is a coin flip. Sharpen the wording first; inline the material only when sharpening has already failed.
 

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -10,6 +10,9 @@ versioned separately and do not replace the skill release version.
 ## [Unreleased]
 
 ### Changed
+- **Readability pass on the opening paragraph** (#227): the single dense mode sentence is
+  now one plain sentence per mode; every fact (mode names, the default, the intake
+  reference, the per-mode shapes) is unchanged. Frontmatter description untouched.
 - **Em-dash sweep** (#226): SKILL.md and all thirteen references rewrote their
   em-dash constructions into periods, commas, colons, or restructured sentences,
   meaning-preserving: every Must-Not and schema rule keeps its exact force, and

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -5,7 +5,7 @@ description: Convene a multi-model advisory board: subscription-backed Claude, C
 
 # Advisory Board
 
-Bring an idea, problem, plan, or architecture to a board of frontier models sitting in different roles. The board runs in one of three **modes**, the interaction topology chosen with the user at intake (`references/modes.md`): **Formal Board Review** (the default: independent first round, rebuttal, structured verdict; the protocol this document defines), **Roundtable** (collaborative, shared transcript, optional moderator), or **Competitive** (pitch → critique → blind vote). Whatever the mode, you leave with the strongest conclusion the board can reach together and a clean takeaway, not disconnected opinions.
+Bring an idea, problem, plan, or architecture to a board of frontier models sitting in different roles. The board runs in one of three **modes**, the interaction topology chosen with the user at intake (`references/modes.md`). **Formal Board Review** is the default and the protocol this document defines: an independent first round, then rebuttal, then a structured verdict. **Roundtable** is collaborative, on a shared transcript, with an optional moderator. **Competitive** runs pitch, then critique, then a blind vote. Whatever the mode, you leave with the strongest conclusion the board can reach together and a clean takeaway, not disconnected opinions.
 
 ## Must Not
 

--- a/skills/decide/decision-map/SKILL.md
+++ b/skills/decide/decision-map/SKILL.md
@@ -5,9 +5,9 @@ description: Chart or work a decision map for genuinely foggy work before any bu
 
 # Decision Map
 
-You are running a decision-map session. The protocol authority is [references/protocol.md](references/protocol.md). Read it first, whole; this skill only sequences the session. If the consuming repo has a domain-vocabulary or context doc (see its team-workflow binding doc, seeded by the setup skill), load that too and use its terms.
+A decision map turns fog into recorded decisions. It is for work nobody can spec in one sitting, where the open questions gate each other. It produces decisions, not deliverables: when the map's frontier is empty, the scope specs and builds as ordinary tracked work.
 
-A decision map exists to turn fog into recorded decisions. It produces decisions, not deliverables: when the map's frontier is empty, the scope specs and builds as ordinary tracked work.
+You are running a decision-map session. The protocol authority is [references/protocol.md](references/protocol.md). Read it first, whole; this skill only sequences the session. If the consuming repo has a domain-vocabulary or context doc (see its team-workflow binding doc, seeded by the setup skill), load that too and use its terms.
 
 ## Mode 1: charting a new map (invoked with a scope or destination)
 

--- a/skills/investigate/codebase-review/SKILL.md
+++ b/skills/investigate/codebase-review/SKILL.md
@@ -5,7 +5,9 @@ description: Run a state review of the codebase: the counterpart to adversarial-
 
 # Codebase review
 
-A review of what the codebase **is**, where [adversarial-review](../../run/adversarial-review/SKILL.md) reviews what a diff changes. It hunts **deepening opportunities**, places where structure taxes every change that passes through, and ends only when the decider has dispositioned every surviving candidate. This skill is the portable protocol: an entry gate, a read-only review lane of lens-named finders, a skeptic pass that kills candidates before the report exists, and the disposition loop. Everything repo-specific lives in **binding slots** the team-workflow setup interview fills: where reports land, the trigger threshold, where rejections are remembered, how the lane is run.
+A review of what the codebase **is**, where [adversarial-review](../../run/adversarial-review/SKILL.md) reviews what a diff changes. It hunts **deepening opportunities**: places where structure taxes every change that passes through. It ends only when the decider has dispositioned every surviving candidate.
+
+This skill is the portable protocol: an entry gate, a read-only review lane of finders each named for the lens it looks through, a skeptic pass that kills candidates before the report exists, and the disposition loop. Everything repo-specific lives in **binding slots** the team-workflow setup interview fills: where reports land, the trigger threshold, where rejections are remembered, how the lane is run.
 
 Read the team-workflow binding doc first. Full domain-modeling discipline (glossaries, decision records) lives in [domain-memory](../../orient/domain-memory/SKILL.md), deliberately not here.
 

--- a/skills/investigate/prototype/SKILL.md
+++ b/skills/investigate/prototype/SKILL.md
@@ -5,7 +5,7 @@ description: Build throwaway prototype code that answers a design question: UI v
 
 # Prototype
 
-A prototype is throwaway code that answers a question. It is the expensive-fidelity tool: simple frames resolve in discussion, and questions answerable from existing screenshots or artifacts resolve from those. Reach for a prototype the moment the question is "I need to see/feel this in action." It runs two ways: as the engine of a `prototype` ticket inside a decision map (see the decision-map skill), and standalone for UI-heavy or state-model-heavy work outside any map.
+A prototype is throwaway code that answers a question. It is the most expensive way to get an answer, so the cheap ways come first: a question with a simple frame resolves in discussion, and a question answerable from existing screenshots or artifacts resolves from those. Reach for a prototype the moment the question is "I need to see/feel this in action." It runs two ways: as the engine of a `prototype` ticket inside a decision map (see the decision-map skill), and standalone for UI-heavy or state-model-heavy work outside any map.
 
 ## Pick the branch
 

--- a/skills/orient/domain-memory/SKILL.md
+++ b/skills/orient/domain-memory/SKILL.md
@@ -5,7 +5,9 @@ description: Keep per-repo institutional memory: a domain glossary plus lightwei
 
 # Domain memory
 
-Per-repo institutional memory: what the repo's words mean, and why its settled decisions went the way they did, written as **side effects of work**, never as a documentation chore. The third orientation instrument beside [router](../router/SKILL.md) and [setup](../setup/SKILL.md): they orient a session on the pack and the repo's bindings; this skill orients it on the domain. This skill is the portable protocol: two artifacts in one store, the write and read moments that keep it alive, and evolution rules that keep it honest. Where the store lives, when consolidation is offered, and whether backfill runs are **binding slots** the team-workflow setup interview fills.
+Per-repo institutional memory: what the repo's words mean, and why its settled decisions went the way they did. It is written as **side effects of work**, never as a documentation chore. [router](../router/SKILL.md) and [setup](../setup/SKILL.md) orient a session on the pack and the repo's bindings; this skill is the third orientation instrument beside them, and it orients the session on the domain.
+
+This skill is the portable protocol: two artifacts in one store, the write and read moments that keep it alive, and evolution rules that keep it honest. Where the store lives, when consolidation is offered, and whether backfill runs are **binding slots** the team-workflow setup interview fills.
 
 Read the team-workflow binding doc first; its domain-memory section names the memory home.
 

--- a/skills/orient/router/SKILL.md
+++ b/skills/orient/router/SKILL.md
@@ -5,7 +5,7 @@ description: Entry point for the team-workflow pack: names every pack skill and 
 
 # Team-workflow router
 
-One entry point for the **team-workflow** pack: a portable discipline for running tracked, multi-session, agent-assisted development, from pressure-testing an idea through parallel lanes to reviewed, merged changes; the table below names every skill and its moment. Everything repo-specific lives in, or is pointed at from, one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
+One entry point for the **team-workflow** pack. The pack is a portable discipline for running tracked, multi-session, agent-assisted development: pressure-test an idea, build it in parallel lanes, ship it reviewed and merged. The table below names every skill and its moment. Everything repo-specific lives in, or is pointed at from, one binding doc seeded by the setup skill; every skill defers decisions to **the decider**, the role that doc names.
 
 **First run in a repo? Run `setup` before anything else.** The other skills read the bindings it seeds.
 

--- a/skills/run/diagnose/SKILL.md
+++ b/skills/run/diagnose/SKILL.md
@@ -5,7 +5,7 @@ description: The disciplined bug-fixing loop: no fix ships without a cause the f
 
 # Diagnose
 
-A fix may not ship without a **named cause**: one plain sentence stating what was wrong, backed by evidence, readable by a non-engineer decider. This skill is the discipline a working lane follows inline when fixing bugs, not a lane type of its own, and deliberately without binding slots: everything repo-specific already arrived in the lane's brief.
+A fix may not ship without a **named cause**: one plain sentence stating what was wrong, backed by evidence, readable by a non-engineer decider. This skill is the discipline a working lane follows inline when fixing bugs. It is not a lane type of its own, and it deliberately has no binding slots: everything repo-specific already arrived in the lane's brief.
 
 **The named-cause test is the trigger, and it binds on every fix.** If you can already state the cause in one sentence and point at the evidence, the loop is satisfied: ship. If you cannot, the loop runs, however small the bug looks. "Hard bugs only" is the wrong gate, because the first fix attempt is where the vibes-fix ships: a change that makes the symptom go away for reasons nobody can state.
 

--- a/skills/run/implement/SKILL.md
+++ b/skills/run/implement/SKILL.md
@@ -5,7 +5,7 @@ description: How a working lane builds an item: seam-scoped test-first, tracer-f
 
 # Implement
 
-How a working lane builds an item. The item's body is the spec, the brief's verification set defines done, and this skill is the discipline between those two points, not a lane type of its own, and deliberately without binding slots: everything repo-specific (verify commands, constraints, the tracker) already arrived in the lane's brief.
+How a working lane builds an item. The item's body is the spec, the brief's verification set defines done, and this skill is the discipline between those two points. It is not a lane type of its own, and it deliberately has no binding slots: everything repo-specific (verify commands, constraints, the tracker) already arrived in the lane's brief.
 
 ## Tracer first
 

--- a/skills/run/orchestrate/SKILL.md
+++ b/skills/run/orchestrate/SKILL.md
@@ -5,7 +5,7 @@ description: Run a session as the orchestrator of parallel agent-assisted work: 
 
 # Orchestrate
 
-One session coordinates many. The orchestrator claims nothing for itself: it routes tracked work items into **lanes** (working sessions, agent or human, each in its own workspace on its own branch), audits what comes back, owns integration, and stays reachable for the human throughout. The portable protocol: principles plus **binding slots** (§7) for the machinery every repo does differently. Rule-based: do every step, every time; memory-only protocols drift.
+One session coordinates many. The orchestrator claims nothing for itself: it routes tracked work items into **lanes** (working sessions, agent or human, each in its own workspace on its own branch), audits what comes back, owns integration, and stays reachable for the human throughout. This skill is the portable protocol: principles, plus **binding slots** (§7) for the machinery every repo does differently. It is rule-based: do every step, every time, because memory-only protocols drift.
 
 Read the team-workflow binding doc first. The tracker discipline (claims, frontier, blocking; [setup's references](../../orient/setup/references/tracker-discipline.md)) is assumed throughout. Measurements behind the cost-shaped rules: [references/evidence.md](references/evidence.md).
 


### PR DESCRIPTION
Closes #227.

Theo read one of our paragraphs on camera and said 'this is unreadable.' This pass fixes the register of the surface a visitor actually reads: the front half of each SKILL.md, judged by the read-aloud test. Ten files rewritten, eleven passed untouched (wizard's front half was judged the best in the catalog). Where precision and readability conflicted, precision won and the plain sentence went above it, never instead of it: the on-camera writing-for-agents context-pointers paragraph now opens with a plain lead while its precise definition stands verbatim below.

Small on purpose: +30/−11 across 10 SKILL.mds and 3 CHANGELOGs. Frontmatter descriptions byte-identical (trigger surfaces).

Close-out review: delegated rule-preservation reviewer, verdict SHIP with zero findings — every hunk compared against origin/main, no rule weakened, no fact drifted, added prose passes the plainspoken catalog, em-dash tripwire green. Orchestrator re-ran verification alongside. The lane also caught its own stale-base error mid-run (first pass edited pre-sweep text; discarded and redone post-sweep).

Filed by the orchestrator on behalf of lane #227 (in-process Claude subagent, Fable 5, session-inherited effort; build ~119k tokens; reviewer ~33k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)