### PR TITLE
verify_evidence re-execution: --allow-program alone no longer accepts model-authored arguments

### DIFF
--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -9,6 +9,18 @@ versioned separately and do not replace the skill release version.
 
 ## [Unreleased]
 
+### Security
+- **`verify_evidence.py` re-execution now pins arguments, not just the program** (#243,
+  surfaced by CodeRabbit on PR #242): `--allow-program NAME` alone used to re-run a
+  `command` citation with whatever arguments it carried, and the command text is
+  model-authored, so an untrusted seat could smuggle hostile arguments to an allowed
+  program (`pytest --rootdir=... -p plugin`, `git -c core.pager=...`). Now
+  `--allow-program` alone permits only the bare program with no arguments; a command
+  carrying any argument must also `re.fullmatch` an `--allow-command` pattern. A refused
+  command stays `unverified` with a `status_reason` naming the missing pattern.
+  Regression tests cover the hostile-argv case at the `command_allowed`, `resolve_command`,
+  and `main()` layers (nothing executes, no `observed` receipt).
+
 ### Changed
 - **Readability pass on the opening paragraph** (#227): the single dense mode sentence is
   now one plain sentence per mode; every fact (mode names, the default, the intake

--- a/skills/decide/advisory-board/references/verdict-schema.md
+++ b/skills/decide/advisory-board/references/verdict-schema.md
@@ -97,7 +97,8 @@ rule). Each item has a `kind`:
 - `source`: `url` plus a verbatim `quote`.
 - `command`: a `command` string, plus optional `expect_exit` (int, default 0) and a verbatim
   `expect` substring. Re-execution is **opt-in** (M3): `verify_evidence.py --allow-program NAME`
-  (+ optional `--allow-command REGEX` to pin args) re-runs a command whose argv[0] is `NAME` with
+  (+ `--allow-command REGEX` to pin args — required for any command that carries arguments;
+  `--allow-program` alone runs only the bare program, #243) re-runs a command whose argv[0] is `NAME` with
   no shell, a curated PATH, an isolated cwd, and a scrubbed env, then attaches the observed
   exit/output under `observed`.
 - `judgment`: no external referent, by design; carries optional `detail`.

--- a/skills/decide/advisory-board/scripts/README.md
+++ b/skills/decide/advisory-board/scripts/README.md
@@ -185,7 +185,9 @@ python3 scripts/render_verdict.py <out>/verdict.json --run <out> --html <out>/fi
 # --- the canonical-verdict chain (after the agent fills verdict.json,
 #     or `run --synthesize` drafts it via the neutral synthesizer seat — M2) ---
 # 1. resolve + stamp each typed citation verified/unverified/refuted.
-#    add --allow-program NAME (+ optional --allow-command 'REGEX' to pin args) to ALSO
+#    add --allow-program NAME (+ --allow-command 'REGEX' to pin args — REQUIRED for any
+#    command that carries arguments; --allow-program alone runs only the bare program,
+#    #243: the command text is model-authored, so unpinned args are attacker-chosen) to ALSO
 #    re-execute command citations whose argv[0] is NAME (M3; opt-in, program-pinned,
 #    no-shell, isolated cwd, curated PATH, scrubbed env, process-group timeout —
 #    allowlist only read-only programs you trust; a re-run's output is persisted)

--- a/skills/decide/advisory-board/scripts/verify_evidence.py
+++ b/skills/decide/advisory-board/scripts/verify_evidence.py
@@ -50,10 +50,13 @@ Command re-execution (M3) — read before enabling:
       program name in that set — never a path (`./x`, `/bin/sh`, `../x` are refused).
       This pins which program runs INDEPENDENT of any regex, so a too-broad
       `--allow-command` pattern cannot let the attacker choose the executable.
-    * OPTIONAL ARG CONSTRAINT: `--allow-command REGEX` (repeatable) further requires
-      the full command to `re.fullmatch` a pattern — for pinning args, not the
-      program. PATTERNS ARE LIVE REGEXES (`.` is a wildcard); they refine, never
-      widen, the program allowlist.
+    * ARGS ARE PINNED TOO (#243): `--allow-program` alone permits only the BARE
+      program (argv is exactly [NAME]). A command that carries ANY arguments must
+      also `re.fullmatch` an `--allow-command REGEX` (repeatable) — the command
+      text is model-authored, so unpinned arguments are attacker-chosen arguments
+      (`pytest --rootdir=... -p plugin`, `git -c core.pager=...`). PATTERNS ARE
+      LIVE REGEXES (`.` is a wildcard); they refine, never widen, the program
+      allowlist.
     * NO SHELL: split with shlex, run with shell=False, so `;`/`&&`/`|`/`>`/`$(...)`/
       globs are inert literal args, not operators.
     * CLEAN PATH, NO PLANTED BINARIES: argv[0] is resolved with shutil.which against
@@ -486,9 +489,12 @@ def command_allowed(command, rerun):
       2. argv[0] is a BARE program name — no `/`, no leading `.`, not absolute
          (kills `./build.sh`, `/bin/sh`, `../x` and other path-based argv[0]);
       3. argv[0] is in `--allow-program` (the load-bearing pin);
-      4. if any `--allow-command` patterns were given, the full command string
-         `re.fullmatch`es one (fullmatch, not search — `pytest -q` never green-lights
-         `pytest -q; rm -rf ~`; a malformed pattern is skipped, never crashes).
+      4. the ARGUMENTS are pinned (#243): a command with any argument beyond
+         argv[0], or any command when `--allow-command` patterns were given, must
+         `re.fullmatch` a pattern (fullmatch, not search — `pytest -q` never
+         green-lights `pytest -q; rm -rf ~`; a malformed pattern is skipped, never
+         crashes). `--allow-program` alone runs only the bare program: the command
+         text is model-authored, so unpinned arguments are attacker-chosen.
     """
     cmd = (command or "").strip()
     if not cmd:
@@ -507,7 +513,7 @@ def command_allowed(command, rerun):
         return None, (f"program {prog!r} is not in the --allow-program allowlist "
                       f"({', '.join(sorted(rerun['programs'])) or 'empty'})")
     patterns = rerun.get("patterns") or []
-    if patterns:
+    if patterns or len(argv) > 1:
         matched = False
         for pat in patterns:
             try:
@@ -517,6 +523,12 @@ def command_allowed(command, rerun):
             except re.error:
                 continue
         if not matched:
+            if not patterns:
+                return None, ("command carries arguments but no --allow-command pattern "
+                              "was given — --allow-program alone permits only the bare "
+                              "program (the command text is model-authored, so unpinned "
+                              "arguments are attacker-chosen); add --allow-command 'REGEX' "
+                              "to pin the exact arguments")
             return None, "command does not match any --allow-command pattern"
     return argv, None
 
@@ -725,14 +737,17 @@ def main(argv=None) -> int:
         "--allow-program", dest="allow_program", action="append", default=[], metavar="NAME",
         help="ENABLE command-evidence re-execution for commands whose argv[0] is exactly this bare "
              "program name (repeatable). This is the load-bearing control: argv[0] is pinned to a "
-             "program you name, never a path and never chosen by a regex. OMITTED => command "
-             "citations stay unverified (re-execution is opt-in). Allowlist only programs you trust "
-             "to be read-only over public material — a re-run's output is persisted to verdict.json.")
+             "program you name, never a path and never chosen by a regex. On its own it permits "
+             "ONLY the bare program with no arguments; a command carrying arguments must also match "
+             "an --allow-command pattern (#243). OMITTED => command citations stay unverified "
+             "(re-execution is opt-in). Allowlist only programs you trust to be read-only over "
+             "public material — a re-run's output is persisted to verdict.json.")
     parser.add_argument(
         "--allow-command", dest="allow_command", action="append", default=[], metavar="REGEX",
-        help="OPTIONAL extra constraint: also require the full command to re.fullmatch this regex "
-             "(repeatable) — for pinning ARGS, not the program. Patterns are LIVE regexes (`.` is a "
-             "wildcard). Refines the --allow-program allowlist; cannot enable re-execution on its own.")
+        help="pin the ARGS: require the full command to re.fullmatch this regex (repeatable). "
+             "REQUIRED for any command that carries arguments (#243) — --allow-program alone runs "
+             "only the bare program. Patterns are LIVE regexes (`.` is a wildcard). Refines the "
+             "--allow-program allowlist; cannot enable re-execution on its own.")
     parser.add_argument(
         "--rerun-timeout", dest="rerun_timeout", type=int, default=DEFAULT_RERUN_TIMEOUT,
         metavar="SECONDS", help=f"hard timeout per re-executed command (default {DEFAULT_RERUN_TIMEOUT}s)")

--- a/skills/decide/advisory-board/tests/README.md
+++ b/skills/decide/advisory-board/tests/README.md
@@ -107,7 +107,8 @@ The M5 canonical-verdict layer adds:
   no-packet → unverified — it never reaches the URL); `command` is unverified by
   default (re-execution is opt-in), and resolves against re-execution under
   `--allow-program NAME` (exit matches `expect_exit` and `expect` substring present
-  → verified, mismatch → refuted); `judgment` is left unstamped.
+  → verified, mismatch → refuted; a command carrying arguments also needs a matching
+  `--allow-command` pattern, #243); `judgment` is left unstamped.
 - **The gate abstains in the torn regime** (`TestGateAbstain`, `TestGateReconcileVerdictVsBoard`,
   `TestGateRefutedAnywhere`) — `--gate` returns exit `3` ("human required") when the seats that
   ran straddle the `--fail-on` line with no strict majority, when the declared `verdict` clears

--- a/skills/decide/advisory-board/tests/test_run_board.py
+++ b/skills/decide/advisory-board/tests/test_run_board.py
@@ -6111,7 +6111,10 @@ class TestCommandReexecution(unittest.TestCase):
     binary); an isolated throwaway cwd by default; a scrubbed env (no PATH/HOME
     inheritance); stdin closed; a process-group-killed hard timeout; and a
     STRUCTURAL match (exit code + verbatim substring — never reasoning over output,
-    design section 11)."""
+    design section 11). Arguments are pinned too (#243): --allow-program alone
+    permits only the bare program; a command carrying any arguments must fullmatch
+    an --allow-command pattern (the command text is model-authored, so unpinned
+    arguments are attacker-chosen)."""
 
     def setUp(self):
         self.d = tempfile.mkdtemp(prefix="m3-rerun-")
@@ -6123,11 +6126,38 @@ class TestCommandReexecution(unittest.TestCase):
         return {"programs": set(programs), "patterns": list(patterns or []),
                 "cwd": cwd or self.d, "timeout": timeout}
 
-    # --- command_allowed: argv[0] pinning + optional regex ------------------ #
+    # --- command_allowed: argv[0] pinning + argument pinning ---------------- #
     def test_allowed_returns_argv(self):
-        argv, reason = ve.command_allowed("echo hi", self.rerun("echo"))
+        argv, reason = ve.command_allowed("echo hi", self.rerun("echo", patterns=[r"echo hi"]))
         self.assertEqual(argv, ["echo", "hi"])
         self.assertIsNone(reason)
+
+    def test_bare_program_allowed_without_pattern(self):
+        # --allow-program alone still covers the no-argument invocation.
+        argv, reason = ve.command_allowed("echo", self.rerun("echo"))
+        self.assertEqual(argv, ["echo"])
+        self.assertIsNone(reason)
+
+    def test_args_without_pattern_refused(self):
+        # THE #243 fix: the evidence command is model-authored, so --allow-program
+        # alone must not hand an allowed program attacker-chosen arguments.
+        for hostile in ("pytest --rootdir=/ -p attacker_plugin",
+                        "git -c core.pager=id log",
+                        "echo hi"):
+            argv, reason = ve.command_allowed(hostile, self.rerun("pytest", "git", "echo"))
+            self.assertIsNone(argv, hostile)
+            self.assertIn("allow-command", reason)
+
+    def test_resolve_hostile_argv_never_runs(self):
+        # #243 at the resolve layer: hostile args with only a program allowlist ->
+        # unverified with the refusal reason, and nothing executed.
+        marker = os.path.join(self.d, "PWNED")
+        ev = self.cmd(f"touch {marker}")
+        status = ve.resolve_command(ev, self.rerun("touch", cwd=self.d))
+        self.assertEqual(status, "unverified")
+        self.assertIn("allow-command", ev["status_reason"])
+        self.assertNotIn("observed", ev)   # never ran
+        self.assertFalse(os.path.exists(marker), "the hostile argv must NOT have run")
 
     def test_program_not_allowlisted_refused(self):
         argv, reason = ve.command_allowed("curl https://evil", self.rerun("echo"))
@@ -6254,7 +6284,8 @@ class TestCommandReexecution(unittest.TestCase):
 
     def test_allowed_passing_is_verified(self):
         ev = self.cmd("echo hello")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo")), "verified")
+        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", patterns=[r"echo hello"])),
+                         "verified")
         self.assertEqual(ev["observed"]["exit"], 0)
         self.assertIn("hello", ev["observed"]["output"])
 
@@ -6306,7 +6337,8 @@ class TestCommandReexecution(unittest.TestCase):
         src_tree = tempfile.mkdtemp(prefix="m3-src-")
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            ve.main([path, "--allow-program", "sh", "--rerun-cwd", src_tree])
+            ve.main([path, "--allow-program", "sh", "--allow-command", r"sh -c .*",
+                     "--rerun-cwd", src_tree])
         with open(path) as fh:
             data = json.load(fh)
         observed = data["blockers"][0]["evidence"][0].get("observed", {})
@@ -6326,17 +6358,20 @@ class TestCommandReexecution(unittest.TestCase):
 
     def test_expect_substring_present_verified(self):
         ev = self.cmd("echo all tests passed", expect="passed")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo")), "verified")
+        rerun = self.rerun("echo", patterns=[r"echo .*"])
+        self.assertEqual(ve.resolve_command(ev, rerun), "verified")
         self.assertIs(ev["observed"]["expect_found"], True)
 
     def test_expect_substring_absent_refuted(self):
         ev = self.cmd("echo something else", expect="passed")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo")), "refuted")
+        rerun = self.rerun("echo", patterns=[r"echo .*"])
+        self.assertEqual(ve.resolve_command(ev, rerun), "refuted")
         self.assertIs(ev["observed"]["expect_found"], False)
 
     def test_expect_substring_whitespace_normalized(self):
         ev = self.cmd("echo 3 passed in 0.1s", expect="3   passed")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo")), "verified")
+        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", patterns=[r"echo .*"])),
+                         "verified")
 
     def test_malformed_expect_exit_requires_clean_exit(self):
         ev = self.cmd("false", expect_exit="banana")
@@ -6348,7 +6383,7 @@ class TestCommandReexecution(unittest.TestCase):
         # The python code rides in a double-quoted segment so shlex keeps it one arg.
         code = "print('H'*100); print('x'*9000); print('TAILMARK')"
         ev = self.cmd(f'python3 -c "{code}"', expect="TAILMARK")
-        status = ve.resolve_command(ev, self.rerun("python3"))
+        status = ve.resolve_command(ev, self.rerun("python3", patterns=[r"python3 -c .*"]))
         self.assertEqual(status, "verified")   # expect matched on FULL output
         self.assertTrue(ev["observed"]["truncated"])
         # The tail marker survives the head+tail excerpt even though it's past the limit.
@@ -6366,7 +6401,8 @@ class TestCommandReexecution(unittest.TestCase):
     def test_stamp_with_rerun_resolves_commands(self):
         data = {"blockers": [{"evidence": [self.cmd("echo hi"),
                                            self.cmd("false", expect_exit=0)]}]}
-        counts = ve.stamp(data, None, None, self.rerun("echo", "false"))
+        counts = ve.stamp(data, None, None,
+                          self.rerun("echo", "false", patterns=[r"echo hi", r"false"]))
         evs = data["blockers"][0]["evidence"]
         self.assertEqual(evs[0]["status"], "verified")
         self.assertEqual(evs[1]["status"], "refuted")
@@ -6414,6 +6450,7 @@ class TestCommandReexecution(unittest.TestCase):
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             rc = ve.main([path, "--allow-program", "echo", "--allow-program", "false",
+                          "--allow-command", r"echo hi", "--allow-command", r"false",
                           "--rerun-cwd", self.d])
         self.assertEqual(rc, 0)
         with open(path) as fh:
@@ -6422,6 +6459,24 @@ class TestCommandReexecution(unittest.TestCase):
         self.assertEqual(evs[0]["status"], "verified")
         self.assertEqual(evs[1]["status"], "refuted")
         self.assertIn("REFUTED", err.getvalue())
+
+    def test_main_hostile_args_without_pattern_stay_unverified(self):
+        # #243 end to end: --allow-program alone must not re-execute a command that
+        # carries arguments (the argv tail is model-authored). The evidence stays
+        # unverified with the refusal reason and no `observed` receipt.
+        marker = os.path.join(self.d, "PWNED-MAIN")
+        path = self._write_verdict([self.cmd(f"touch {marker}")])
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ve.main([path, "--allow-program", "touch"])
+        self.assertEqual(rc, 0)
+        with open(path) as fh:
+            data = json.load(fh)
+        ev = data["blockers"][0]["evidence"][0]
+        self.assertEqual(ev["status"], "unverified")
+        self.assertIn("allow-command", ev["status_reason"])
+        self.assertNotIn("observed", ev)
+        self.assertFalse(os.path.exists(marker), "the hostile argv must NOT have run")
 
     def test_main_default_cwd_is_throwaway_and_cleaned(self):
         # No --rerun-cwd: a fresh throwaway dir is created and removed after.


### PR DESCRIPTION
A verdict's `evidence[].command` text is written by the model, and the reviewer's `--allow-program NAME` opt-in re-executed that command with whatever arguments it carried. An untrusted seat could therefore smuggle hostile arguments to a program the reviewer trusts, for example `pytest --rootdir=... -p plugin` or `git -c core.pager=...`. The program pin was load-bearing but the argument tail was wide open.

Cause in one sentence: `command_allowed` treated the `--allow-command` argument patterns as an optional refinement, so enabling re-execution with only `--allow-program` left every argument attacker-chosen.

Now `--allow-program` alone permits only the bare program with no arguments. Any command that carries arguments must also fullmatch an `--allow-command` pattern, so the reviewer pins the exact argv shape before anything runs. A refused command stays `unverified` with a `status_reason` that names the missing pattern, and nothing executes.

Regression tests exercise the hostile-argv case at three layers (`command_allowed`, `resolve_command`, and `main()` end to end) and assert the command never ran and attached no `observed` receipt. The bare-program and pinned-pattern paths keep their existing behavior, with tests updated to pin arguments where they use them. Docs and the skill CHANGELOG describe the new requirement.

Part of #243
Closes #243