### PR TITLE
advisory-board: use defaults cannot skip the doctor preflight

### DIFF
--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -27,7 +27,9 @@ versioned separately and do not replace the skill release version.
   straight" to the step-6 confirm card, which let a run launch with an unconfirmed or
   unavailable seat. Both now state that `use defaults` resolves steps 2-5 to defaults only
   after step 1 completes and its findings are applied to the card; a seat that is not GO is
-  never offered as a default. Doc-only: the conductor scripts have no intake path and never
+  never offered as a default, and below two GO seats the fast path cannot fill a board
+  (the two-seat minimum in `board-composition.md`; step 3's fallbacks are the user's
+  call). Doc-only: the conductor scripts have no intake path and never
   encoded the jump.
 
 ### Changed

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -21,6 +21,15 @@ versioned separately and do not replace the skill release version.
   Regression tests cover the hostile-argv case at the `command_allowed`, `resolve_command`,
   and `main()` layers (nothing executes, no `observed` receipt).
 
+### Fixed
+- **`use defaults` no longer reads as a way past the doctor preflight** (#244, surfaced by
+  CodeRabbit on PR #242): `intake-interview.md` and SKILL.md said the fast path "jumps
+  straight" to the step-6 confirm card, which let a run launch with an unconfirmed or
+  unavailable seat. Both now state that `use defaults` resolves steps 2-5 to defaults only
+  after step 1 completes and its findings are applied to the card; a seat that is not GO is
+  never offered as a default. Doc-only: the conductor scripts have no intake path and never
+  encoded the jump.
+
 ### Changed
 - **Readability pass on the opening paragraph** (#227): the single dense mode sentence is
   now one plain sentence per mode; every fact (mode names, the default, the intake

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -43,7 +43,7 @@ Every run opens with the wizard in `references/intake-interview.md`, presented a
 5. **Rounds and output.** With defaults marked.
 6. **Confirm-summary.** The resolved plan as one card; nothing launches without this yes.
 
-"Use defaults" resolves steps 2-5 to defaults and goes to step 6, but only after step 1 completes and its findings are applied to the card: doctor still runs, and a seat that is not GO is never a default. It never skips the confirmation, and it never waives data-handling consent: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`).
+"Use defaults" resolves steps 2-5 to defaults and goes to step 6, but only after step 1 completes and its findings are applied to the card: doctor still runs, a seat that is not GO is never a default, and below two GO seats there is no defaults board (step 3's fallbacks are settled with the user first). It never skips the confirmation, and it never waives data-handling consent: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`).
 
 ## Model Lineup
 

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -43,7 +43,7 @@ Every run opens with the wizard in `references/intake-interview.md`, presented a
 5. **Rounds and output.** With defaults marked.
 6. **Confirm-summary.** The resolved plan as one card; nothing launches without this yes.
 
-"Use defaults" jumps straight to step 6 with everything resolved to defaults. It never skips the confirmation, and it never waives data-handling consent: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`).
+"Use defaults" resolves steps 2-5 to defaults and goes to step 6, but only after step 1 completes and its findings are applied to the card: doctor still runs, and a seat that is not GO is never a default. It never skips the confirmation, and it never waives data-handling consent: if the material isn't clearly public, still disclose which providers will receive it and get an explicit go-ahead before launching any external seat (`references/data-handling.md`).
 
 ## Model Lineup
 

--- a/skills/decide/advisory-board/references/intake-interview.md
+++ b/skills/decide/advisory-board/references/intake-interview.md
@@ -1,6 +1,6 @@
 # Guided Intake: the wizard
 
-Every board run opens with this intake. It is **mandatory**: the run's shape is chosen by the user on the record, never by the agent on the user's behalf: mode, seats, lenses, effort, rounds, output. The one fast path is `use defaults`, which collapses steps 2-5 into a single confirm-summary card (step 6); it never skips step 1, it never skips confirmation, and it never waives data-handling consent.
+Every board run opens with this intake. It is **mandatory**: the run's shape is chosen by the user on the record, never by the agent on the user's behalf: mode, seats, lenses, effort, rounds, output. The one fast path is `use defaults`, which collapses steps 2-5 into a single confirm-summary card (step 6); it never skips step 1, it never collapses below two GO seats (step 3's fallbacks are the user's call), it never skips confirmation, and it never waives data-handling consent.
 
 Present choices the way the `grilling` skill does: choice-shaped questions as selection cards with your recommendation first and marked `(Recommended)`, at most four cards per round; open questions as ❓/➡️ text. Where cards aren't available, ask the same questions as numbered text.
 
@@ -45,7 +45,7 @@ On a Competitive run, offer the optional graft-and-verify close here (`reference
 
 ## Step 6: Confirm-summary, then consent
 
-Play back the fully resolved plan as one card the user approves before anything runs: mode (on Competitive, with `graft-and-verify close: on/off` as resolved), seats with lenses, effort, rounds, output, and where artifacts land. **Nothing launches without this yes.** `use defaults` reaches this card only through step 1: run doctor first, resolve each broken seat with the user (fix, continue without, or abort), and only then resolve steps 2-5 to defaults and build this card from what doctor confirmed. A seat that is not GO never appears on the card as a default.
+Play back the fully resolved plan as one card the user approves before anything runs: mode (on Competitive, with `graft-and-verify close: on/off` as resolved), seats with lenses, effort, rounds, output, and where artifacts land. **Nothing launches without this yes.** `use defaults` reaches this card only through step 1: run doctor first, resolve each broken seat with the user (fix, continue without, or abort), and only then resolve steps 2-5 to defaults and build this card from what doctor confirmed. A seat that is not GO never appears on the card as a default, and below two GO seats defaults cannot fill the board: walk step 3's fallbacks with the user before this card (`references/board-composition.md` sets the two-seat minimum).
 
 Data-handling consent (`references/data-handling.md`) is separate and unwaivable: for non-public material, disclose what leaves the machine and to whom, and get the explicit go-ahead; `use defaults` and the confirm-summary never cover it.
 

--- a/skills/decide/advisory-board/references/intake-interview.md
+++ b/skills/decide/advisory-board/references/intake-interview.md
@@ -1,6 +1,6 @@
 # Guided Intake: the wizard
 
-Every board run opens with this intake. It is **mandatory**: the run's shape is chosen by the user on the record, never by the agent on the user's behalf: mode, seats, lenses, effort, rounds, output. The one fast path is `use defaults`, which collapses the questions into a single confirm-summary card (step 6); it never skips confirmation, and it never waives data-handling consent.
+Every board run opens with this intake. It is **mandatory**: the run's shape is chosen by the user on the record, never by the agent on the user's behalf: mode, seats, lenses, effort, rounds, output. The one fast path is `use defaults`, which collapses steps 2-5 into a single confirm-summary card (step 6); it never skips step 1, it never skips confirmation, and it never waives data-handling consent.
 
 Present choices the way the `grilling` skill does: choice-shaped questions as selection cards with your recommendation first and marked `(Recommended)`, at most four cards per round; open questions as ❓/➡️ text. Where cards aren't available, ask the same questions as numbered text.
 
@@ -45,7 +45,7 @@ On a Competitive run, offer the optional graft-and-verify close here (`reference
 
 ## Step 6: Confirm-summary, then consent
 
-Play back the fully resolved plan as one card the user approves before anything runs: mode (on Competitive, with `graft-and-verify close: on/off` as resolved), seats with lenses, effort, rounds, output, and where artifacts land. **Nothing launches without this yes.** `use defaults` jumps straight here with everything resolved to defaults and doctor's findings applied.
+Play back the fully resolved plan as one card the user approves before anything runs: mode (on Competitive, with `graft-and-verify close: on/off` as resolved), seats with lenses, effort, rounds, output, and where artifacts land. **Nothing launches without this yes.** `use defaults` reaches this card only through step 1: run doctor first, resolve each broken seat with the user (fix, continue without, or abort), and only then resolve steps 2-5 to defaults and build this card from what doctor confirmed. A seat that is not GO never appears on the card as a default.
 
 Data-handling consent (`references/data-handling.md`) is separate and unwaivable: for non-public material, disclose what leaves the machine and to whom, and get the explicit go-ahead; `use defaults` and the confirm-summary never cover it.
 


### PR DESCRIPTION
Part of #244. Closes #244.

The intake docs said "use defaults" jumps straight to step 6's confirm card. Read literally, that lets a run launch with a seat doctor never confirmed, or one that is not available today, because step 1 (doctor/preflight) is the only place seat availability is checked. CodeRabbit surfaced this on PR #242 as pre-existing.

Both intake-interview.md and SKILL.md now say the fast path resolves steps 2-5 to defaults only after step 1 completes and its findings are applied to the card, and that a seat that is not GO is never offered as a default. The conductor scripts have no intake path and never encoded the jump, so this is a doc-only fix; the advisory-board CHANGELOG records it under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)