### PR TITLE
README: a row for every promoted skill, and CI now requires it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@
 | [adversarial-review](./skills/run/adversarial-review/SKILL.md) | Break the change before it ships: isolated finders, a skeptic pass that kills unproven findings, and a gate only confirmed blockers may hold — run before external reviewers see it. | team-workflow pack | fires itself |
 | [diagnose](./skills/run/diagnose/SKILL.md) | The disciplined bug-fixing loop — reproduce red, minimize, hypothesize falsifiably, instrument, fix, regression-test — where no fix ships without a cause named in one plain sentence, with evidence. | team-workflow pack | fires itself |
 | [implement](./skills/run/implement/SKILL.md) | How a lane builds an item: seam-scoped test-first, tracer-first sequencing, a green checkpoint commit per slice, and file-don't-fix scope discipline — adjacent discoveries go to the tracker, never into the diff. | team-workflow pack | fires itself |
+| [blast-radius](./skills/run/blast-radius/SKILL.md) | Find what a change breaks somewhere else before it ships: past where grep stops, into library source, timing, and wire formats. The one fact it's safe because of gets proven by running real code. | Standalone plugin | fires itself |
 | [writing-for-agents](./skills/author/writing-for-agents/SKILL.md) | Write and prune documents an agent consumes — context pointers, the two loads, the information hierarchy, leading words, and the no-op test. | Standalone plugin | fires itself |
 | [writing-for-humans](./skills/author/writing-for-humans/SKILL.md) | Write copy a human reads — pages, READMEs, launch posts. Guide structure over catalog structure, the warmth moves, three named failure modes, and a last-mile AI-tell scrub. | Standalone plugin | fires itself |
+| [plainspoken](./skills/author/plainspoken/SKILL.md) | Write like a person in everything the agent emits: plain words, concrete claims, no AI tells, in chat replies and commit messages included. Governs how a message sounds, nothing more. | Standalone plugin | fires itself |
+| [huh](./skills/author/huh/SKILL.md) | Decode a message that didn't land: restate it in plain sentences, expand invented shorthand, split report from request, and flag claims stated without evidence. | Standalone plugin | fires itself |
 
-The fifteen **team-workflow** skills ship and version together as one pack — install them as a set and they cover the full loop of tracked, multi-session, agent-assisted development. **advisory-board** stands alone and works anywhere a hard decision does; **ingest** stands alone and turns media into evidence wherever it lands; **writing-for-agents** stands alone as the standard the rest of this catalog is written against, and **writing-for-humans** as its counterpart for the copy humans read.
+The fifteen **team-workflow** skills ship and version together as one pack — install them as a set and they cover the full loop of tracked, multi-session, agent-assisted development. The rest stand alone: **advisory-board** works anywhere a hard decision does; **ingest** turns media into evidence wherever it lands; **blast-radius** proves a change safe before it merges; **writing-for-agents** is the standard the rest of this catalog is written against, and **writing-for-humans** its counterpart for the copy humans read; **plainspoken** keeps everything an agent writes sounding human, and **huh** translates the messages that don't land.
 
 ## Install
 
@@ -43,12 +46,15 @@ Add the marketplace once, then install whichever plugins you want.
 /plugin install ingest@skills              # media → evidence packet + routing
 /plugin install writing-for-agents@skills  # the skill-authoring reference
 /plugin install writing-for-humans@skills  # the human-facing copy reference
+/plugin install plainspoken@skills         # the always-on plain-writing voice rule
+/plugin install huh@skills                 # decode a message that didn't land
+/plugin install blast-radius@skills        # prove a change safe before it merges
 ```
 
 ### Codex
 
-The same nineteen skills, native. Codex allows one plugin per repository root, so the
-whole catalog arrives as a single plugin rather than five:
+Every skill in the catalog above, native. Codex allows one plugin per repository
+root, so the whole catalog arrives as a single plugin rather than one per skill:
 
 ```bash
 codex plugin marketplace add timharris707/skills

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [plainspoken](./skills/author/plainspoken/SKILL.md) | Write like a person in everything the agent emits: plain words, concrete claims, no AI tells, in chat replies and commit messages included. Governs how a message sounds, nothing more. | Standalone plugin | fires itself |
 | [huh](./skills/author/huh/SKILL.md) | Decode a message that didn't land: restate it in plain sentences, expand invented shorthand, split report from request, and flag claims stated without evidence. | Standalone plugin | fires itself |
 
-The fifteen **team-workflow** skills ship and version together as one pack — install them as a set and they cover the full loop of tracked, multi-session, agent-assisted development. The rest stand alone: **advisory-board** works anywhere a hard decision does; **ingest** turns media into evidence wherever it lands; **blast-radius** proves a change safe before it merges; **writing-for-agents** is the standard the rest of this catalog is written against, and **writing-for-humans** its counterpart for the copy humans read; **plainspoken** keeps everything an agent writes sounding human, and **huh** translates the messages that don't land.
+The **team-workflow** skills ship and version together as one pack — install them as a set and they cover the full loop of tracked, multi-session, agent-assisted development. The rest stand alone: **advisory-board** works anywhere a hard decision does; **ingest** turns media into evidence wherever it lands; **blast-radius** proves a change safe before it merges; **writing-for-agents** is the standard the rest of this catalog is written against, and **writing-for-humans** its counterpart for the copy humans read; **plainspoken** keeps everything an agent writes sounding human, and **huh** translates the messages that don't land.
 
 ## Install
 
@@ -42,7 +42,7 @@ Add the marketplace once, then install whichever plugins you want.
 ```text
 /plugin marketplace add timharris707/skills
 /plugin install advisory-board@skills      # the multi-model advisory board
-/plugin install team-workflow@skills       # all fifteen pack skills as one plugin
+/plugin install team-workflow@skills       # every pack skill as one plugin
 /plugin install ingest@skills              # media → evidence packet + routing
 /plugin install writing-for-agents@skills  # the skill-authoring reference
 /plugin install writing-for-humans@skills  # the human-facing copy reference

--- a/scripts/check_invocation_freshness.py
+++ b/scripts/check_invocation_freshness.py
@@ -83,7 +83,9 @@ def promoted_skills() -> dict:
             continue
         bucket_dir = SKILLS_DIR / bucket["id"]
         if not bucket_dir.is_dir():
-            continue
+            print(f"ERROR: promoted bucket '{bucket['id']}' has no skills/{bucket['id']} "
+                  "directory; a skipped bucket is not a green check")
+            sys.exit(1)
         for entry in sorted(bucket_dir.iterdir()):
             if entry.is_dir() and (entry / "SKILL.md").is_file():
                 out[entry.name] = entry

--- a/scripts/check_invocation_freshness.py
+++ b/scripts/check_invocation_freshness.py
@@ -29,8 +29,8 @@ column, one tag per state: "you call it" (user), "fires itself" (agent),
 check derives each row's expected cell from the same frontmatter derivation
 and fails on any disagreement, a row for a skill that is not promoted, or a
 row missing the cell, so the README marking cannot silently drift either.
-A promoted skill absent from the table is not this check's concern; the table
-is checked as listed.
+The table must also be complete: every promoted skill has a row, so a
+promotion cannot skip the README and pass CI silently (#248).
 
 Standard library only. Exit 0 = in agreement; exit 1 = drift, one line per
 problem.
@@ -190,12 +190,14 @@ def check_readme(expected: dict):
             table.append((offset, line))
 
     rows = 0
+    listed = set()
     for lineno, line in table:
         row = README_ROW_RE.match(line)
         if row is None:
             continue
         rows += 1
         slug = row.group("slug")
+        listed.add(slug)
         if slug not in expected:
             errors.append(
                 f"README.md:{lineno}: '{slug}' is in the catalog table but is not a promoted skill"
@@ -213,6 +215,11 @@ def check_readme(expected: dict):
             )
     if rows == 0:
         errors.append("README.md has no catalog-table skill rows; an empty check is not a green check")
+    for slug in sorted(set(expected) - listed):
+        errors.append(
+            f"'{slug}' is promoted but has no row in README.md's catalog table; "
+            f"add one with the Invocation cell '{readme_mark(*expected[slug])}'"
+        )
 
 
 def main():


### PR DESCRIPTION
Part of #248. Closes #248.

The README's catalog table was missing rows for three promoted skills: huh, plainspoken, and blast-radius (promoted after the issue was filed, in PR #253). The Codex section still said "The same nineteen skills" while 22 are promoted, and the paragraph under the table plus the Claude install list also stopped at the older standalone set. The invocation freshness check only validated rows as listed, so each missing row passed CI silently.

Now the table carries all 22 promoted skills, the count phrasing is gone ("Every skill in the catalog above" and "one per skill" cannot go stale), and check_invocation_freshness.py fails when any promoted skill has no catalog-table row, naming the slug and the expected Invocation cell. Verified against a seeded omission: with the huh row removed the check exits 1 with "'huh' is promoted but has no row in README.md's catalog table"; restored, it exits 0.

No table redesign; the columns and row format are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)