### PR TITLE
BEARINGS chart: separate blast-radius from plainspoken's row

### DIFF
--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -96,7 +96,7 @@ export const PLOT: Record<string, { x: number; y: number; anchor?: "start" | "en
   "to-tickets": { x: 655, y: 290 },
   wizard: { x: 655, y: 415 },
   orchestrate: { x: 830, y: 190 },
-  "blast-radius": { x: 830, y: 95 },
+  "blast-radius": { x: 940, y: 150, anchor: "end" },
   "adversarial-review": { x: 830, y: 320, anchor: "end" },
   handoff: { x: 830, y: 430 },
   "writing-for-agents": { x: 940, y: 490, anchor: "end" },


### PR DESCRIPTION
On the hero chart, blast-radius landed on plainspoken's row in PR #253: a start-anchored label at (830,95) under an end-anchored one at (940,95), so the two names render on top of each other (screenshot on the issue).

blast-radius moves into the right-hand end-anchored dot column at (940,150), between plainspoken's and orchestrate's rows. Verified against every neighbouring label span in the 1000x520 viewBox; no other node moves.

Part of #258. Closes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)