### PR TITLE
verify_evidence: literal --allow-command pins and a stale-receipt scrub (PR #252 follow-up)

### DIFF
--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -10,6 +10,16 @@ versioned separately and do not replace the skill release version.
 ## [Unreleased]
 
 ### Security
+- **`--allow-command` entries are literal command lines now, not regexes** (CodeRabbit on
+  PR #252, CWE-78): under `re.fullmatch`, allowlisting an interpreter with a pattern like
+  `sh -c .*` or `python3 -c .*` authorized any model-authored payload — and since `.`
+  matches spaces, even a "constrained" pattern like `pytest -q tests/.*` was an open argv
+  tail (`pytest -q tests/x.py -p attacker_plugin` fullmatched it). A command now runs only
+  when its shlex-split argv EXACTLY equals an `--allow-command` entry's, so the reviewer
+  pins the whole command line by copying it out of the verdict; quoting variants of the
+  same argv still match, and an unparseable entry is skipped. Hostile-payload regression
+  tests cover the old wildcard shapes at the `command_allowed` layer.
+
 - **`verify_evidence.py` re-execution now pins arguments, not just the program** (#243,
   surfaced by CodeRabbit on PR #242): `--allow-program NAME` alone used to re-run a
   `command` citation with whatever arguments it carried, and the command text is
@@ -22,6 +32,13 @@ versioned separately and do not replace the skill release version.
   and `main()` layers (nothing executes, no `observed` receipt).
 
 ### Fixed
+- **A refused or disabled re-execution pass no longer keeps a stale `observed` receipt**
+  (CodeRabbit on PR #252): `resolve_command` only wrote `status_reason` on refusal, so a
+  citation re-verified after an earlier authorized run could persist as `unverified` while
+  still carrying the old execution receipt (and a later verified pass kept a stale
+  `status_reason`). Every resolve pass now drops both keys first — mirroring `stamp()`'s
+  stale-snippet drop — and re-attaches only what it actually did. Covered at the
+  `resolve_command` and `main()` layers, including seeding stale metadata end to end.
 - **`use defaults` no longer reads as a way past the doctor preflight** (#244, surfaced by
   CodeRabbit on PR #242): `intake-interview.md` and SKILL.md said the fast path "jumps
   straight" to the step-6 confirm card, which let a run launch with an unconfirmed or

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -26,8 +26,10 @@ versioned separately and do not replace the skill release version.
   model-authored, so an untrusted seat could smuggle hostile arguments to an allowed
   program (`pytest --rootdir=... -p plugin`, `git -c core.pager=...`). Now
   `--allow-program` alone permits only the bare program with no arguments; a command
-  carrying any argument must also `re.fullmatch` an `--allow-command` pattern. A refused
-  command stays `unverified` with a `status_reason` naming the missing pattern.
+  carrying any argument must shlex-split to exactly an `--allow-command` literal entry
+  (matching went literal in the bullet above; it was a `re.fullmatch` pattern when this
+  first shipped). A refused command stays `unverified` with a `status_reason` naming the
+  missing entry.
   Regression tests cover the hostile-argv case at the `command_allowed`, `resolve_command`,
   and `main()` layers (nothing executes, no `observed` receipt).
 

--- a/skills/decide/advisory-board/references/verdict-schema.md
+++ b/skills/decide/advisory-board/references/verdict-schema.md
@@ -97,7 +97,8 @@ rule). Each item has a `kind`:
 - `source`: `url` plus a verbatim `quote`.
 - `command`: a `command` string, plus optional `expect_exit` (int, default 0) and a verbatim
   `expect` substring. Re-execution is **opt-in** (M3): `verify_evidence.py --allow-program NAME`
-  (+ `--allow-command REGEX` to pin args — required for any command that carries arguments;
+  (+ `--allow-command COMMAND`, a literal command line matched argv-for-argv, to pin args —
+  required for any command that carries arguments;
   `--allow-program` alone runs only the bare program, #243) re-runs a command whose argv[0] is `NAME` with
   no shell, a curated PATH, an isolated cwd, and a scrubbed env, then attaches the observed
   exit/output under `observed`.

--- a/skills/decide/advisory-board/scripts/README.md
+++ b/skills/decide/advisory-board/scripts/README.md
@@ -185,7 +185,8 @@ python3 scripts/render_verdict.py <out>/verdict.json --run <out> --html <out>/fi
 # --- the canonical-verdict chain (after the agent fills verdict.json,
 #     or `run --synthesize` drafts it via the neutral synthesizer seat — M2) ---
 # 1. resolve + stamp each typed citation verified/unverified/refuted.
-#    add --allow-program NAME (+ --allow-command 'REGEX' to pin args — REQUIRED for any
+#    add --allow-program NAME (+ --allow-command 'COMMAND', a LITERAL command line whose
+#    shlex argv must equal the citation's, to pin args — REQUIRED for any
 #    command that carries arguments; --allow-program alone runs only the bare program,
 #    #243: the command text is model-authored, so unpinned args are attacker-chosen) to ALSO
 #    re-execute command citations whose argv[0] is NAME (M3; opt-in, program-pinned,

--- a/skills/decide/advisory-board/scripts/verify_evidence.py
+++ b/skills/decide/advisory-board/scripts/verify_evidence.py
@@ -44,19 +44,20 @@ Command re-execution (M3) — read before enabling:
   was synthesized from untrusted source (the M2 synthesizer over poisoned reviews),
   a `command` citation can be attacker-influenced. Re-execution is OFF by default;
   enabling it is two explicit allowlists plus several structural containments. The
-  program allowlist (NOT the regex) is the load-bearing control:
+  program allowlist (NOT the command list) is the load-bearing control:
     * OPT-IN, PROGRAM-PINNED: nothing re-runs unless you pass `--allow-program NAME`
       (repeatable). A command runs only if its argv[0] (after shlex.split) is a BARE
       program name in that set — never a path (`./x`, `/bin/sh`, `../x` are refused).
-      This pins which program runs INDEPENDENT of any regex, so a too-broad
-      `--allow-command` pattern cannot let the attacker choose the executable.
+      This pins which program runs INDEPENDENT of the command list, so an
+      `--allow-command` entry cannot let the attacker choose the executable.
     * ARGS ARE PINNED TOO (#243): `--allow-program` alone permits only the BARE
       program (argv is exactly [NAME]). A command that carries ANY arguments must
-      also `re.fullmatch` an `--allow-command REGEX` (repeatable) — the command
-      text is model-authored, so unpinned arguments are attacker-chosen arguments
-      (`pytest --rootdir=... -p plugin`, `git -c core.pager=...`). PATTERNS ARE
-      LIVE REGEXES (`.` is a wildcard); they refine, never widen, the program
-      allowlist.
+      shlex-split to EXACTLY the argv of an `--allow-command COMMAND` entry
+      (repeatable) — the command text is model-authored, so unpinned arguments are
+      attacker-chosen arguments (`pytest --rootdir=... -p plugin`,
+      `git -c core.pager=...`). ENTRIES ARE LITERAL COMMAND LINES, not regexes
+      (CodeRabbit on PR #252: `.` matched spaces, so a pattern's wildcard was an
+      open argv tail); they refine, never widen, the program allowlist.
     * NO SHELL: split with shlex, run with shell=False, so `;`/`&&`/`|`/`>`/`$(...)`/
       globs are inert literal args, not operators.
     * CLEAN PATH, NO PLANTED BINARIES: argv[0] is resolved with shutil.which against
@@ -490,11 +491,14 @@ def command_allowed(command, rerun):
          (kills `./build.sh`, `/bin/sh`, `../x` and other path-based argv[0]);
       3. argv[0] is in `--allow-program` (the load-bearing pin);
       4. the ARGUMENTS are pinned (#243): a command with any argument beyond
-         argv[0], or any command when `--allow-command` patterns were given, must
-         `re.fullmatch` a pattern (fullmatch, not search — `pytest -q` never
-         green-lights `pytest -q; rm -rf ~`; a malformed pattern is skipped, never
-         crashes). `--allow-program` alone runs only the bare program: the command
-         text is model-authored, so unpinned arguments are attacker-chosen.
+         argv[0], or any command when `--allow-command` entries were given, must
+         shlex-split to EXACTLY the argv of an `--allow-command` entry (a LITERAL
+         command line, never a regex — CodeRabbit on PR #252: `.` matches spaces,
+         so even a "constrained" pattern like `pytest -q tests/.*` fullmatched an
+         arbitrary argv tail, and an allowlisted interpreter with `sh -c .*` ran
+         arbitrary payloads; an unparseable entry is skipped, never crashes).
+         `--allow-program` alone runs only the bare program: the command text is
+         model-authored, so unpinned arguments are attacker-chosen.
     """
     cmd = (command or "").strip()
     if not cmd:
@@ -512,24 +516,24 @@ def command_allowed(command, rerun):
     if prog not in rerun["programs"]:
         return None, (f"program {prog!r} is not in the --allow-program allowlist "
                       f"({', '.join(sorted(rerun['programs'])) or 'empty'})")
-    patterns = rerun.get("patterns") or []
-    if patterns or len(argv) > 1:
+    allowed = rerun.get("commands") or []
+    if allowed or len(argv) > 1:
         matched = False
-        for pat in patterns:
+        for entry in allowed:
             try:
-                if re.fullmatch(pat, cmd):
+                if shlex.split(entry) == argv:
                     matched = True
                     break
-            except re.error:
+            except ValueError:
                 continue
         if not matched:
-            if not patterns:
-                return None, ("command carries arguments but no --allow-command pattern "
+            if not allowed:
+                return None, ("command carries arguments but no --allow-command entry "
                               "was given — --allow-program alone permits only the bare "
                               "program (the command text is model-authored, so unpinned "
-                              "arguments are attacker-chosen); add --allow-command 'REGEX' "
-                              "to pin the exact arguments")
-            return None, "command does not match any --allow-command pattern"
+                              "arguments are attacker-chosen); add --allow-command 'COMMAND' "
+                              "to pin the exact command line")
+            return None, "command does not match any --allow-command entry"
     return argv, None
 
 
@@ -628,8 +632,8 @@ def _output_excerpt(output: str) -> tuple:
 def resolve_command(ev: dict, rerun) -> str:
     """Resolve a `command` citation by RE-EXECUTING it (M3). `rerun` is None (the
     feature is off → `unverified`, the pre-M3 default) or a dict with keys
-    `programs` (the argv[0] allowlist), `patterns` (optional full-command regexes),
-    `cwd`, `timeout`, and optional `home`.
+    `programs` (the argv[0] allowlist), `commands` (optional literal full-command
+    pins), `cwd`, `timeout`, and optional `home`.
 
     Structural match only (design section 11): verified iff exit == expect_exit
     (default 0) AND any verbatim `expect` substring is present in the output. The
@@ -644,6 +648,13 @@ def resolve_command(ev: dict, rerun) -> str:
     `refuted`: re-execution drops PYTHONPATH/VIRTUAL_ENV etc., so an env-shaped
     failure must NOT be defamed as a fabricated receipt (and a refuted citation
     routes the gate to abstain)."""
+    # A re-verify must never carry STALE execution metadata from a prior pass
+    # (mirrors stamp()'s snippet drop, CodeRabbit on PR #252): a refused or
+    # disabled pass that kept an old `observed` would persist an `unverified`
+    # citation still carrying an execution receipt. Drop both; this pass
+    # re-attaches only what it actually did.
+    ev.pop("observed", None)
+    ev.pop("status_reason", None)
     if rerun is None:
         return "unverified"   # re-execution not enabled for this verify pass
     argv, reason = command_allowed(ev.get("command", ""), rerun)
@@ -688,8 +699,8 @@ def stamp(data: dict, source_root, packet_text, rerun=None, manifest=None) -> di
     """Resolve every code/source/command citation and write its `status`. Mutates data.
 
     `rerun` (M3) is None by default — command citations stay `unverified`, exactly
-    the pre-M3 behavior — or a dict {allow, cwd, timeout} that enables allowlisted
-    command re-execution (see resolve_command).
+    the pre-M3 behavior — or a dict {programs, commands, cwd, timeout} that enables
+    allowlisted command re-execution (see resolve_command).
 
     `manifest` (v1.13 P3, Blocker 2) is None (ungrounded verify — capture allowed,
     gated only by Blocker 1's read), MANIFEST_UNUSABLE (a present-but-broken
@@ -739,15 +750,17 @@ def main(argv=None) -> int:
              "program name (repeatable). This is the load-bearing control: argv[0] is pinned to a "
              "program you name, never a path and never chosen by a regex. On its own it permits "
              "ONLY the bare program with no arguments; a command carrying arguments must also match "
-             "an --allow-command pattern (#243). OMITTED => command citations stay unverified "
+             "an --allow-command entry (#243). OMITTED => command citations stay unverified "
              "(re-execution is opt-in). Allowlist only programs you trust to be read-only over "
              "public material — a re-run's output is persisted to verdict.json.")
     parser.add_argument(
-        "--allow-command", dest="allow_command", action="append", default=[], metavar="REGEX",
-        help="pin the ARGS: require the full command to re.fullmatch this regex (repeatable). "
-             "REQUIRED for any command that carries arguments (#243) — --allow-program alone runs "
-             "only the bare program. Patterns are LIVE regexes (`.` is a wildcard). Refines the "
-             "--allow-program allowlist; cannot enable re-execution on its own.")
+        "--allow-command", dest="allow_command", action="append", default=[], metavar="COMMAND",
+        help="pin the ARGS: allow a command whose shlex-split argv EXACTLY equals this literal "
+             "command line (repeatable). REQUIRED for any command that carries arguments (#243) — "
+             "--allow-program alone runs only the bare program. Entries are LITERAL commands, not "
+             "regexes (a pattern's wildcard could green-light an arbitrary argv tail): copy the "
+             "exact command out of the verdict you are re-executing. Refines the --allow-program "
+             "allowlist; cannot enable re-execution on its own.")
     parser.add_argument(
         "--rerun-timeout", dest="rerun_timeout", type=int, default=DEFAULT_RERUN_TIMEOUT,
         metavar="SECONDS", help=f"hard timeout per re-executed command (default {DEFAULT_RERUN_TIMEOUT}s)")
@@ -777,7 +790,7 @@ def main(argv=None) -> int:
     manifest = load_scope_manifest(args.run_dir)
 
     # M3: assemble the re-execution config only when the user opted in with at least
-    # one --allow-program. The PROGRAM allowlist (not the regex) is the enabler; a
+    # one --allow-program. The PROGRAM allowlist (not the command list) is the enabler; a
     # bare --allow-command does NOT run anything. cwd defaults to a fresh empty
     # throwaway dir (no attacker files in cwd, no planted conftest/Makefile, nothing
     # writes into the reviewed source); --rerun-cwd opts into a real tree.
@@ -803,7 +816,7 @@ def main(argv=None) -> int:
         throwaways.append(home)
         rerun = {
             "programs": set(args.allow_program),
-            "patterns": list(args.allow_command),
+            "commands": list(args.allow_command),
             "cwd": cwd,
             "home": home,
             "timeout": args.rerun_timeout,

--- a/skills/decide/advisory-board/tests/README.md
+++ b/skills/decide/advisory-board/tests/README.md
@@ -107,8 +107,9 @@ The M5 canonical-verdict layer adds:
   no-packet → unverified — it never reaches the URL); `command` is unverified by
   default (re-execution is opt-in), and resolves against re-execution under
   `--allow-program NAME` (exit matches `expect_exit` and `expect` substring present
-  → verified, mismatch → refuted; a command carrying arguments also needs a matching
-  `--allow-command` pattern, #243); `judgment` is left unstamped.
+  → verified, mismatch → refuted; a command carrying arguments also needs an
+  `--allow-command` entry whose shlex argv matches exactly — a literal command line,
+  not a regex, #243); `judgment` is left unstamped.
 - **The gate abstains in the torn regime** (`TestGateAbstain`, `TestGateReconcileVerdictVsBoard`,
   `TestGateRefutedAnywhere`) — `--gate` returns exit `3` ("human required") when the seats that
   ran straddle the `--fail-on` line with no strict majority, when the declared `verdict` clears

--- a/skills/decide/advisory-board/tests/test_run_board.py
+++ b/skills/decide/advisory-board/tests/test_run_board.py
@@ -6112,9 +6112,10 @@ class TestCommandReexecution(unittest.TestCase):
     inheritance); stdin closed; a process-group-killed hard timeout; and a
     STRUCTURAL match (exit code + verbatim substring — never reasoning over output,
     design section 11). Arguments are pinned too (#243): --allow-program alone
-    permits only the bare program; a command carrying any arguments must fullmatch
-    an --allow-command pattern (the command text is model-authored, so unpinned
-    arguments are attacker-chosen)."""
+    permits only the bare program; a command carrying any arguments must shlex-split
+    to exactly an --allow-command LITERAL's argv (the command text is model-authored,
+    so unpinned arguments are attacker-chosen; regex entries died with the PR #252
+    follow-up — `.*` matches spaces, so any wildcard was an open argv tail)."""
 
     def setUp(self):
         self.d = tempfile.mkdtemp(prefix="m3-rerun-")
@@ -6122,13 +6123,13 @@ class TestCommandReexecution(unittest.TestCase):
     def cmd(self, command, **kw):
         return dict(kind="command", command=command, **kw)
 
-    def rerun(self, *programs, patterns=None, timeout=5, cwd=None):
-        return {"programs": set(programs), "patterns": list(patterns or []),
+    def rerun(self, *programs, commands=None, timeout=5, cwd=None):
+        return {"programs": set(programs), "commands": list(commands or []),
                 "cwd": cwd or self.d, "timeout": timeout}
 
     # --- command_allowed: argv[0] pinning + argument pinning ---------------- #
     def test_allowed_returns_argv(self):
-        argv, reason = ve.command_allowed("echo hi", self.rerun("echo", patterns=[r"echo hi"]))
+        argv, reason = ve.command_allowed("echo hi", self.rerun("echo", commands=["echo hi"]))
         self.assertEqual(argv, ["echo", "hi"])
         self.assertIsNone(reason)
 
@@ -6172,30 +6173,51 @@ class TestCommandReexecution(unittest.TestCase):
             self.assertIsNone(argv, bad)
             self.assertIn("bare program name", reason)
 
-    def test_regex_cannot_choose_program(self):
-        # THE blocker-3 fix: a too-broad --allow-command can't un-pin argv[0].
-        # The command matches the pattern but the program isn't allowlisted.
+    def test_allow_command_cannot_choose_program(self):
+        # THE blocker-3 fix: an --allow-command entry can't un-pin argv[0].
+        # The command equals the entry but the program isn't allowlisted.
         argv, reason = ve.command_allowed(
-            "sh -c id", self.rerun("pytest", patterns=[r"pytest .*|.*id"]))
+            "sh -c id", self.rerun("pytest", commands=["sh -c id"]))
         self.assertIsNone(argv)
         self.assertIn("allow-program", reason)
 
-    def test_pattern_refines_args(self):
-        rerun = self.rerun("pytest", patterns=[r"pytest -q .*"])
+    def test_entry_pins_args(self):
+        rerun = self.rerun("pytest", commands=["pytest -q tests/x.py"])
         self.assertIsNotNone(ve.command_allowed("pytest -q tests/x.py", rerun)[0])
-        # program allowlisted but args don't match the pattern -> refused
+        # program allowlisted but the args aren't the pinned ones -> refused
         argv, reason = ve.command_allowed("pytest --collect-only", rerun)
         self.assertIsNone(argv)
         self.assertIn("does not match", reason)
 
-    def test_pattern_fullmatch_rejects_superstring(self):
-        rerun = self.rerun("pytest", patterns=[r"pytest -q"])
-        # fullmatch: `pytest -q` is allowed, `pytest -q extra` is not.
+    def test_entry_rejects_superstring(self):
+        rerun = self.rerun("pytest", commands=["pytest -q"])
+        # exact argv: `pytest -q` is allowed, `pytest -q extra` is not.
         self.assertIsNotNone(ve.command_allowed("pytest -q", rerun)[0])
         self.assertIsNone(ve.command_allowed("pytest -q extra", rerun)[0])
 
-    def test_malformed_pattern_skipped(self):
-        rerun = self.rerun("echo", patterns=["(unbalanced", r"echo .*"])
+    def test_wildcard_entry_pins_nothing_but_itself(self):
+        # CodeRabbit on PR #252 (CWE-78): under regex matching, allowlisting an
+        # interpreter with `sh -c .*` fullmatched ANY payload — and `.*` matches
+        # spaces, so even `pytest -q tests/.*` was an open argv tail. Entries are
+        # LITERAL now: the old wildcard shapes match only their own literal text.
+        for entry, hostile in ((r"sh -c .*", "sh -c 'rm -rf ~'"),
+                               (r"python3 -c .*", "python3 -c 'import os;os.system(\"id\")'"),
+                               (r"pytest -q tests/.*", "pytest -q tests/x.py -p attacker_plugin")):
+            prog = entry.split()[0]
+            argv, reason = ve.command_allowed(hostile, self.rerun(prog, commands=[entry]))
+            self.assertIsNone(argv, entry)
+            self.assertIn("does not match", reason)
+
+    def test_entry_matches_across_quoting_variants(self):
+        # shlex-split equality, not string equality: the same argv spelled with
+        # different quoting still matches — the pin is the argv, not the spelling.
+        rerun = self.rerun("sh", commands=['sh -c "echo hi"'])
+        argv, reason = ve.command_allowed("sh -c 'echo hi'", rerun)
+        self.assertEqual(argv, ["sh", "-c", "echo hi"])
+        self.assertIsNone(reason)
+
+    def test_unparseable_entry_skipped(self):
+        rerun = self.rerun("echo", commands=["echo 'unclosed", "echo hi"])
         self.assertIsNotNone(ve.command_allowed("echo hi", rerun)[0])
 
     def test_empty_command_refused(self):
@@ -6284,10 +6306,35 @@ class TestCommandReexecution(unittest.TestCase):
 
     def test_allowed_passing_is_verified(self):
         ev = self.cmd("echo hello")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", patterns=[r"echo hello"])),
+        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", commands=["echo hello"])),
                          "verified")
         self.assertEqual(ev["observed"]["exit"], 0)
         self.assertIn("hello", ev["observed"]["output"])
+
+    # --- stale-metadata scrub (CodeRabbit on PR #252) ------------------------ #
+    def test_refusal_clears_stale_observed(self):
+        # A refusal used to keep the `observed` receipt from an earlier authorized
+        # run — the persisted citation read `unverified` yet still carried an
+        # execution receipt. Every resolve pass now starts from clean metadata.
+        ev = self.cmd("echo hi", observed={"exit": 0, "output": "hi"},
+                      status_reason="stale reason from an earlier pass")
+        status = ve.resolve_command(ev, self.rerun("echo"))  # args, no entry -> refused
+        self.assertEqual(status, "unverified")
+        self.assertNotIn("observed", ev)
+        self.assertIn("allow-command", ev["status_reason"])
+
+    def test_rerun_off_clears_stale_observed(self):
+        ev = self.cmd("echo hi", observed={"exit": 0, "output": "hi"},
+                      status_reason="stale reason from an earlier pass")
+        self.assertEqual(ve.resolve_command(ev, None), "unverified")
+        self.assertNotIn("observed", ev)
+        self.assertNotIn("status_reason", ev)
+
+    def test_verified_run_clears_stale_status_reason(self):
+        ev = self.cmd("echo hello", status_reason="stale refusal from an earlier pass")
+        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", commands=["echo hello"])),
+                         "verified")
+        self.assertNotIn("status_reason", ev)
 
     def test_off_allowlist_is_unverified_with_reason(self):
         ev = self.cmd("curl https://evil.example")
@@ -6332,12 +6379,12 @@ class TestCommandReexecution(unittest.TestCase):
         # Second-pass fix: under --rerun-cwd, HOME must NOT be the reviewed tree, so a
         # HOME-writing command can't drop dotfiles into the source. main() mints a
         # separate throwaway HOME; assert a re-run sees HOME != its cwd.
-        path = self._write_verdict([self.cmd(
-            "sh -c " + json.dumps("echo HOME=$HOME"), expect="HOME=")])
+        home_cmd = "sh -c " + json.dumps("echo HOME=$HOME")
+        path = self._write_verdict([self.cmd(home_cmd, expect="HOME=")])
         src_tree = tempfile.mkdtemp(prefix="m3-src-")
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            ve.main([path, "--allow-program", "sh", "--allow-command", r"sh -c .*",
+            ve.main([path, "--allow-program", "sh", "--allow-command", home_cmd,
                      "--rerun-cwd", src_tree])
         with open(path) as fh:
             data = json.load(fh)
@@ -6358,19 +6405,19 @@ class TestCommandReexecution(unittest.TestCase):
 
     def test_expect_substring_present_verified(self):
         ev = self.cmd("echo all tests passed", expect="passed")
-        rerun = self.rerun("echo", patterns=[r"echo .*"])
+        rerun = self.rerun("echo", commands=["echo all tests passed"])
         self.assertEqual(ve.resolve_command(ev, rerun), "verified")
         self.assertIs(ev["observed"]["expect_found"], True)
 
     def test_expect_substring_absent_refuted(self):
         ev = self.cmd("echo something else", expect="passed")
-        rerun = self.rerun("echo", patterns=[r"echo .*"])
+        rerun = self.rerun("echo", commands=["echo something else"])
         self.assertEqual(ve.resolve_command(ev, rerun), "refuted")
         self.assertIs(ev["observed"]["expect_found"], False)
 
     def test_expect_substring_whitespace_normalized(self):
         ev = self.cmd("echo 3 passed in 0.1s", expect="3   passed")
-        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", patterns=[r"echo .*"])),
+        self.assertEqual(ve.resolve_command(ev, self.rerun("echo", commands=["echo 3 passed in 0.1s"])),
                          "verified")
 
     def test_malformed_expect_exit_requires_clean_exit(self):
@@ -6383,7 +6430,7 @@ class TestCommandReexecution(unittest.TestCase):
         # The python code rides in a double-quoted segment so shlex keeps it one arg.
         code = "print('H'*100); print('x'*9000); print('TAILMARK')"
         ev = self.cmd(f'python3 -c "{code}"', expect="TAILMARK")
-        status = ve.resolve_command(ev, self.rerun("python3", patterns=[r"python3 -c .*"]))
+        status = ve.resolve_command(ev, self.rerun("python3", commands=[f'python3 -c "{code}"']))
         self.assertEqual(status, "verified")   # expect matched on FULL output
         self.assertTrue(ev["observed"]["truncated"])
         # The tail marker survives the head+tail excerpt even though it's past the limit.
@@ -6402,7 +6449,7 @@ class TestCommandReexecution(unittest.TestCase):
         data = {"blockers": [{"evidence": [self.cmd("echo hi"),
                                            self.cmd("false", expect_exit=0)]}]}
         counts = ve.stamp(data, None, None,
-                          self.rerun("echo", "false", patterns=[r"echo hi", r"false"]))
+                          self.rerun("echo", "false", commands=["echo hi", "false"]))
         evs = data["blockers"][0]["evidence"]
         self.assertEqual(evs[0]["status"], "verified")
         self.assertEqual(evs[1]["status"], "refuted")
@@ -6438,7 +6485,7 @@ class TestCommandReexecution(unittest.TestCase):
         path = self._write_verdict([self.cmd("echo hi")])
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            rc = ve.main([path, "--allow-command", r"echo .*"])
+            rc = ve.main([path, "--allow-command", "echo hi"])
         self.assertEqual(rc, 0)
         with open(path) as fh:
             data = json.load(fh)
@@ -6463,9 +6510,13 @@ class TestCommandReexecution(unittest.TestCase):
     def test_main_hostile_args_without_pattern_stay_unverified(self):
         # #243 end to end: --allow-program alone must not re-execute a command that
         # carries arguments (the argv tail is model-authored). The evidence stays
-        # unverified with the refusal reason and no `observed` receipt.
+        # unverified with the refusal reason and no `observed` receipt — including
+        # a STALE one seeded by an earlier authorized pass (CodeRabbit on PR #252).
         marker = os.path.join(self.d, "PWNED-MAIN")
-        path = self._write_verdict([self.cmd(f"touch {marker}")])
+        path = self._write_verdict([self.cmd(
+            f"touch {marker}",
+            observed={"exit": 0, "output": "stale receipt from an earlier pass"},
+            status_reason="stale reason from an earlier pass")])
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             rc = ve.main([path, "--allow-program", "touch"])


### PR DESCRIPTION
PR #252 merged four minutes after CodeRabbit's review, and its two outside-diff findings (embedded in the review body — no inline threads) never got the repo-required disposition. An audit on 2026-08-19 judged both still live on main. Verified both against current `main`; both are real. This PR fixes them.

## Finding 1 — Injection, CWE-78 (Major): broad `--allow-command` patterns

`command_allowed` fullmatched a live regex against the whole command string. Allowlisting an interpreter with `sh -c .*` or `python3 -c .*` authorized any model-authored payload — and since `.` matches spaces, even a pattern that looks constrained (`pytest -q tests/.*`) was an open argv tail: `pytest -q tests/x.py -p attacker_plugin` fullmatches it. No regex-lint heuristic closes that class, so this takes CodeRabbit's literal-argv option: an `--allow-command` entry is now a literal command line, and a command runs only when its shlex-split argv exactly equals an entry's. Quoting variants of the same argv still match; an unparseable entry is skipped. The reviewer pins a command by copying it out of the verdict, repeating the flag per command.

Tests: `test_wildcard_entry_pins_nothing_but_itself` runs the three old wildcard shapes against hostile payloads (nothing executes, refusal recorded), plus quoting-variant, superstring, and unparseable-entry cases. Docs, help text, and the skill CHANGELOG updated.

## Finding 2 — Data integrity (Major): stale execution metadata survives a refusal

`resolve_command`'s refusal path wrote `status_reason` but never removed an `observed` receipt left by an earlier authorized run, so a re-verified citation could persist as `unverified` while still carrying an old execution receipt (and a later verified pass kept a stale `status_reason`). Both keys are now dropped at the top of every resolve pass — mirroring `stamp()`'s stale-snippet drop — and the pass re-attaches only what it actually did.

Tests: refusal, rerun-off, and verified-pass scrub cases at the resolve layer, and the end-to-end `main()` hostile-args test now seeds stale metadata and asserts it is gone, per the finding's ask.

## Tripwire

Both regressions are named tests in the suite CI already requires: `test_wildcard_entry_pins_nothing_but_itself` and the stale-metadata trio + the extended `test_main_hostile_args_without_pattern_stay_unverified`. Full suite: 1598 tests, OK.

Dispositions will be recorded on PR #252's threads once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)