### PR TITLE
Review-settled merge gate: require CodeRabbit review of head and resolved threads

### DIFF
--- a/.github/workflows/pr-review-settled.yml
+++ b/.github/workflows/pr-review-settled.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/review-settled.yml
     with:
       # Mirrors .coderabbit.yaml: docs-titled and skip-review-labeled PRs
-      # get no bot review, so the gate must not wait for one.
-      skip-title-regex: '^docs:'
+      # get no bot review, so the gate must not wait for one. CodeRabbit
+      # matches the keyword anywhere in the title; the gate greps -Ei.
+      skip-title-regex: 'docs:'
       skip-label: skip-review

--- a/.github/workflows/pr-review-settled.yml
+++ b/.github/workflows/pr-review-settled.yml
@@ -1,0 +1,32 @@
+name: pr-review-settled
+
+# This repo's caller for the reusable review-settled gate. The review and
+# comment triggers re-evaluate as dispositions land; thread resolution alone
+# emits no event, so a re-run after resolving is sometimes needed.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: review-settled-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-settled:
+    # Local path so the gate exercises the version on this branch; external
+    # repos call timharris707/skills/.github/workflows/review-settled.yml@main.
+    uses: ./.github/workflows/review-settled.yml
+    with:
+      # Mirrors .coderabbit.yaml: docs-titled and skip-review-labeled PRs
+      # get no bot review, so the gate must not wait for one.
+      skip-title-regex: '^docs:'
+      skip-label: skip-review

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -49,7 +49,9 @@ jobs:
           owner=${REPO%/*}
           name=${REPO#*/}
 
-          if [ -n "$SKIP_TITLE_REGEX" ] && printf '%s' "$PR_TITLE" | grep -Eq "$SKIP_TITLE_REGEX"; then
+          # Case-insensitive to mirror CodeRabbit's ignore_title_keywords
+          # matching (keyword anywhere in the title, any case).
+          if [ -n "$SKIP_TITLE_REGEX" ] && printf '%s' "$PR_TITLE" | grep -Eiq "$SKIP_TITLE_REGEX"; then
             echo "exempt: title matches skip regex ($SKIP_TITLE_REGEX)"
             exit 0
           fi
@@ -58,37 +60,55 @@ jobs:
             exit 0
           fi
 
+          # Anchor for skip notices: only a notice at least as new as the head
+          # commit counts, so a skip for an earlier commit can't settle a
+          # later push.
+          head_committed_at=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')
+
+          # Sum unresolved review threads across every page; a partial count
+          # would either deadlock resolved PRs or green-light unseen threads.
+          count_unresolved() {
+            local cursor='' page n
+            n=0
+            while :; do
+              page=$(gh api graphql \
+                -f query='query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes { isResolved }
+                      }
+                    }
+                  }
+                }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+                ${cursor:+-f cursor="$cursor"} \
+                --jq '.data.repository.pullRequest.reviewThreads')
+              n=$((n + $(jq '[.nodes[] | select(.isResolved | not)] | length' <<<"$page")))
+              [ "$(jq -r '.pageInfo.hasNextPage' <<<"$page")" = "true" ] || break
+              cursor=$(jq -r '.pageInfo.endCursor' <<<"$page")
+            done
+            echo "$n"
+          }
+
           deadline=$((SECONDS + WAIT_MINUTES * 60))
           while :; do
             # A review object whose commit_id is the current head means the
-            # bot has seen this exact code, fix pushes included.
-            reviewed=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-              --jq "[.[] | select(.user.login == \"coderabbitai[bot]\" and .commit_id == \"$HEAD_SHA\")] | length")
+            # bot has seen this exact code, fix pushes included. --paginate
+            # emits one JSON array per page, so aggregate with jq -s.
+            reviewed=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate | jq -s \
+              --arg head "$HEAD_SHA" \
+              '[.[][] | select(.user.login == "coderabbitai[bot]" and .commit_id == $head)] | length')
 
             # Skip notices live in the pre-<details> segment of the bot's
             # latest comment; the segment test is the reliable detection.
-            skipped=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-              --jq '[.[] | select(.user.login == "coderabbitai[bot]") | .body] | last // "" | split("<details>")[0] | test("Review skipped") | if . then 1 else 0 end')
+            skipped=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s \
+              --arg since "$head_committed_at" \
+              '[.[][] | select(.user.login == "coderabbitai[bot]")] | last // null
+               | if . != null and .updated_at >= $since and (.body | split("<details>")[0] | test("Review skipped"))
+                 then 1 else 0 end')
 
-            threads=$(gh api graphql \
-              -f query='query($owner: String!, $name: String!, $number: Int!) {
-                repository(owner: $owner, name: $name) {
-                  pullRequest(number: $number) {
-                    reviewThreads(first: 100) {
-                      pageInfo { hasNextPage }
-                      nodes { isResolved }
-                    }
-                  }
-                }
-              }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
-              --jq '.data.repository.pullRequest.reviewThreads')
-            unresolved=$(printf '%s' "$threads" | jq '[.nodes[] | select(.isResolved | not)] | length')
-            # Past 100 threads the count is partial; stay conservative rather
-            # than green-lighting threads the query never saw.
-            if [ "$(printf '%s' "$threads" | jq '.pageInfo.hasNextPage')" = "true" ] && [ "$unresolved" -eq 0 ]; then
-              unresolved=1
-              echo "over 100 review threads; treating the overflow as unresolved"
-            fi
+            unresolved=$(count_unresolved)
 
             echo "head-reviewed=$reviewed review-skipped=$skipped unresolved-threads=$unresolved"
             if { [ "$reviewed" -gt 0 ] || [ "$skipped" -eq 1 ]; } && [ "$unresolved" -eq 0 ]; then

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -1,7 +1,7 @@
 name: review-settled
 
 # Reusable merge gate: a PR is "settled" only when CodeRabbit has reviewed
-# the current head commit (or explicitly skipped it) and no review thread is
+# the current head commit and no review thread is
 # unresolved. Closes the race where a PR merges minutes before the bot's
 # incremental pass lands, stranding findings nobody dispositions (audit,
 # 2026-08-19: live escapes on three repos). Callers make this a required
@@ -60,11 +60,6 @@ jobs:
             exit 0
           fi
 
-          # Anchor for skip notices: only a notice at least as new as the head
-          # commit counts, so a skip for an earlier commit can't settle a
-          # later push.
-          head_committed_at=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')
-
           # Sum unresolved review threads across every page; a partial count
           # would either deadlock resolved PRs or green-light unseen threads.
           count_unresolved() {
@@ -100,24 +95,17 @@ jobs:
               --arg head "$HEAD_SHA" \
               '[.[][] | select(.user.login == "coderabbitai[bot]" and .commit_id == $head)] | length')
 
-            # Skip notices live in the pre-<details> segment of the bot's
-            # latest comment; the segment test is the reliable detection.
-            skipped=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s \
-              --arg since "$head_committed_at" \
-              '[.[][] | select(.user.login == "coderabbitai[bot]")] | last // null
-               | if . != null and .updated_at >= $since and (.body | split("<details>")[0] | test("Review skipped"))
-                 then 1 else 0 end')
-
             unresolved=$(count_unresolved)
 
-            echo "head-reviewed=$reviewed review-skipped=$skipped unresolved-threads=$unresolved"
-            if { [ "$reviewed" -gt 0 ] || [ "$skipped" -eq 1 ]; } && [ "$unresolved" -eq 0 ]; then
+            echo "head-reviewed=$reviewed unresolved-threads=$unresolved"
+            if [ "$reviewed" -gt 0 ] && [ "$unresolved" -eq 0 ]; then
               echo "settled: CodeRabbit has seen $HEAD_SHA and every review thread is resolved"
               exit 0
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
               echo "not settled after $WAIT_MINUTES minutes."
-              echo "needs: a CodeRabbit review of head $HEAD_SHA (or a Review-skipped notice), and zero unresolved threads."
+              echo "needs: a CodeRabbit review of head $HEAD_SHA and zero unresolved threads."
+              echo "if CodeRabbit is configured to skip this PR, exempt it explicitly via the skip label or title regex."
               echo "after dispositioning findings and resolving threads, re-run this check (gh run rerun <run-id>)."
               exit 1
             fi

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -1,0 +1,105 @@
+name: review-settled
+
+# Reusable merge gate: a PR is "settled" only when CodeRabbit has reviewed
+# the current head commit (or explicitly skipped it) and no review thread is
+# unresolved. Closes the race where a PR merges minutes before the bot's
+# incremental pass lands, stranding findings nobody dispositions (audit,
+# 2026-08-19: live escapes on three repos). Callers make this a required
+# status check so the merge button waits for the review instead of racing it.
+
+on:
+  workflow_call:
+    inputs:
+      skip-title-regex:
+        description: PR titles matching this regex are exempt (CodeRabbit is configured to skip them)
+        type: string
+        default: ''
+      skip-label:
+        description: PRs carrying this label are exempt (CodeRabbit is configured to skip them)
+        type: string
+        default: ''
+      wait-minutes:
+        description: minutes to wait for CodeRabbit to review the head commit before failing
+        type: number
+        default: 20
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # PR fields flow in via env, never inline ${{ }} in run: a PR title is
+      # attacker-controlled on public repos (template-injection class).
+      - name: Wait for CodeRabbit review of head and zero unresolved threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          SKIP_TITLE_REGEX: ${{ inputs.skip-title-regex }}
+          SKIP_LABEL: ${{ inputs.skip-label }}
+          WAIT_MINUTES: ${{ inputs.wait-minutes }}
+        run: |
+          set -euo pipefail
+          owner=${REPO%/*}
+          name=${REPO#*/}
+
+          if [ -n "$SKIP_TITLE_REGEX" ] && printf '%s' "$PR_TITLE" | grep -Eq "$SKIP_TITLE_REGEX"; then
+            echo "exempt: title matches skip regex ($SKIP_TITLE_REGEX)"
+            exit 0
+          fi
+          if [ -n "$SKIP_LABEL" ] && gh api "repos/$REPO/issues/$PR_NUMBER/labels" --paginate --jq '.[].name' | grep -Fxq "$SKIP_LABEL"; then
+            echo "exempt: PR carries the $SKIP_LABEL label"
+            exit 0
+          fi
+
+          deadline=$((SECONDS + WAIT_MINUTES * 60))
+          while :; do
+            # A review object whose commit_id is the current head means the
+            # bot has seen this exact code, fix pushes included.
+            reviewed=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+              --jq "[.[] | select(.user.login == \"coderabbitai[bot]\" and .commit_id == \"$HEAD_SHA\")] | length")
+
+            # Skip notices live in the pre-<details> segment of the bot's
+            # latest comment; the segment test is the reliable detection.
+            skipped=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '[.[] | select(.user.login == "coderabbitai[bot]") | .body] | last // "" | split("<details>")[0] | test("Review skipped") | if . then 1 else 0 end')
+
+            threads=$(gh api graphql \
+              -f query='query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100) {
+                      pageInfo { hasNextPage }
+                      nodes { isResolved }
+                    }
+                  }
+                }
+              }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+              --jq '.data.repository.pullRequest.reviewThreads')
+            unresolved=$(printf '%s' "$threads" | jq '[.nodes[] | select(.isResolved | not)] | length')
+            # Past 100 threads the count is partial; stay conservative rather
+            # than green-lighting threads the query never saw.
+            if [ "$(printf '%s' "$threads" | jq '.pageInfo.hasNextPage')" = "true" ] && [ "$unresolved" -eq 0 ]; then
+              unresolved=1
+              echo "over 100 review threads; treating the overflow as unresolved"
+            fi
+
+            echo "head-reviewed=$reviewed review-skipped=$skipped unresolved-threads=$unresolved"
+            if { [ "$reviewed" -gt 0 ] || [ "$skipped" -eq 1 ]; } && [ "$unresolved" -eq 0 ]; then
+              echo "settled: CodeRabbit has seen $HEAD_SHA and every review thread is resolved"
+              exit 0
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "not settled after $WAIT_MINUTES minutes."
+              echo "needs: a CodeRabbit review of head $HEAD_SHA (or a Review-skipped notice), and zero unresolved threads."
+              echo "after dispositioning findings and resolving threads, re-run this check (gh run rerun <run-id>)."
+              exit 1
+            fi
+            sleep 30
+          done


### PR DESCRIPTION
## Why

The 2026-08-19 cross-project review audit found undispositioned CodeRabbit findings behind merged PRs on three repos, some hiding live defects. Two mechanical gaps caused all of them: merges racing CodeRabbit's incremental pass (findings land after merge), and threads nobody resolved. Branch-protection thread resolution catches the second; nothing caught the first.

## What

- `.github/workflows/review-settled.yml`: reusable (`workflow_call`) gate that passes only when CodeRabbit has posted a review whose `commit_id` is the current head (or a Review-skipped notice) and zero review threads are unresolved. Polls up to a configurable window so it absorbs the bot's 3-10 minute review latency instead of failing fast.
- `.github/workflows/pr-review-settled.yml`: this repo's caller, exempting `docs:`-titled and `skip-review`-labeled PRs to mirror `.coderabbit.yaml`.

chili, modeldeck-private, and grab-rabbit get thin callers referencing this workflow at `@main` in follow-up PRs.

## Verify

The gate runs on this PR itself: it should sit pending until CodeRabbit reviews this head, then go green once all threads are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)