### PR TITLE
review-settled: a clean CodeRabbit pass now settles instead of deadlocking

### DIFF
--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -95,6 +95,19 @@ jobs:
               --arg head "$HEAD_SHA" \
               '[.[][] | select(.user.login == "coderabbitai[bot]" and .commit_id == $head)] | length')
 
+            # A zero-finding pass posts NO review object (proven live:
+            # timharris707/chili#307 sat red for 20 minutes after a clean
+            # review). The walkthrough comment is updated every pass and its
+            # Commits section names the exact head SHA the bot reviewed, so a
+            # full-SHA match there is the same evidence.
+            if [ "$reviewed" -eq 0 ]; then
+              reviewed=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s \
+                --arg head "$HEAD_SHA" \
+                '[.[][] | select(.user.login == "coderabbitai[bot]"
+                                 and (.body | contains("auto-generated comment: summarize"))
+                                 and (.body | contains($head)))] | length')
+            fi
+
             unresolved=$(count_unresolved)
 
             echo "head-reviewed=$reviewed unresolved-threads=$unresolved"

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -98,14 +98,16 @@ jobs:
             # A zero-finding pass posts NO review object (proven live:
             # timharris707/chili#307 sat red for 20 minutes after a clean
             # review). The walkthrough comment is updated every pass and its
-            # Commits section names the exact head SHA the bot reviewed, so a
-            # full-SHA match there is the same evidence.
+            # Commits section names the reviewed range, so the head SHA as
+            # the range's endpoint ("between <sha> and <head>") is the same
+            # evidence. Anchored to that phrase, not the whole body: the SHA
+            # appearing elsewhere in a bot comment proves nothing.
             if [ "$reviewed" -eq 0 ]; then
               reviewed=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s \
                 --arg head "$HEAD_SHA" \
                 '[.[][] | select(.user.login == "coderabbitai[bot]"
                                  and (.body | contains("auto-generated comment: summarize"))
-                                 and (.body | contains($head)))] | length')
+                                 and (.body | test("between [0-9a-f]{40} and " + $head)))] | length')
             fi
 
             unresolved=$(count_unresolved)


### PR DESCRIPTION
The first repo to consume this gate exposed a deadlock: on timharris707/chili#307, CodeRabbit reviewed the head commit, found nothing actionable, and posted no review object at all — the only evidence the gate looks for. The check sat red for the full 20-minute wait on a PR the bot had already cleared. Any clean PR on any consuming repo hits the same wall once the gate is a required check.

The fix adds a second, equivalent settle signal: when no head-commit review object exists, the gate checks CodeRabbit's walkthrough comment for the exact 40-character head SHA in its reviewed-commits range. That comment is bot-authored, updated on every pass, and names the precise commit reviewed, so it proves the same fact for fix pushes too. Verified against live data: the check returns 1 for chili#307's real head and 0 for a fabricated SHA. PRs with findings keep settling exactly as before via review objects; nothing else changes.

A commit-status signal was considered and rejected: this repo's own `.coderabbit.yaml` turns `commit_status` off, so it isn't universal, while the walkthrough comment appears on every reviewed PR.

Filed by Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
