### PR TITLE
review-settled: request contents: none so callers aren't forced to grant read

### DIFF
--- a/.github/workflows/pr-review-settled.yml
+++ b/.github/workflows/pr-review-settled.yml
@@ -13,7 +13,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: none
   pull-requests: read
 
 concurrency:

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -24,7 +24,8 @@ on:
         default: 20
 
 # contents: none — this workflow never checks out code or reads repo contents
-# (REST reviews + GraphQL reviewThreads only). Anything above "none" would
+# (REST reviews, issue labels/comments, and GraphQL reviewThreads only).
+# Anything above "none" would
 # force every caller to grant at least that much: a workflow_call fails when
 # the caller's grant is narrower than what the called workflow requests
 # (flagged by CodeRabbit on modeldeck-private#544).

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -23,8 +23,13 @@ on:
         type: number
         default: 20
 
+# contents: none — this workflow never checks out code or reads repo contents
+# (REST reviews + GraphQL reviewThreads only). Anything above "none" would
+# force every caller to grant at least that much: a workflow_call fails when
+# the caller's grant is narrower than what the called workflow requests
+# (flagged by CodeRabbit on modeldeck-private#544).
 permissions:
-  contents: read
+  contents: none
   pull-requests: read
 
 jobs:


### PR DESCRIPTION
## What

The reusable merge gate `.github/workflows/review-settled.yml` declared `contents: read` but never checks out code or reads repo contents — it only calls the PR reviews REST API and the reviewThreads GraphQL API. Because a `workflow_call` fails when the caller grants narrower permissions than the called workflow requests, every caller (including private repos) was forced to grant `contents: read` it doesn't need. Flagged by CodeRabbit on [modeldeck-private#544](https://github.com/timharris707/modeldeck-private/pull/544).

## Change

- `review-settled.yml`: `contents: read` → `contents: none` (keeps `pull-requests: read`), with a comment stating the constraint so it isn't re-widened casually.
- `pr-review-settled.yml` (this repo's caller): drops `contents` to `none` too — this PR's own gate run is the live proof that a caller granting only `pull-requests: read` passes.

## Verification

This PR's `pr-review-settled` run exercises the changed workflow via the local-path `uses:`. Green check on this PR = a caller run passing with `contents: none` on both sides. External callers like modeldeck-private's `pr-review-settled.yml` can drop `contents` to `none` in a follow-up once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)