### PR TITLE
writing-for-agents: description trigger names the rules-file case (#266)

### DIFF
--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -9,6 +9,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Description names the rules-file case** (#266): the frontmatter trigger now says
+  "recording a decision as a rule agents will follow" with the concrete file names an
+  agent sees in the moment (CLAUDE.md, AGENTS.md, CODE-RULES, conduct rules). Written
+  after a live miss: an agent recording a verdict as a rules-file entry never connected
+  that act to "editing standing agent instructions," so the skill sat unfired while an
+  overstated rule went into the durable record. Same branch, wording matched to the
+  agent's in-the-moment framing. The quoted description example in
+  `references/skill-mechanics.md` follows.
 - **Context-pointers definition gets a readable lead** (#227, Theo-video takeaways): the
   paragraph defining a context pointer now opens with a plain-English sentence carrying the
   examples, with the precise definition kept verbatim after it. No rule changed.

--- a/skills/author/writing-for-agents/SKILL.md
+++ b/skills/author/writing-for-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-for-agents
-description: Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a reference file reached by a pointer. Use when authoring or revising a skill, editing standing agent instructions, or diagnosing why a document fires unreliably or gets skimmed.
+description: Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. Use when authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably or gets skimmed.
 ---
 
 # Writing for Agents

--- a/skills/author/writing-for-agents/references/skill-mechanics.md
+++ b/skills/author/writing-for-agents/references/skill-mechanics.md
@@ -15,7 +15,7 @@ description: <what it does, then when to reach for it>
 
 `description` **is** the context pointer, and it is the only part of a skill loaded into every session. Everything in SKILL.md's "Context pointers" section applies to it with full force. The house shape is one sentence of identity followed by the branches:
 
-> Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a reference file reached by a pointer. **Use when** authoring or revising a skill, editing standing agent instructions, or diagnosing why a document fires unreliably.
+> Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. **Use when** authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably.
 
 The `Use when` clause is where the branches live. One trigger per branch; a run of synonyms is one branch written three times.
 

--- a/skills/author/writing-for-agents/references/skill-mechanics.md
+++ b/skills/author/writing-for-agents/references/skill-mechanics.md
@@ -15,7 +15,7 @@ description: <what it does, then when to reach for it>
 
 `description` **is** the context pointer, and it is the only part of a skill loaded into every session. Everything in SKILL.md's "Context pointers" section applies to it with full force. The house shape is one sentence of identity followed by the branches:
 
-> Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. **Use when** authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably.
+> Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. **Use when** authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably or gets skimmed.
 
 The `Use when` clause is where the branches live. One trigger per branch; a run of synonyms is one branch written three times.
 


### PR DESCRIPTION
Closes #266.

## Why

Observed live 2026-08-20 in the decision-cloud workspace: an agent recording a decider verdict as a rules-file entry (CODE-RULES.md) wrote an overstated rule that a later session would have obeyed, refusing allowed work. writing-for-agents is agent-invocable and its body covers exactly this failure (the no-op test, checkable criteria, single source of truth), but it never fired. The trigger said "editing standing agent instructions," and an agent mid-conversation writing a rule entry believes it is recording a decision, not authoring an agent document. The skill's own lesson: the pointer's wording, not its target, decides firing.

## What changed

- **SKILL.md frontmatter description**: identity list gains "a rules file"; the trigger clause now reads "editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry)." One branch, not two: this is the same branch as standing-instructions editing, written to match the agent's in-the-moment framing, with the concrete file names that recruit the match.
- **references/skill-mechanics.md**: the house-shape example quotes the description; updated to the same text so the example cannot drift.
- **CHANGELOG**: entry under Unreleased, no version bump; rolls with the next batch release.

## Verification

- `check_emdash_density.py`, `check_invocation_freshness.py`, `check_router_freshness.py`, `check_site_disclosure.py` all pass locally; the server-dependent twin and OG-card checks ride CI.
- Tripwire for the regression this guards: the skill-mechanics example is the quoted description itself, so any future description edit that forgets the example shows up as a visible mismatch in the file that teaches description shape, and the Done-when line in #266 states the sync requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)