### PR TITLE
Quote SKILL.md descriptions so frontmatter parses as strict YAML

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "advisory-board",
       "source": "./",
       "strict": false,
-      "version": "1.18.1",
+      "version": "1.18.2",
       "description": "Convene a board of frontier AI models — Claude, Codex, Gemini, and Grok — that each review the same decision independently, debate across rounds, and hand back one clear recommendation.",
       "license": "MIT",
       "skills": [
@@ -23,7 +23,7 @@
       "name": "team-workflow",
       "source": "./",
       "strict": false,
-      "version": "1.5.2",
+      "version": "1.5.3",
       "description": "Fifteen skills that ship as one pack — a portable discipline for tracked, multi-session, agent-assisted development: a router entry point, a once-per-repo setup interview, per-repo institutional memory written as side effects of work, relentless grilling, decision maps, throwaway prototypes, autonomous research lanes, ticket filing, human-step wizards, session handoffs, an orchestration protocol for parallel lanes, a build discipline of seam-scoped test-first tracer slices, a disciplined bug-diagnosis loop where no fix ships without a named cause, an adversarial review that breaks changes before they ship, and a skeptic-verified state review of the codebase itself. Versioned together (team-workflow/vX.Y.Z); this version mirrors the latest pack tag.",
       "license": "MIT",
       "skills": [
@@ -59,7 +59,7 @@
       "name": "huh",
       "source": "./",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Decode an agent message that didn't land — a plain-sentence restatement, every piece of invented shorthand expanded, what's being asked of you separated from what happened, and unevidenced claims flagged.",
       "license": "MIT",
       "skills": [
@@ -70,7 +70,7 @@
       "name": "writing-for-agents",
       "source": "./",
       "strict": false,
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Write and prune documents an agent consumes — a SKILL.md, an AGENTS.md or CLAUDE.md, a reference reached by a pointer. Context pointers, the two loads, the information hierarchy, leading words, and the no-op test.",
       "license": "MIT",
       "skills": [
@@ -81,7 +81,7 @@
       "name": "writing-for-humans",
       "source": "./",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Write copy a human reads — a landing page, a README's front half, a launch post. Guide structure over catalog structure, the warmth moves, three named failure modes, standing voice rules, and a last-mile AI-tell scrub.",
       "license": "MIT",
       "skills": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Check invocation classification freshness
         run: python3 scripts/check_invocation_freshness.py
 
+      # GitHub and strict-YAML harnesses reject frontmatter with an unquoted
+      # ": " in a value (16 descriptions shipped that way — GitHub rendered an
+      # error banner instead of the frontmatter table). This fails the build
+      # when any tracked SKILL.md frontmatter is not strict YAML. PyYAML ships
+      # on GitHub runners; the install is a guard against image changes.
+      - name: Check SKILL.md frontmatter is strict YAML
+        run: |
+          python3 -m pip install --quiet PyYAML
+          python3 scripts/check_skill_frontmatter.py
+
       # The em dash is a reliable AI tell and skill prose style leaks into
       # model output (#226): this fails the build when any SKILL.md or
       # references file exceeds the per-file density threshold outside code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,12 @@ jobs:
         run: python3 scripts/check_invocation_freshness.py
 
       # GitHub and strict-YAML harnesses reject frontmatter with an unquoted
-      # ": " in a value (16 descriptions shipped that way — GitHub rendered an
+      # ": " in a value (16 descriptions shipped that way; GitHub rendered an
       # error banner instead of the frontmatter table). This fails the build
-      # when any tracked SKILL.md frontmatter is not strict YAML. PyYAML ships
-      # on GitHub runners; the install is a guard against image changes.
+      # when any tracked SKILL.md frontmatter falls outside the flat
+      # strict-YAML-safe subset. Standard library only. See the docstring.
       - name: Check SKILL.md frontmatter is strict YAML
-        run: |
-          python3 -m pip install --quiet PyYAML
-          python3 scripts/check_skill_frontmatter.py
+        run: python3 scripts/check_skill_frontmatter.py
 
       # The em dash is a reliable AI tell and skill prose style leaks into
       # model output (#226): this fails the build when any SKILL.md or

--- a/packs/team-workflow/CHANGELOG.md
+++ b/packs/team-workflow/CHANGELOG.md
@@ -14,7 +14,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.5.3] - 2026-08-25 — frontmatter descriptions parse as strict YAML
+
 ### Fixed
+- **Frontmatter descriptions are strict YAML now**: twelve pack SKILL.mds (router, setup,
+  domain-memory, grilling, decision-map, prototype, codebase-review, wizard, orchestrate,
+  adversarial-review, diagnose, implement) carried an unquoted ": " inside the
+  description, which a strict YAML parser reads as the start of a nested mapping. GitHub
+  showed an error banner instead of the frontmatter table, and any strict-parsing harness
+  could reject the skill outright. The descriptions are now double-quoted with the wording
+  byte-identical; `scripts/check_skill_frontmatter.py` in CI is the regression tripwire.
 - **setup: glossary + non-negotiables Done-when bullet admits the sync-managed pending
   state** (#192, found during #168's review): the bullet accepted only the carried
   section, the memory-home pointer, or a recorded decline, unsatisfiable on a

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Fail the build when any tracked SKILL.md frontmatter is not strict YAML.
+
+GitHub, gray-matter-based harnesses, and anything else standards-shaped parse
+the leading `---` block with a real YAML parser. An unquoted `: ` inside a
+description reads as a nested mapping and the whole block fails to parse:
+GitHub shows an error banner instead of the frontmatter table, and a strict
+loader drops or rejects the skill. Sixteen catalog descriptions shipped that
+way before this check existed.
+
+For every SKILL.md git tracks, this requires that:
+  - a `---` frontmatter block opens the file,
+  - the block parses under yaml.safe_load (PyYAML mirrors the strict parsers
+    that matter; the CI step installs it, which is a no-op on GitHub runners),
+  - it parses to a mapping with non-empty string `name` and `description`.
+
+Each violation prints one line; any violation exits non-zero. An empty file
+list fails too — an empty check is not a green check.
+"""
+
+import re
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("check_skill_frontmatter: PyYAML is required (pip install PyYAML)",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    files = subprocess.run(
+        ["git", "ls-files", "*SKILL.md"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    if not files:
+        print("ERROR: no tracked SKILL.md files found — an empty check is "
+              "not a green check")
+        sys.exit(1)
+
+    errors = []
+    for path in files:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        match = re.match(r"^---\n(.*?)\n---(?:\n|$)", text, re.S)
+        if not match:
+            errors.append(f"{path}: no leading --- frontmatter block")
+            continue
+        try:
+            data = yaml.safe_load(match.group(1))
+        except yaml.YAMLError as exc:
+            first = str(exc).replace("\n", " ").strip()
+            errors.append(f"{path}: frontmatter is not strict YAML ({first})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path}: frontmatter parses to {type(data).__name__}, "
+                          "not a mapping")
+            continue
+        for key in ("name", "description"):
+            value = data.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{path}: frontmatter lacks a non-empty string "
+                              f"'{key}'")
+
+    for error in errors:
+        print(f"ERROR: {error}")
+    if errors:
+        print(f"\n{len(errors)} frontmatter problem(s). Quote descriptions "
+              "that contain ': ' (JSON-style double quotes are valid YAML).")
+        sys.exit(1)
+    print(f"OK: {len(files)} SKILL.md frontmatter blocks parse as strict YAML")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -8,26 +8,93 @@ GitHub shows an error banner instead of the frontmatter table, and a strict
 loader drops or rejects the skill. Sixteen catalog descriptions shipped that
 way before this check existed.
 
-For every SKILL.md git tracks, this requires that:
-  - a `---` frontmatter block opens the file,
-  - the block parses under yaml.safe_load (PyYAML mirrors the strict parsers
-    that matter; the CI step installs it, which is a no-op on GitHub runners),
-  - it parses to a mapping with non-empty string `name` and `description`.
+Standard library only, so no YAML engine: instead this enforces a flat
+`key: value` subset that every strict YAML parser agrees on. A value must be
+one of:
 
-Each violation prints one line; any violation exits non-zero. An empty file
-list fails too — an empty check is not a green check.
+  - a JSON string (double-quoted, validated with json.loads — JSON strings
+    are a subset of YAML double-quoted scalars),
+  - a single-quoted YAML scalar ('' is the only escape),
+  - a plain scalar with no `: `, no trailing `:`, no ` #`, and no leading
+    YAML indicator character.
+
+Anything outside the subset fails, including nested or multi-line
+frontmatter: keep SKILL.md frontmatter flat, and quote descriptions that
+contain `: ` (JSON-style double quotes). On top of the form, `name` must be
+a slug and `description` a non-empty string. Each violation prints one line;
+any violation exits non-zero. An empty file list fails too — an empty check
+is not a green check.
 """
 
+import json
 import re
 import subprocess
 import sys
 
-try:
-    import yaml
-except ImportError:
-    print("check_skill_frontmatter: PyYAML is required (pip install PyYAML)",
-          file=sys.stderr)
-    sys.exit(1)
+KEY_LINE = re.compile(r"^([A-Za-z][\w-]*):(?: (.*))?$")
+JSON_STRING = re.compile(r'^"(?:[^"\\]|\\.)*"$')
+SINGLE_QUOTED = re.compile(r"^'(?:[^']|'')*'$")
+SLUG = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+# Leading characters YAML reserves or that start non-scalar nodes.
+PLAIN_UNSAFE_LEAD = set("#&*!|>%@`\"'{}[],?:- ")
+
+
+def value_error(value: str) -> str | None:
+    """Why this value falls outside the strict-YAML-safe subset, or None."""
+    if JSON_STRING.match(value):
+        try:
+            json.loads(value)
+            return None
+        except ValueError:
+            return "double-quoted value is not a valid JSON string"
+    if value.startswith('"'):
+        return "unterminated or malformed double-quoted value"
+    if SINGLE_QUOTED.match(value):
+        return None
+    if value.startswith("'"):
+        return "unterminated single-quoted value ('' is the only escape)"
+    if ": " in value or value.endswith(":"):
+        return "unquoted ': ' reads as a nested mapping — quote the value"
+    if " #" in value:
+        return "unquoted ' #' starts a YAML comment — quote the value"
+    if value and value[0] in PLAIN_UNSAFE_LEAD:
+        return f"leading {value[0]!r} is not safe in a plain scalar — quote the value"
+    return None
+
+
+def check_file(path: str) -> list:
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    match = re.match(r"^---\n(.*?)\n---(?:\n|$)", text, re.S)
+    if not match:
+        return [f"{path}: no leading --- frontmatter block"]
+
+    errors = []
+    fields = {}
+    for line in match.group(1).split("\n"):
+        if not line.strip():
+            continue
+        key_match = KEY_LINE.match(line)
+        if not key_match:
+            errors.append(f"{path}: line {line!r} is not flat 'key: value' — "
+                          "keep SKILL.md frontmatter flat")
+            continue
+        key, value = key_match.group(1), (key_match.group(2) or "").strip()
+        if key in fields:
+            errors.append(f"{path}: duplicate frontmatter key '{key}'")
+            continue
+        problem = value_error(value)
+        if problem:
+            errors.append(f"{path}: '{key}': {problem}")
+            continue
+        fields[key] = value
+
+    name = fields.get("name", "")
+    if not SLUG.match(name.strip("\"'")):
+        errors.append(f"{path}: frontmatter 'name' {name!r} is not a slug")
+    if not fields.get("description"):
+        errors.append(f"{path}: frontmatter lacks a non-empty 'description'")
+    return errors
 
 
 def main() -> None:
@@ -40,37 +107,14 @@ def main() -> None:
               "not a green check")
         sys.exit(1)
 
-    errors = []
-    for path in files:
-        with open(path, encoding="utf-8") as fh:
-            text = fh.read()
-        match = re.match(r"^---\n(.*?)\n---(?:\n|$)", text, re.S)
-        if not match:
-            errors.append(f"{path}: no leading --- frontmatter block")
-            continue
-        try:
-            data = yaml.safe_load(match.group(1))
-        except yaml.YAMLError as exc:
-            first = str(exc).replace("\n", " ").strip()
-            errors.append(f"{path}: frontmatter is not strict YAML ({first})")
-            continue
-        if not isinstance(data, dict):
-            errors.append(f"{path}: frontmatter parses to {type(data).__name__}, "
-                          "not a mapping")
-            continue
-        for key in ("name", "description"):
-            value = data.get(key)
-            if not isinstance(value, str) or not value.strip():
-                errors.append(f"{path}: frontmatter lacks a non-empty string "
-                              f"'{key}'")
-
+    errors = [error for path in files for error in check_file(path)]
     for error in errors:
         print(f"ERROR: {error}")
     if errors:
         print(f"\n{len(errors)} frontmatter problem(s). Quote descriptions "
               "that contain ': ' (JSON-style double quotes are valid YAML).")
         sys.exit(1)
-    print(f"OK: {len(files)} SKILL.md frontmatter blocks parse as strict YAML")
+    print(f"OK: {len(files)} SKILL.md frontmatter blocks are strict-YAML safe")
 
 
 if __name__ == "__main__":

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -62,6 +62,22 @@ def value_error(value: str) -> str | None:
     return None
 
 
+def decoded(value: str):
+    """The value a YAML parser would produce for a subset-valid token."""
+    if value.startswith('"'):
+        return json.loads(value)
+    if value.startswith("'"):
+        return value[1:-1].replace("''", "'")
+    lowered = value.lower()
+    if lowered in ("", "~", "null"):
+        return None
+    if lowered in ("true", "false"):
+        return lowered == "true"
+    if re.fullmatch(r"[-+]?\d+(\.\d+)?", value):
+        return float(value) if "." in value else int(value)
+    return value
+
+
 def check_file(path: str) -> list:
     with open(path, encoding="utf-8") as fh:
         text = fh.read()
@@ -87,13 +103,15 @@ def check_file(path: str) -> list:
         if problem:
             errors.append(f"{path}: '{key}': {problem}")
             continue
-        fields[key] = value
+        fields[key] = decoded(value)
 
-    name = fields.get("name", "")
-    if not SLUG.match(name.strip("\"'")):
+    name = fields.get("name")
+    if not isinstance(name, str) or not SLUG.match(name):
         errors.append(f"{path}: frontmatter 'name' {name!r} is not a slug")
-    if not fields.get("description"):
-        errors.append(f"{path}: frontmatter lacks a non-empty 'description'")
+    description = fields.get("description")
+    if not isinstance(description, str) or not description.strip():
+        errors.append(f"{path}: frontmatter lacks a non-empty string "
+                      "'description'")
     return errors
 
 

--- a/scripts/check_skill_md_twins.py
+++ b/scripts/check_skill_md_twins.py
@@ -9,7 +9,8 @@ asserts, so a serving regression fails CI instead of shipping silently:
      trailer — is byte-identical to the source SKILL.md body (the route
      strips leading whitespace, so the comparison allows only that).
   2. The regenerated frontmatter carries the source's name and description
-     verbatim, modulo the quote-stripping the site's parser applies. That
+     verbatim, modulo the unquoting the site's parser applies and the
+     JSON-style requoting the route emits to keep the twin strict YAML. That
      regeneration and the appended install trailer are the only sanctioned
      differences.
 
@@ -84,7 +85,9 @@ def split_source(raw: str) -> tuple[dict[str, str], str]:
         if not match:
             continue
         value = match.group(2).strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        if len(value) >= 2 and value[0] == value[-1] == '"':
+            value = re.sub(r'\\(["\\])', r"\1", value[1:-1])
+        elif len(value) >= 2 and value[0] == value[-1] == "'":
             value = value[1:-1]
         fields[match.group(1)] = value
     body = "\n".join(lines[close + 1 :])
@@ -100,7 +103,13 @@ def check_twin(slug: str, skill_file: Path, base: str) -> list[str]:
         return [f"{slug}: served twin has no frontmatter block"]
 
     failures = []
-    expected_head = ["---", f"name: {fields.get('name', '')}", f"description: {fields.get('description', '')}"]
+    # The route emits the description JSON-quoted so the twin's frontmatter
+    # stays strict YAML; json.dumps mirrors JSON.stringify for these strings.
+    expected_head = [
+        "---",
+        f"name: {fields.get('name', '')}",
+        f"description: {json.dumps(fields.get('description', ''), ensure_ascii=False)}",
+    ]
     if head.split("\n") != expected_head:
         failures.append(f"{slug}: regenerated frontmatter does not match the source's name/description")
 

--- a/scripts/check_skill_md_twins.py
+++ b/scripts/check_skill_md_twins.py
@@ -86,7 +86,10 @@ def split_source(raw: str) -> tuple[dict[str, str], str]:
             continue
         value = match.group(2).strip()
         if len(value) >= 2 and value[0] == value[-1] == '"':
-            value = re.sub(r'\\(["\\])', r"\1", value[1:-1])
+            try:
+                value = json.loads(value)
+            except ValueError:
+                value = value[1:-1]
         elif len(value) >= 2 and value[0] == value[-1] == "'":
             value = value[1:-1]
         fields[match.group(1)] = value

--- a/site/src/app/api/skill-md/[slug]/route.ts
+++ b/site/src/app/api/skill-md/[slug]/route.ts
@@ -26,7 +26,9 @@ export async function GET(_request: Request, context: { params: Promise<{ slug: 
   const source = [
     "---",
     `name: ${skill.name}`,
-    `description: ${skill.description}`,
+    // JSON string quoting is valid YAML, so the twin's frontmatter stays
+    // parseable even when the description contains colons or quotes.
+    `description: ${JSON.stringify(skill.description)}`,
     "---",
     "",
     skill.body.trimStart(),

--- a/site/src/lib/skills.ts
+++ b/site/src/lib/skills.ts
@@ -65,10 +65,16 @@ function parseFrontmatter(raw: string): { data: Record<string, string>; body: st
     const match = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
     if (!match) continue;
     let value = match[2].trim();
-    // Descriptions containing a colon are quoted in some skills; quoted
-    // values may carry \" and \\ escapes.
+    // Descriptions containing a colon are quoted in some skills. CI's
+    // check_skill_frontmatter.py guarantees double-quoted values are JSON
+    // strings, so JSON.parse decodes every escape; fall back to a bare
+    // unquote rather than crash the build on a file CI hasn't seen yet.
     if (value.startsWith('"') && value.endsWith('"')) {
-      value = value.slice(1, -1).replace(/\\(["\\])/g, "$1");
+      try {
+        value = JSON.parse(value);
+      } catch {
+        value = value.slice(1, -1);
+      }
     } else if (value.startsWith("'") && value.endsWith("'")) {
       value = value.slice(1, -1);
     }

--- a/site/src/lib/skills.ts
+++ b/site/src/lib/skills.ts
@@ -65,11 +65,11 @@ function parseFrontmatter(raw: string): { data: Record<string, string>; body: st
     const match = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
     if (!match) continue;
     let value = match[2].trim();
-    // Descriptions containing a colon are quoted in some skills.
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
+    // Descriptions containing a colon are quoted in some skills; quoted
+    // values may carry \" and \\ escapes.
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\(["\\])/g, "$1");
+    } else if (value.startsWith("'") && value.endsWith("'")) {
       value = value.slice(1, -1);
     }
     data[match[1]] = value;

--- a/skills/author/huh/CHANGELOG.md
+++ b/skills/author/huh/CHANGELOG.md
@@ -7,6 +7,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.0.1] - 2026-08-25 — frontmatter description parses as strict YAML
+
+### Fixed
+- **Frontmatter description is strict YAML now**: the SKILL.md description carried an
+  unquoted ": ", which a strict YAML parser reads as the start of a nested mapping.
+  GitHub showed an error banner instead of the frontmatter table, and any
+  strict-parsing harness could reject the skill outright. The description is now
+  double-quoted with the wording byte-identical; `scripts/check_skill_frontmatter.py`
+  in CI is the regression tripwire.
+
 ### Changed
 - **Em-dash sweep** (#226): SKILL.md's em-dash constructions rewrote into periods,
   commas, and colons, meaning-preserving; the description's trigger wording is

--- a/skills/author/huh/SKILL.md
+++ b/skills/author/huh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huh
-description: Decode a message that didn't land: restate it in plain sentences, expand invented shorthand, split report from request, and flag claims stated without evidence. Use when the user signals your last message didn't land ("huh?", "what do you mean"), or pastes agent output from another session to translate.
+description: "Decode a message that didn't land: restate it in plain sentences, expand invented shorthand, split report from request, and flag claims stated without evidence. Use when the user signals your last message didn't land (\"huh?\", \"what do you mean\"), or pastes agent output from another session to translate."
 ---
 
 # Huh

--- a/skills/author/writing-for-agents/CHANGELOG.md
+++ b/skills/author/writing-for-agents/CHANGELOG.md
@@ -8,6 +8,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.0.2] - 2026-08-25 — frontmatter description parses as strict YAML
+
+### Fixed
+- **Frontmatter description is strict YAML now**: the SKILL.md description carried an
+  unquoted ": ", which a strict YAML parser reads as the start of a nested mapping.
+  GitHub showed an error banner instead of the frontmatter table, and any
+  strict-parsing harness could reject the skill outright. The description is now
+  double-quoted with the wording byte-identical; `scripts/check_skill_frontmatter.py`
+  in CI is the regression tripwire.
+
 ### Changed
 - **Description names the rules-file case** (#266): the frontmatter trigger now says
   "recording a decision as a rule agents will follow" with the concrete file names an
@@ -20,6 +30,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Context-pointers definition gets a readable lead** (#227, Theo-video takeaways): the
   paragraph defining a context pointer now opens with a plain-English sentence carrying the
   examples, with the precise definition kept verbatim after it. No rule changed.
+- **Em-dash sweep** (#226): SKILL.md and `references/skill-mechanics.md` rewrote
+  their em-dash constructions into periods, commas, and colons, meaning-preserving;
+  the frontmatter description's trigger wording is unchanged. The description-shape
+  example in skill-mechanics now demonstrates the swept form. Part of the
+  catalog-wide sweep guarded by `scripts/check_emdash_density.py` in CI.
 
 ### Added
 - **Punctuation rule** (#226): a compact section stating that skill prose carries
@@ -27,13 +42,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tell and the style of prose an agent reads leaks into what it writes; rationale
   pointed at plainspoken's tell catalog, pattern 13. A matching Done-when bullet
   ("No em dash appears outside a code block") makes it checkable.
-
-### Changed
-- **Em-dash sweep** (#226): SKILL.md and `references/skill-mechanics.md` rewrote
-  their em-dash constructions into periods, commas, and colons, meaning-preserving;
-  the frontmatter description's trigger wording is unchanged. The description-shape
-  example in skill-mechanics now demonstrates the swept form. Part of the
-  catalog-wide sweep guarded by `scripts/check_emdash_density.py` in CI.
 
 ## [v1.0.1] - 2026-08-13 — fidelity and invariant corrections
 

--- a/skills/author/writing-for-agents/SKILL.md
+++ b/skills/author/writing-for-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-for-agents
-description: Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. Use when authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably or gets skimmed.
+description: "Write and prune documents an agent consumes: a SKILL.md, an AGENTS.md or CLAUDE.md, a rules file, a reference file reached by a pointer. Use when authoring or revising a skill, editing standing agent instructions or recording a decision as a rule agents will follow (a CLAUDE.md, AGENTS.md, CODE-RULES, or conduct-rules entry), or diagnosing why a document fires unreliably or gets skimmed."
 ---
 
 # Writing for Agents

--- a/skills/author/writing-for-humans/CHANGELOG.md
+++ b/skills/author/writing-for-humans/CHANGELOG.md
@@ -8,6 +8,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v1.2.1] - 2026-08-25 — frontmatter description parses as strict YAML
+
+### Fixed
+
+- **Frontmatter description is strict YAML now**: the SKILL.md description carried an
+  unquoted ": ", which a strict YAML parser reads as the start of a nested mapping.
+  GitHub showed an error banner instead of the frontmatter table, and any
+  strict-parsing harness could reject the skill outright. The description is now
+  double-quoted with the wording byte-identical; `scripts/check_skill_frontmatter.py`
+  in CI is the regression tripwire.
+
 ### Changed
 
 - **Em-dash sweep** (#226): SKILL.md and `references/last-mile-scrub.md` rewrote

--- a/skills/author/writing-for-humans/SKILL.md
+++ b/skills/author/writing-for-humans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-for-humans
-description: Write copy a human reads: a landing page, a README's front half, a launch post, a profile page. Use when drafting or revising public-facing prose, when a page reads like agent documentation, or when a finished draft needs its last-mile scrub for AI tells.
+description: "Write copy a human reads: a landing page, a README's front half, a launch post, a profile page. Use when drafting or revising public-facing prose, when a page reads like agent documentation, or when a finished draft needs its last-mile scrub for AI tells."
 ---
 
 # Writing for Humans

--- a/skills/decide/advisory-board/CHANGELOG.md
+++ b/skills/decide/advisory-board/CHANGELOG.md
@@ -9,6 +9,8 @@ versioned separately and do not replace the skill release version.
 
 ## [Unreleased]
 
+## [v1.18.2] - 2026-08-25 — allowlist hardening lands, frontmatter parses strict
+
 ### Security
 - **`--allow-command` entries are literal command lines now, not regexes** (CodeRabbit on
   PR #252, CWE-78): under `re.fullmatch`, allowlisting an interpreter with a pattern like
@@ -34,6 +36,12 @@ versioned separately and do not replace the skill release version.
   and `main()` layers (nothing executes, no `observed` receipt).
 
 ### Fixed
+- **Frontmatter description is strict YAML now**: the SKILL.md description carried an
+  unquoted ": ", which a strict YAML parser reads as the start of a nested mapping.
+  GitHub showed an error banner instead of the frontmatter table, and any
+  strict-parsing harness could reject the skill outright. The description is now
+  double-quoted with the wording byte-identical; `scripts/check_skill_frontmatter.py`
+  in CI is the regression tripwire.
 - **A refused or disabled re-execution pass no longer keeps a stale `observed` receipt**
   (CodeRabbit on PR #252): `resolve_command` only wrote `status_reason` on refusal, so a
   citation re-verified after an earlier authorized run could persist as `unverified` while

--- a/skills/decide/advisory-board/SKILL.md
+++ b/skills/decide/advisory-board/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisory-board
-description: Convene a multi-model advisory board: subscription-backed Claude, Codex, Gemini, and Grok CLIs reviewing the same material in formal, roundtable, or competitive mode. Use when the user asks for an advisory board, roundtable, panel, or idea tournament; a multi-model or cross-provider review or debate; a red-team of a plan, design, decision, or document by several models; or a consensus handoff from several frontier models.
+description: "Convene a multi-model advisory board: subscription-backed Claude, Codex, Gemini, and Grok CLIs reviewing the same material in formal, roundtable, or competitive mode. Use when the user asks for an advisory board, roundtable, panel, or idea tournament; a multi-model or cross-provider review or debate; a red-team of a plan, design, decision, or document by several models; or a consensus handoff from several frontier models."
 ---
 
 # Advisory Board

--- a/skills/decide/decision-map/SKILL.md
+++ b/skills/decide/decision-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decision-map
-description: Chart or work a decision map for genuinely foggy work before any build slice is written: a new primitive, a milestone charter, an integration nobody can spec in one sitting. Use when asked to chart a decision map, work a map ticket, or plan a decision-heavy effort whose open questions gate each other.
+description: "Chart or work a decision map for genuinely foggy work before any build slice is written: a new primitive, a milestone charter, an integration nobody can spec in one sitting. Use when asked to chart a decision map, work a map ticket, or plan a decision-heavy effort whose open questions gate each other."
 ---
 
 # Decision Map

--- a/skills/decide/grilling/SKILL.md
+++ b/skills/decide/grilling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grilling
-description: Interview the decider relentlessly to turn a half-formed plan, design, or idea into shared understanding: a design tree worked in rounds until nothing is silently assumed. Use when asked to grill, stress-test, or pressure-test thinking, and before charting a decision map or writing a spec off a conversation nobody has pressure-tested.
+description: "Interview the decider relentlessly to turn a half-formed plan, design, or idea into shared understanding: a design tree worked in rounds until nothing is silently assumed. Use when asked to grill, stress-test, or pressure-test thinking, and before charting a decision map or writing a spec off a conversation nobody has pressure-tested."
 ---
 
 # Grilling

--- a/skills/investigate/codebase-review/SKILL.md
+++ b/skills/investigate/codebase-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-review
-description: Run a state review of the codebase: the counterpart to adversarial-review's change review. Use before building against an upcoming spec (make the change easy first), when lanes merged since the last review cross the repo's threshold, or when lanes or the orchestrator report the code fighting them.
+description: "Run a state review of the codebase: the counterpart to adversarial-review's change review. Use before building against an upcoming spec (make the change easy first), when lanes merged since the last review cross the repo's threshold, or when lanes or the orchestrator report the code fighting them."
 ---
 
 # Codebase review

--- a/skills/investigate/prototype/SKILL.md
+++ b/skills/investigate/prototype/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prototype
-description: Build throwaway prototype code that answers a design question: UI variants on a live route, or a terminal UI or single shareable HTML file over a pure logic module. Use when a question is "how should this look / behave / feel in action" and discussion or static artifacts cannot settle it.
+description: "Build throwaway prototype code that answers a design question: UI variants on a live route, or a terminal UI or single shareable HTML file over a pure logic module. Use when a question is \"how should this look / behave / feel in action\" and discussion or static artifacts cannot settle it."
 ---
 
 # Prototype

--- a/skills/orient/domain-memory/SKILL.md
+++ b/skills/orient/domain-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-memory
-description: Keep per-repo institutional memory: a domain glossary plus lightweight decision records, written as side effects of work. Use when a grilling closes, a review rejection or declined finding is dispositioned, the decider corrects a session's wrong assumption, a session starts in a repo whose binding names a memory home, or the store passes its size bound.
+description: "Keep per-repo institutional memory: a domain glossary plus lightweight decision records, written as side effects of work. Use when a grilling closes, a review rejection or declined finding is dispositioned, the decider corrects a session's wrong assumption, a session starts in a repo whose binding names a memory home, or the store passes its size bound."
 ---
 
 # Domain memory

--- a/skills/orient/router/SKILL.md
+++ b/skills/orient/router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: router
-description: Entry point for the team-workflow pack: names every pack skill and when to reach for it. Use when unsure which team-workflow skill applies, or to orient a new session/repo on what the pack offers.
+description: "Entry point for the team-workflow pack: names every pack skill and when to reach for it. Use when unsure which team-workflow skill applies, or to orient a new session/repo on what the pack offers."
 ---
 
 # Team-workflow router

--- a/skills/orient/setup/SKILL.md
+++ b/skills/orient/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Once-per-repo binding interview for the team-workflow pack: records how the pack composes with this repo and seeds the binding doc the other skills read. Use when installing the pack into a repo, refreshing an existing installation's bindings, or auditing a consuming repo for drift after a pack release (audit mode).
+description: "Once-per-repo binding interview for the team-workflow pack: records how the pack composes with this repo and seeds the binding doc the other skills read. Use when installing the pack into a repo, refreshing an existing installation's bindings, or auditing a consuming repo for drift after a pack release (audit mode)."
 ---
 
 # Setup

--- a/skills/run/adversarial-review/SKILL.md
+++ b/skills/run/adversarial-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-review
-description: Run an adversarial review of a change before it ships: isolated finders trying to break it, a skeptic pass that kills unproven findings, and a gate on confirmed blockers. Use before committing substantial work, at lane close-out, when the user asks for an adversarial or red-team review of a diff/branch/PR, or before external reviewers see the change.
+description: "Run an adversarial review of a change before it ships: isolated finders trying to break it, a skeptic pass that kills unproven findings, and a gate on confirmed blockers. Use before committing substantial work, at lane close-out, when the user asks for an adversarial or red-team review of a diff/branch/PR, or before external reviewers see the change."
 ---
 
 # Adversarial review

--- a/skills/run/diagnose/SKILL.md
+++ b/skills/run/diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diagnose
-description: The disciplined bug-fixing loop: no fix ships without a cause the fixer can state in one plain sentence, with evidence. Use when any fix is about to ship without a nameable cause, when a bug resists its first fix attempt, or when a bug-shaped lane brief points here.
+description: "The disciplined bug-fixing loop: no fix ships without a cause the fixer can state in one plain sentence, with evidence. Use when any fix is about to ship without a nameable cause, when a bug resists its first fix attempt, or when a bug-shaped lane brief points here."
 ---
 
 # Diagnose

--- a/skills/run/implement/SKILL.md
+++ b/skills/run/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: How a working lane builds an item: seam-scoped test-first, tracer-first sequencing, a green checkpoint per slice, and file-don't-fix scope discipline. Use when a build-shaped lane brief points here, when implementing a spec or tracked item, or when mid-build discoveries tempt a lane beyond its brief.
+description: "How a working lane builds an item: seam-scoped test-first, tracer-first sequencing, a green checkpoint per slice, and file-don't-fix scope discipline. Use when a build-shaped lane brief points here, when implementing a spec or tracked item, or when mid-build discoveries tempt a lane beyond its brief."
 ---
 
 # Implement

--- a/skills/run/orchestrate/SKILL.md
+++ b/skills/run/orchestrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrate
-description: Run a session as the orchestrator of parallel agent-assisted work: routing items to working sessions, auditing results, and owning integration, instead of implementing. Use when the user says "orchestration mode", asks one session to coordinate several lanes/sessions, or hands over an orchestrator role.
+description: "Run a session as the orchestrator of parallel agent-assisted work: routing items to working sessions, auditing results, and owning integration, instead of implementing. Use when the user says \"orchestration mode\", asks one session to coordinate several lanes/sessions, or hands over an orchestrator role."
 ---
 
 # Orchestrate

--- a/skills/run/wizard/SKILL.md
+++ b/skills/run/wizard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wizard
-description: Generate an interactive bash wizard that walks a human through a procedure only they can perform: third-party dashboards, credentials, DNS records, CI secrets, one-off cutovers. Use when a task stalls on steps an agent cannot take, or when a manual setup is tedious to re-explain every time. Not for steps the agent can perform itself.
+description: "Generate an interactive bash wizard that walks a human through a procedure only they can perform: third-party dashboards, credentials, DNS records, CI secrets, one-off cutovers. Use when a task stalls on steps an agent cannot take, or when a manual setup is tedious to re-explain every time. Not for steps the agent can perform itself."
 ---
 
 # Wizard


### PR DESCRIPTION
## What

GitHub showed an "Error in user YAML" banner on 16 SKILL.md pages (first spotted on [grilling](https://github.com/timharris707/skills/blob/main/skills/decide/grilling/SKILL.md)): each description carried an unquoted `: `, which a strict YAML parser reads as the start of a nested mapping. GitHub falls back to an error banner, and any strict-parsing harness (gray-matter and friends) could reject the skill outright, which cuts against the catalog's portability claim.

## Changes

- **16 descriptions double-quoted, wording byte-identical** (verified by a parse round-trip during the sweep): grilling, decision-map, advisory-board, codebase-review, prototype, router, setup, domain-memory, adversarial-review, diagnose, implement, orchestrate, wizard, huh, writing-for-agents, writing-for-humans.
- **Tripwire:** new `scripts/check_skill_frontmatter.py` in CI fails the build when any tracked SKILL.md frontmatter is not strict YAML (or lacks string name/description). It would have caught all 16.
- **Site:** the frontmatter parser now unescapes `\"` and `\\` in double-quoted values (three descriptions contain literal quotes), and the markdown-twin route emits the description JSON-quoted so served twins are strict YAML too. `check_skill_md_twins.py` mirrors both, per its "replicate, don't trust" note.
- **Releases:** patch bumps with changelog sections for the five affected plugins — team-workflow 1.5.3, advisory-board 1.18.2, huh 1.0.1, writing-for-agents 1.0.2, writing-for-humans 1.2.1. Each release also carries that plugin's pending Unreleased entries, folded into the new section.

## Verified locally

- `check_skill_frontmatter.py`: all 24 tracked SKILL.mds pass (16 failed before).
- `changelog_section.py` resolves a non-empty section for each bumped version.
- Router, invocation, em-dash, and disclosure checks all green.
- Site builds; twins check green against a local server; llms.txt and the huh/prototype twins render the quoted descriptions with no stray escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)