### PR TITLE
CodeRabbit reviews each PR once instead of on every push

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,6 +31,10 @@ reviews:
     - "!design/**"
   auto_review:
     enabled: true
+    # One review per PR (timharris707/insight-chat#574 cost audit): no
+    # re-review on later pushes or rebases — the first automatic review is
+    # the only one. A human can still ask with `@coderabbitai review`.
+    auto_incremental_review: false
     # Docs-only PRs merge in minutes; skip them rather than produce post-merge
     # commentary. CodeRabbit matches the keyword ANYWHERE in the title
     # (case-insensitive), so keep the substring "docs:" out of code-PR titles.


### PR DESCRIPTION
CodeRabbit re-reviewed every PR on every push and rebase, and its billing is per file changed — across Tim's repos that spent \$405 of the \$500 monthly cap by Aug 30, with 46% of review attempts rate-limited and wasted. This repo's config already had good path filters and a non-blocking posture; the only gap was re-reviews. Full audit: timharris707/insight-chat#574.

One key changes, nothing else:

- `reviews.auto_review.auto_incremental_review: false` — the first automatic review on a PR is the only one; later pushes and rebases no longer trigger a new pass. A human can still request another with `@coderabbitai review`. ([schema reference](https://docs.coderabbit.ai/reference/configuration))

The rest of the file is byte-identical. The config parses and every key validates against CodeRabbit's published schema (schema.v2.json). This repo has no skip-review label, so this PR will itself get one CodeRabbit review — harmless, and the last of its kind at this cost.

Filed by Claude Fable 5 via Claude Code.