### PR TITLE
review-settled: require a reply on every CodeRabbit thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
       - name: Check retired positioning lines stay retired
         run: python3 scripts/check_positioning.py
 
+      # The review-settled merge gate is shell + jq inside a workflow file, so
+      # nothing else exercises it. This lifts its two thread filters out of
+      # the workflow text verbatim and runs them against fixture pages, so
+      # the reply-per-finding rule (#288) cannot be dropped silently.
+      - name: Check the review-settled gate's thread filters
+        run: python3 -m unittest discover -s tests/gate -p 'test*.py'
+
       # Tracker recipes must name the bound repo explicitly (#208): an
       # unqualified gh command resolves the repo implicitly, which in a fork
       # targets the upstream repo instead of the bound tracker.

--- a/.github/workflows/review-settled.yml
+++ b/.github/workflows/review-settled.yml
@@ -1,10 +1,12 @@
 name: review-settled
 
 # Reusable merge gate: a PR is "settled" only when CodeRabbit has reviewed
-# the current head commit and no review thread is
-# unresolved. Closes the race where a PR merges minutes before the bot's
-# incremental pass lands, stranding findings nobody dispositions (audit,
-# 2026-08-19: live escapes on three repos). Callers make this a required
+# the current head commit, no review thread is unresolved, and every thread
+# CodeRabbit opened carries a reply from someone other than a bot. Closes the
+# race where a PR merges minutes before the bot's incremental pass lands,
+# stranding findings nobody dispositions (audit, 2026-08-19: live escapes on
+# three repos), and the quieter escape where every thread is clicked resolved
+# with no fix or reason on record (skills#288). Callers make this a required
 # status check so the merge button waits for the review instead of racing it.
 
 on:
@@ -40,7 +42,7 @@ jobs:
     steps:
       # PR fields flow in via env, never inline ${{ }} in run: a PR title is
       # attacker-controlled on public repos (template-injection class).
-      - name: Wait for CodeRabbit review of head and zero unresolved threads
+      - name: Wait for CodeRabbit review of head, zero unresolved threads, a reply on every finding
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -66,11 +68,17 @@ jobs:
             exit 0
           fi
 
-          # Sum unresolved review threads across every page; a partial count
-          # would either deadlock resolved PRs or green-light unseen threads.
-          count_unresolved() {
-            local cursor='' page n
-            n=0
+          # Count review threads across every page; a partial count would
+          # either deadlock resolved PRs or green-light unseen threads. Emits
+          # two numbers: unresolved threads, and threads CodeRabbit opened
+          # that carry no reply from a non-bot author (resolving a finding
+          # without answering it is the escape this closes). GraphQL reports
+          # the bot's login without the "[bot]" suffix REST uses; a deleted
+          # replier has a null author and still counts as a human reply.
+          count_threads() {
+            local cursor='' page unresolved unreplied
+            unresolved=0
+            unreplied=0
             while :; do
               page=$(gh api graphql \
                 -f query='query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
@@ -78,18 +86,25 @@ jobs:
                     pullRequest(number: $number) {
                       reviewThreads(first: 100, after: $cursor) {
                         pageInfo { hasNextPage endCursor }
-                        nodes { isResolved }
+                        nodes {
+                          isResolved
+                          comments(first: 100) { nodes { author { __typename login } } }
+                        }
                       }
                     }
                   }
                 }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
                 ${cursor:+-f cursor="$cursor"} \
                 --jq '.data.repository.pullRequest.reviewThreads')
-              n=$((n + $(jq '[.nodes[] | select(.isResolved | not)] | length' <<<"$page")))
+              unresolved=$((unresolved + $(jq '[.nodes[] | select(.isResolved | not)] | length' <<<"$page")))
+              unreplied=$((unreplied + $(jq '[.nodes[]
+                | select(.comments.nodes[0].author.login == "coderabbitai")
+                | select([.comments.nodes[1:][] | select((.author.__typename // "User") != "Bot")] | length == 0)
+                ] | length' <<<"$page")))
               [ "$(jq -r '.pageInfo.hasNextPage' <<<"$page")" = "true" ] || break
               cursor=$(jq -r '.pageInfo.endCursor' <<<"$page")
             done
-            echo "$n"
+            echo "$unresolved $unreplied"
           }
 
           deadline=$((SECONDS + WAIT_MINUTES * 60))
@@ -116,16 +131,20 @@ jobs:
                                  and (.body | test("between [0-9a-f]{40} and " + $head)))] | length')
             fi
 
-            unresolved=$(count_unresolved)
+            # Assign first so a failed count aborts under set -e; a bare
+            # read <<<"$(...)" discards the substitution's status and would
+            # spin the whole wait window on a transient API error.
+            counts=$(count_threads)
+            read -r unresolved unreplied <<<"$counts"
 
-            echo "head-reviewed=$reviewed unresolved-threads=$unresolved"
-            if [ "$reviewed" -gt 0 ] && [ "$unresolved" -eq 0 ]; then
-              echo "settled: CodeRabbit has seen $HEAD_SHA and every review thread is resolved"
+            echo "head-reviewed=$reviewed unresolved-threads=$unresolved unreplied-findings=$unreplied"
+            if [ "$reviewed" -gt 0 ] && [ "$unresolved" -eq 0 ] && [ "$unreplied" -eq 0 ]; then
+              echo "settled: CodeRabbit has seen $HEAD_SHA, every review thread is resolved, and every finding has a reply"
               exit 0
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
               echo "not settled after $WAIT_MINUTES minutes."
-              echo "needs: a CodeRabbit review of head $HEAD_SHA and zero unresolved threads."
+              echo "needs: a CodeRabbit review of head $HEAD_SHA, zero unresolved threads, and a non-bot reply on every thread CodeRabbit opened (fixed, or declined with a reason)."
               echo "if CodeRabbit is configured to skip this PR, exempt it explicitly via the skip label or title regex."
               echo "after dispositioning findings and resolving threads, re-run this check (gh run rerun <run-id>)."
               exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # Repo instructions
 
-- Agent may merge a PR once checks are green and CodeRabbit is dispositioned (every finding verified and replied to on its thread — fixed or declined with a reason). Branch protection additionally requires the branch up to date with `main` and all review threads resolved.
+- Agent may merge a PR once checks are green and CodeRabbit is dispositioned (every finding verified and replied to on its thread, fixed or declined with a reason). The review-settled check enforces the reply: it stays red while any thread CodeRabbit opened has no non-bot reply. Branch protection additionally requires the branch up to date with `main` and all review threads resolved.

--- a/docs/agents/team-workflow.md
+++ b/docs/agents/team-workflow.md
@@ -24,6 +24,7 @@ python3 scripts/check_invocation_freshness.py
 python3 scripts/check_emdash_density.py
 python3 scripts/check_site_disclosure.py
 python3 scripts/check_positioning.py
+python3 -m unittest discover -s tests/gate -p 'test*.py'
 python -m compileall -q skills/decide/advisory-board/scripts
 python -m unittest discover -s skills/decide/advisory-board/tests -p 'test*.py'
 python -m compileall -q skills/investigate/ingest/scripts

--- a/tests/gate/test_review_settled.py
+++ b/tests/gate/test_review_settled.py
@@ -7,7 +7,8 @@ These tests lift the two jq filters verbatim out of the workflow text and run
 them with jq against fixture pages shaped like the GraphQL response, so the
 tested filter is always the shipped one.
 
-Requires jq on PATH, as the workflow does.
+Requires jq on PATH, as the workflow does; a missing jq fails the suite rather than
+skipping it, so a green run always means the filters ran.
 """
 
 from __future__ import annotations
@@ -51,9 +52,10 @@ def page(*threads: dict) -> dict:
     return {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": list(threads)}
 
 
-@unittest.skipUnless(shutil.which("jq"), "jq not on PATH")
 class ReviewSettledFilters(unittest.TestCase):
     def setUp(self) -> None:
+        # Fail, never skip: a skipped suite reports success without testing the gate.
+        self.assertIsNotNone(shutil.which("jq"), "jq is required to test the gate's filters")
         self.unresolved, self.unreplied = filters()
 
     def test_unresolved_counts_only_open_threads(self) -> None:

--- a/tests/gate/test_review_settled.py
+++ b/tests/gate/test_review_settled.py
@@ -1,0 +1,98 @@
+"""Tripwire for the review-settled merge gate's thread filters (skills#288).
+
+The gate is shell + jq inside .github/workflows/review-settled.yml, so nothing
+else in CI exercises it; a regression there (say, the reply requirement quietly
+dropped, or a bot reply counted as a disposition) would pass every other check.
+These tests lift the two jq filters verbatim out of the workflow text and run
+them with jq against fixture pages shaped like the GraphQL response, so the
+tested filter is always the shipped one.
+
+Requires jq on PATH, as the workflow does.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/review-settled.yml"
+
+
+def filters() -> tuple[str, str]:
+    text = WORKFLOW.read_text()
+    unresolved = re.search(r"unresolved=\$\(\(unresolved \+ \$\(jq '(.+?)' <<<", text)
+    unreplied = re.search(r"unreplied=\$\(\(unreplied \+ \$\(jq '(.+?)' <<<", text, re.S)
+    assert unresolved and unreplied, "gate filters not found in the workflow"
+    return unresolved.group(1), unreplied.group(1)
+
+
+def run(filter_text: str, page: dict) -> int:
+    out = subprocess.run(["jq", filter_text], input=json.dumps(page), capture_output=True, text=True, check=True)
+    return int(out.stdout.strip())
+
+
+def bot(login: str = "coderabbitai") -> dict:
+    return {"author": {"__typename": "Bot", "login": login}}
+
+
+def user(login: str = "timharris707") -> dict:
+    return {"author": {"__typename": "User", "login": login}}
+
+
+def thread(*comments: dict, resolved: bool = True) -> dict:
+    return {"isResolved": resolved, "comments": {"nodes": list(comments)}}
+
+
+def page(*threads: dict) -> dict:
+    return {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": list(threads)}
+
+
+@unittest.skipUnless(shutil.which("jq"), "jq not on PATH")
+class ReviewSettledFilters(unittest.TestCase):
+    def setUp(self) -> None:
+        self.unresolved, self.unreplied = filters()
+
+    def test_unresolved_counts_only_open_threads(self) -> None:
+        p = page(thread(bot(), user(), resolved=False), thread(bot(), user()), thread(user(), resolved=False))
+        self.assertEqual(run(self.unresolved, p), 2)
+
+    def test_resolved_bot_thread_without_reply_is_unreplied(self) -> None:
+        # The escape #288 closes: every thread resolved, nothing answered.
+        p = page(thread(bot()), thread(bot()))
+        self.assertEqual(run(self.unreplied, p), 2)
+
+    def test_human_reply_settles_a_thread(self) -> None:
+        p = page(thread(bot(), user()), thread(bot(), user("someone-else"), bot()))
+        self.assertEqual(run(self.unreplied, p), 0)
+
+    def test_bot_only_replies_do_not_count(self) -> None:
+        p = page(thread(bot(), bot()), thread(bot(), bot("github-actions")))
+        self.assertEqual(run(self.unreplied, p), 2)
+
+    def test_deleted_replier_counts_as_human(self) -> None:
+        p = page(thread(bot(), {"author": None}))
+        self.assertEqual(run(self.unreplied, p), 0)
+
+    def test_human_opened_threads_are_ignored(self) -> None:
+        # A reviewer's own thread needs resolution, not a reply.
+        p = page(thread(user()), thread(user(), resolved=False))
+        self.assertEqual(run(self.unreplied, p), 0)
+
+    def test_merge_condition_still_requires_a_reply(self) -> None:
+        # The filters mean nothing if the exit condition stops consuming them (#288).
+        self.assertIn(
+            '[ "$reviewed" -gt 0 ] && [ "$unresolved" -eq 0 ] && [ "$unreplied" -eq 0 ]',
+            WORKFLOW.read_text(),
+        )
+
+    def test_empty_page(self) -> None:
+        self.assertEqual(run(self.unreplied, page()), 0)
+        self.assertEqual(run(self.unresolved, page()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #288.

## What

The merge gate passed when CodeRabbit had reviewed the head commit and every review thread was resolved. Nothing checked that anyone answered the findings, so resolving each thread without a fix or a reason could merge, against the rule in `CLAUDE.md`. The gate now also counts threads CodeRabbit opened that have no reply from a non-bot author, and stays red until that count is zero.

## How

- `count_threads` replaces `count_unresolved`: one paginated GraphQL walk returns both numbers. GraphQL reports the bot as `coderabbitai` (no `[bot]` suffix); a deleted replier has a null author and counts as human.
- The count is assigned before `read` so a failed API call aborts under `set -e` instead of spinning the full wait window with a misleading message (caught in review).
- `tests/gate/test_review_settled.py` lifts the two jq filters out of the workflow text verbatim and runs them against fixture pages, and asserts the merge condition still consumes the reply count. Wired into `ci.yml`.

## Callers

chili, grab-rabbit, modeldeck, and modeldeck-mirror consume this workflow `@main`. Exemption paths (skip label, title regex) and permissions are unchanged; a zero-finding review still passes. Three open chili PRs currently have unreplied CodeRabbit threads and will show the gate red until answered; I'll leave a note on each.

## Review

Adversarial review before commit: 2 finders (Opus, Sonnet), 7 candidates, per-finding skeptic on Opus. 2 confirmed and fixed, 5 refuted.

## Verify

```
python3 -m unittest discover -s tests/gate -p 'test*.py'
```

Plus a stub-`gh` run of the extracted script: API 502 now exits 1 in 0s; the healthy path prints "settled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)